### PR TITLE
Fix host panic on DIVS.L i64::MIN / -1

### DIFF
--- a/src/core/instructions/mul_div_long.rs
+++ b/src/core/instructions/mul_div_long.rs
@@ -45,10 +45,16 @@ impl CpuCore {
             } else {
                 self.d(dq) as i32 as i64
             };
-            let q = dividend / divisor;
-            let r = dividend % divisor;
-            let overflow = q < i32::MIN as i64 || q > i32::MAX as i64;
-            (q as i32 as u32, r as i32 as u32, overflow)
+            if dividend == i64::MIN && divisor == -1 {
+                // The one quotient that does not fit in i64: hardware just
+                // flags overflow, but Rust's i64 division would panic.
+                (0, 0, true)
+            } else {
+                let q = dividend / divisor;
+                let r = dividend % divisor;
+                let overflow = q < i32::MIN as i64 || q > i32::MAX as i64;
+                (q as i32 as u32, r as i32 as u32, overflow)
+            }
         } else {
             let divisor = divisor_u32 as u64;
             let dividend = if use_64 {

--- a/tests/divl_overflow_tests.rs
+++ b/tests/divl_overflow_tests.rs
@@ -1,0 +1,62 @@
+//! DIVS.L overflow edge cases.
+//!
+//! The 64-bit dividend form can present the one division that does not fit
+//! i64 (`i64::MIN / -1`). Hardware flags overflow and leaves the registers
+//! alone; a native Rust division would panic with an arithmetic overflow,
+//! taking the host process down with it.
+
+use m68k::core::memory::AddressBus;
+use m68k::{CpuCore, CpuType, LinearMemoryBus, StepResult};
+
+const SR_V: u16 = 0x0002;
+
+/// Reset into supervisor mode with PC at 0x0200 and one DIVS.L there.
+///
+/// Encoding: opcode 0x4C40 | EA (register-direct D1 divisor), extension
+/// 0x0800 (signed) | optional 0x0400 (64-bit dividend) | Dq in bits 14..12,
+/// Dr in bits 2..0.
+fn setup(ext: u16) -> (CpuCore, LinearMemoryBus) {
+    let mut bus = LinearMemoryBus::new(0x1000);
+    bus.write_long(0x00, 0x0800); // SSP
+    bus.write_long(0x04, 0x0200); // initial PC
+    bus.write_word(0x0200, 0x4C41); // DIVS.L D1, ...
+    bus.write_word(0x0202, ext);
+
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68020);
+    cpu.reset(&mut bus);
+    (cpu, bus)
+}
+
+#[test]
+fn divs_l_64bit_min_dividend_by_minus_one_sets_v_instead_of_panicking() {
+    // DIVS.L D1, D2:D0 -- dividend D2:D0 = i64::MIN, divisor D1 = -1.
+    let (mut cpu, mut bus) = setup(0x0C02);
+    cpu.set_d(2, 0x8000_0000); // dividend high (Dr)
+    cpu.set_d(0, 0x0000_0000); // dividend low (Dq)
+    cpu.set_d(1, 0xFFFF_FFFF); // divisor -1
+
+    let result = cpu.step(&mut bus);
+
+    assert!(matches!(result, StepResult::Ok { .. }));
+    assert_eq!(cpu.pc, 0x0204, "overflow must not trap");
+    assert_ne!(cpu.get_sr() & SR_V, 0, "V must be set on overflow");
+    assert_eq!(cpu.d(0), 0x0000_0000, "quotient register left alone");
+    assert_eq!(cpu.d(2), 0x8000_0000, "remainder register left alone");
+}
+
+#[test]
+fn divs_l_32bit_min_dividend_by_minus_one_sets_v() {
+    // DIVS.L D1, D0 -- dividend D0 = i32::MIN, divisor D1 = -1: the +2^31
+    // quotient does not fit i32, so V is set and D0 is left alone.
+    let (mut cpu, mut bus) = setup(0x0800);
+    cpu.set_d(0, 0x8000_0000);
+    cpu.set_d(1, 0xFFFF_FFFF);
+
+    let result = cpu.step(&mut bus);
+
+    assert!(matches!(result, StepResult::Ok { .. }));
+    assert_eq!(cpu.pc, 0x0204, "overflow must not trap");
+    assert_ne!(cpu.get_sr() & SR_V, 0, "V must be set on overflow");
+    assert_eq!(cpu.d(0), 0x8000_0000, "quotient register left alone");
+}


### PR DESCRIPTION
Emulated code can crash the host: the 64-bit dividend form of DIVS.L with dividend `$8000000000000000` and divisor `-1` reaches Rust's native `i64` division in `exec_divl`, which panics with "attempt to divide with overflow". Real hardware just flags overflow for this case (V set, destination registers untouched), the same as the existing +/-2^31 quotient overflow path.

This guards the one unrepresentable quotient and routes it to the overflow path. `tests/divl_overflow_tests.rs` pins the panicking case (it fails with a panic without the guard) and the adjacent 32-bit `i32::MIN / -1` boundary, which already worked via the i64 widening.

Found while running the WinUAE cputest suite against our Amiga emulator's fork of this core (Copperline); the same guard has been in our tree for a while.
