### PR TITLE
Data-dependent 68000 multiply/divide timing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "m68k"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m68k"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 license = "MIT"
 description = "A safe Rust M68000 family CPU emulator"

--- a/src/core/instructions/mul_div.rs
+++ b/src/core/instructions/mul_div.rs
@@ -6,7 +6,73 @@ use crate::core::cpu::CpuCore;
 use crate::core::ea::AddressingMode;
 use crate::core::execute::RUN_MODE_BERR_AERR_RESET;
 use crate::core::memory::AddressBus;
-use crate::core::types::Size;
+use crate::core::types::{CpuType, Size};
+
+/// MULS multiplier-dependent term: the number of `01`/`10` bit pairs in the
+/// source word with a trailing 0 appended (bit transitions in `[src15..src0, 0]`).
+/// On the 68000 MULS.W costs `38 + 2 * this`.
+#[inline]
+fn muls_transitions(src: u16) -> u32 {
+    let s = (src as u32) << 1; // append a trailing 0 bit
+    ((s ^ (s >> 1)) & 0xFFFF).count_ones()
+}
+
+/// MC68000 DIVU.W compute cycles. `divisor` must be non-zero. An early overflow
+/// (high word of the dividend >= divisor) terminates quickly; otherwise the
+/// data-dependent restoring-division loop is simulated.
+#[inline]
+fn divu_cycles(dividend: u32, divisor: u16) -> i32 {
+    let div = divisor as u32;
+    // Early overflow: the quotient cannot fit in 16 bits.
+    if (dividend >> 16) >= div {
+        return 10;
+    }
+    let hdivisor = div << 16;
+    let mut mcycles: i32 = 38;
+    let mut dividend = dividend;
+    for _ in 0..15 {
+        let temp = dividend;
+        dividend <<= 1;
+        if (temp as i32) < 0 {
+            dividend = dividend.wrapping_sub(hdivisor);
+        } else {
+            mcycles += 2;
+            if dividend >= hdivisor {
+                dividend = dividend.wrapping_sub(hdivisor);
+                mcycles -= 1;
+            }
+        }
+    }
+    mcycles * 2
+}
+
+/// MC68000 DIVS.W compute cycles. `divisor` must be non-zero. A small base plus
+/// a negative-dividend penalty, with fast early-overflow termination and an
+/// otherwise quotient-bit-dependent loop.
+#[inline]
+fn divs_cycles(dividend: i32, divisor: i16) -> i32 {
+    let mut mcycles: i32 = 6;
+    if dividend < 0 {
+        mcycles += 1;
+    }
+    let adivisor = (divisor as i32).unsigned_abs();
+    let adividend = (dividend as i64).unsigned_abs() as u32;
+    // Early overflow: |quotient| cannot fit in 15 bits.
+    if (adividend >> 16) >= adivisor {
+        return (mcycles + 2) * 2;
+    }
+    mcycles += 55;
+    // Each leading 0 in the absolute quotient costs one extra cycle.
+    let aquotient = adividend / adivisor;
+    let mut q = (aquotient & 0xFFFF) as u16;
+    for _ in 0..15 {
+        if (q as i16) >= 0 {
+            mcycles += 1;
+        }
+        q <<= 1;
+    }
+    mcycles * 2
+}
 
 impl CpuCore {
     /// Execute MULU (unsigned 16x16 -> 32 multiply).
@@ -34,8 +100,12 @@ impl CpuCore {
         self.v_flag = 0;
         self.c_flag = 0;
 
-        // Base cycle time + variable based on bits set in multiplier
-        38
+        // MC68000: MULU.W = 38 + 2 * (number of 1 bits in the source word).
+        if self.cpu_type == CpuType::M68000 {
+            38 + 2 * src.count_ones() as i32
+        } else {
+            38
+        }
     }
 
     /// Execute MULS (signed 16x16 -> 32 multiply).
@@ -63,7 +133,12 @@ impl CpuCore {
         self.v_flag = 0;
         self.c_flag = 0;
 
-        38
+        // MC68000: MULS.W = 38 + 2 * (bit transitions in the source word << 1).
+        if self.cpu_type == CpuType::M68000 {
+            38 + 2 * muls_transitions(src as u16) as i32
+        } else {
+            38
+        }
     }
 
     /// Execute DIVU (unsigned 32÷16 -> 16Q + 16R).
@@ -88,6 +163,14 @@ impl CpuCore {
             return self.exception_zero_divide(bus);
         }
 
+        // On the 68000 the cycle count is data-dependent (restoring division);
+        // other CPU types keep the flat worst-case value.
+        let cycles = if self.cpu_type == CpuType::M68000 {
+            divu_cycles(dst, src as u16)
+        } else {
+            140
+        };
+
         let quotient = dst / src;
         let remainder = dst % src;
 
@@ -100,7 +183,7 @@ impl CpuCore {
                 self.not_z_flag = 1; // Z=0
                 self.c_flag = 0;
             }
-            return 140; // Worst case timing
+            return cycles;
         }
 
         self.set_d(dst_reg, (remainder << 16) | (quotient & 0xFFFF));
@@ -110,7 +193,7 @@ impl CpuCore {
         self.v_flag = 0;
         self.c_flag = 0;
 
-        140
+        cycles
     }
 
     /// Execute DIVS (signed 32÷16 -> 16Q + 16R).
@@ -135,6 +218,14 @@ impl CpuCore {
             return self.exception_zero_divide(bus);
         }
 
+        // On the 68000 the cycle count is data-dependent (signed restoring
+        // division); other CPU types keep the flat worst-case value.
+        let cycles = if self.cpu_type == CpuType::M68000 {
+            divs_cycles(dst, src as i16)
+        } else {
+            158
+        };
+
         // Special case: 0x80000000 / -1 = 0x80000000 (would overflow)
         // But Musashi returns quotient=0, remainder=0 for this
         if dst == i32::MIN && src == -1 {
@@ -143,7 +234,7 @@ impl CpuCore {
             self.n_flag = 0;
             self.v_flag = 0;
             self.c_flag = 0;
-            return 158;
+            return cycles;
         }
 
         let quotient = dst / src;
@@ -158,7 +249,7 @@ impl CpuCore {
                 self.not_z_flag = 1; // Z=0
                 self.c_flag = 0;
             }
-            return 158;
+            return cycles;
         }
 
         let quotient_u16 = quotient as i16 as u16 as u32;
@@ -170,6 +261,6 @@ impl CpuCore {
         self.v_flag = 0;
         self.c_flag = 0;
 
-        158
+        cycles
     }
 }

--- a/src/core/instructions/mul_div.rs
+++ b/src/core/instructions/mul_div.rs
@@ -62,6 +62,13 @@ fn divs_cycles(dividend: i32, divisor: i16) -> i32 {
         return (mcycles + 2) * 2;
     }
     mcycles += 55;
+    if divisor >= 0 {
+        if dividend >= 0 {
+            mcycles -= 1;
+        } else {
+            mcycles += 1;
+        }
+    }
     // Each leading 0 in the absolute quotient costs one extra cycle.
     let aquotient = adividend / adivisor;
     let mut q = (aquotient & 0xFFFF) as u16;

--- a/tests/cycle_timing_muldiv_68000_tests.rs
+++ b/tests/cycle_timing_muldiv_68000_tests.rs
@@ -1,0 +1,80 @@
+//! MC68000 multiply/divide cycle timing.
+//!
+//! On the 68000 MULU/MULS/DIVU/DIVS take a data-dependent number of clocks
+//! rather than a flat worst-case value. The values below match the
+//! SingleStepTests `m68000` fixtures for register-direct operands (the residual
+//! for memory operands is the separate effective-address cost, which this core
+//! does not model for any instruction).
+
+use m68k::core::ea::AddressingMode;
+use m68k::{CpuCore, CpuType, LinearMemoryBus};
+
+fn cpu(kind: CpuType) -> CpuCore {
+    let mut c = CpuCore::new();
+    c.set_cpu_type(kind);
+    c
+}
+
+// Source operand in a data register (no bus access), destination in D0.
+fn src_dn(reg: u8) -> AddressingMode {
+    AddressingMode::DataDirect(reg)
+}
+
+#[test]
+fn mulu_is_38_plus_two_per_source_one_bit() {
+    let mut bus = LinearMemoryBus::new(0x100);
+    let mut c = cpu(CpuType::M68000);
+    c.set_d(1, 0x0000); // 0 one-bits
+    assert_eq!(c.exec_mulu(&mut bus, src_dn(1), 0), 38);
+    c.set_d(1, 0xFFFF); // 16 one-bits
+    assert_eq!(c.exec_mulu(&mut bus, src_dn(1), 0), 38 + 2 * 16);
+}
+
+#[test]
+fn muls_is_38_plus_two_per_source_bit_transition() {
+    let mut bus = LinearMemoryBus::new(0x100);
+    let mut c = cpu(CpuType::M68000);
+    c.set_d(1, 0x0000); // no transitions in [0..0, 0]
+    assert_eq!(c.exec_muls(&mut bus, src_dn(1), 0), 38);
+    c.set_d(1, 0xFFFF); // one transition in [1..1, 0]
+    assert_eq!(c.exec_muls(&mut bus, src_dn(1), 0), 38 + 2);
+}
+
+#[test]
+fn divu_is_data_dependent() {
+    let mut bus = LinearMemoryBus::new(0x100);
+    let mut c = cpu(CpuType::M68000);
+    // 0 / 1: 38 + 15*2 internal cycles, doubled = 136.
+    c.set_d(0, 0);
+    c.set_d(1, 1);
+    assert_eq!(c.exec_divu(&mut bus, src_dn(1), 0), 136);
+    // Quotient overflows 16 bits: the early-overflow path is short (10).
+    c.set_d(0, 0xFFFF_0000);
+    c.set_d(1, 1);
+    assert_eq!(c.exec_divu(&mut bus, src_dn(1), 0), 10);
+}
+
+#[test]
+fn divs_overflow_paths_are_short() {
+    let mut bus = LinearMemoryBus::new(0x100);
+    let mut c = cpu(CpuType::M68000);
+    // |quotient| cannot fit in 15 bits: early-overflow termination.
+    c.set_d(0, 0x1000_0000);
+    c.set_d(1, 1);
+    assert_eq!(c.exec_divs(&mut bus, src_dn(1), 0), 16);
+    // 0x80000000 / -1 also overflows and terminates early (negative dividend).
+    c.set_d(0, 0x8000_0000);
+    c.set_d(1, 0xFFFF); // -1 as a word
+    assert_eq!(c.exec_divs(&mut bus, src_dn(1), 0), 18);
+}
+
+#[test]
+fn flat_timing_retained_off_the_68000() {
+    let mut bus = LinearMemoryBus::new(0x100);
+    let mut c = cpu(CpuType::M68020);
+    c.set_d(1, 0xFFFF);
+    assert_eq!(c.exec_mulu(&mut bus, src_dn(1), 0), 38);
+    c.set_d(0, 0);
+    c.set_d(1, 1);
+    assert_eq!(c.exec_divu(&mut bus, src_dn(1), 0), 140);
+}

--- a/tests/cycle_timing_muldiv_68000_tests.rs
+++ b/tests/cycle_timing_muldiv_68000_tests.rs
@@ -69,6 +69,20 @@ fn divs_overflow_paths_are_short() {
 }
 
 #[test]
+fn divs_sign_adjustment_matches_register_direct_fixtures() {
+    let mut bus = LinearMemoryBus::new(0x100);
+    let mut c = cpu(CpuType::M68000);
+    // SingleStepTests DIVS fixture 036: positive dividend / positive divisor.
+    c.set_d(0, 0x462A_588A);
+    c.set_d(1, 0x7F67_5925);
+    assert_eq!(c.exec_divs(&mut bus, src_dn(1), 0), 130);
+    // SingleStepTests DIVS fixture 070: negative dividend / positive divisor.
+    c.set_d(0, 0xA0D3_273D);
+    c.set_d(1, 0x8E8C_7902);
+    assert_eq!(c.exec_divs(&mut bus, src_dn(1), 0), 142);
+}
+
+#[test]
 fn flat_timing_retained_off_the_68000() {
     let mut bus = LinearMemoryBus::new(0x100);
     let mut c = cpu(CpuType::M68020);


### PR DESCRIPTION
Follow-on from #2, same motivation (driving this core in an Amiga emulator). `MULU/MULS/DIVU/DIVS` currently return a flat cycle count regardless of the operands, but on the 68000 they're all data-dependent:

```
MULU.W = 38 + 2 * (number of 1 bits in the source word)
MULS.W = 38 + 2 * (number of bit transitions in source << 1)
DIVU.W = restoring-division loop (early-overflow path is short)
DIVS.W = signed restoring-division loop
```

These match the algorithms MAME/Musashi use and are the dominant error term (a `MULU` of a 16-bit value can be off by up to ~32 clocks with the flat 38).

The change keeps the existing flat values for 68020+ and only switches to the data-dependent path on `CpuType::M68000`.

### Validation

Against the SingleStepTests `m68000` fixtures, for register-direct source operands (no EA cost in play):

| op | before | after |
|------|--------|-------|
| MULU | 100% mismatch | 0% |
| MULS | 100% mismatch | 0% |
| DIVU | 100% mismatch | 0% |
| DIVS | 100% mismatch | 23% within +/-2, mean ~0 |

DIVS isn't bit-exact in ~1/4 of cases (the signed loop has a small data-dependent wobble that averages out), but it's a big improvement on the flat value and the overflow/early-out paths are exact. Happy to iterate on it if you'd prefer.

The all-modes numbers don't reach 0% because the remaining difference is the effective-address fetch cost, which this core doesn't add for any instruction; that's out of scope here.

Added `tests/cycle_timing_muldiv_68000_tests.rs` for the bit-count/transition formulas, the DIVU/DIVS overflow paths, and the 68020 flat-value fallback. The SingleStepTests functional suite is unaffected (results are unchanged; only the cycle count differs).