### PR TITLE
Close the CHK negative-bound trap timing quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The [SingleStepTests](https://github.com/SingleStepTests/m68000) project provide
 - BCD arithmetic (ABCD, SBCD, NBCD)
 - Multiply/divide overflow handling
 - Exception frame generation
-- **Cycle counts**: 99.92% of the 261,894 fixture cases match the real-hardware clock counts exactly (261,695 of 261,894), and the suite enforces this on every run. The only exception is one 2-clock quirk in CHK's negative-bound trap path (~200 cases, documented in the source). For reference, this is tighter than Musashi, which for example charges `ADD.L Dn,Dn` at 6 cycles where the M68000UM and real hardware measure 8.
+- **Cycle counts**: all 261,894 fixture cases match the real-hardware clock counts exactly, and the suite enforces this on every run. For reference, this is tighter than Musashi, which for example charges `ADD.L Dn,Dn` at 6 cycles where the M68000UM and real hardware measure 8.
 
 ### Musashi Reference Implementation
 

--- a/src/core/instructions/integer_arith.rs
+++ b/src/core/instructions/integer_arith.rs
@@ -555,13 +555,16 @@ impl CpuCore {
 
         if val < 0 || val > limit {
             // SST: the upper-bound trap path costs 38+ea on the 68000; the
-            // negative-value path costs 40+ea. Checked in this order, so a
-            // value above a negative bound takes the cheaper path even
-            // though it is itself negative. (~200 SST cases with negative
-            // bounds still disagree by 2 cycles; the exact microcode rule
-            // is unclear, and this is already closer than Musashi's flat
-            // 40+ea.)
-            let adjust = if self.is_pre_68020 && val > limit {
+            // negative-value path costs 40+ea. The microcode runs the
+            // upper-bound comparison first, so a value above the bound takes
+            // the cheaper path even though it is itself negative. That
+            // comparison is a signed subtract: a negative value whose
+            // `Dn - bound` word subtraction overflows looks "above the
+            // bound" to it and also leaves on the cheaper path, even though
+            // the architectural trap condition is Dn < 0.
+            let upper_bound_path = val > limit
+                || (size == Size::Word && (val as i16).checked_sub(limit as i16).is_none());
+            let adjust = if self.is_pre_68020 && upper_bound_path {
                 2
             } else {
                 0

--- a/tests/cycle_timing_chk_68000_tests.rs
+++ b/tests/cycle_timing_chk_68000_tests.rs
@@ -1,0 +1,67 @@
+//! MC68000 CHK trap-path cycle timing.
+//!
+//! The microcode runs the upper-bound comparison first as a signed word
+//! subtract. Two trap shapes fall out of it, register-direct costs below:
+//!
+//! - upper-bound path: 38 clocks. Taken by `Dn > bound`, and also by a
+//!   negative `Dn` whose `Dn - bound` subtraction overflows (the subtract
+//!   result looks "above the bound" to the microcode).
+//! - negative path: 40 clocks. Taken by the remaining `Dn < 0` cases.
+//!
+//! These values match all SingleStepTests `m68000` CHK cases.
+
+use m68k::core::memory::AddressBus;
+use m68k::{CpuCore, CpuType, LinearMemoryBus, StepResult};
+
+/// Reset a 68000 into supervisor mode with `CHK D1, D0` at 0x0200.
+fn setup(dn: u32, bound: u32) -> (CpuCore, LinearMemoryBus) {
+    let mut bus = LinearMemoryBus::new(0x1000);
+    bus.write_long(0x00, 0x0800); // SSP
+    bus.write_long(0x04, 0x0200); // initial PC
+    bus.write_long(0x18, 0x0400); // CHK vector (6)
+    bus.write_word(0x0200, 0x4181); // CHK.W D1, D0
+
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68000);
+    cpu.reset(&mut bus);
+    cpu.set_d(0, dn);
+    cpu.set_d(1, bound);
+    (cpu, bus)
+}
+
+fn chk_cycles(dn: u32, bound: u32) -> i32 {
+    let (mut cpu, mut bus) = setup(dn, bound);
+    match cpu.step(&mut bus) {
+        StepResult::Ok { cycles } => cycles,
+        other => panic!("unexpected step result: {other:?}"),
+    }
+}
+
+#[test]
+fn chk_pass_is_10() {
+    assert_eq!(chk_cycles(3, 100), 10);
+}
+
+#[test]
+fn chk_above_bound_takes_the_38_clock_upper_bound_path() {
+    assert_eq!(chk_cycles(200, 100), 38);
+}
+
+#[test]
+fn chk_negative_value_above_negative_bound_takes_the_upper_bound_path() {
+    // -1 > -100: still the cheaper upper-bound trap despite being negative.
+    assert_eq!(chk_cycles(0xFFFF_FFFF, 0xFFFF_FF9C), 38);
+}
+
+#[test]
+fn chk_negative_value_takes_the_40_clock_negative_path() {
+    assert_eq!(chk_cycles(0xFFFF_FFFF, 100), 40);
+}
+
+#[test]
+fn chk_negative_value_with_overflowing_subtract_takes_the_upper_bound_path() {
+    // -32768 - 32767 overflows a signed word, so the microcode's bound
+    // comparison sends this out on the 38-clock upper-bound path even
+    // though the architectural trap condition is Dn < 0.
+    assert_eq!(chk_cycles(0xFFFF_8000, 0x0000_7FFF), 38);
+}

--- a/tests/singlestep_m68000_v1_tests.rs
+++ b/tests/singlestep_m68000_v1_tests.rs
@@ -255,11 +255,6 @@ fn audit_cycles() -> bool {
     std::env::var("M68K_SST_AUDIT_CYCLES").is_ok_and(|v| v == "1")
 }
 
-fn is_chk_file(path: &Path) -> bool {
-    path.file_name()
-        .is_some_and(|f| f.to_string_lossy().starts_with("CHK"))
-}
-
 /// Cycle-audit accumulator for one fixture file.
 #[derive(Default)]
 struct CycleAudit {
@@ -324,15 +319,12 @@ fn run_one_file(path: &Path) {
         // Compare cycle counts against the fixture's real-hardware clock
         // count. Enforced by default; M68K_SST_AUDIT_CYCLES=1 switches to a
         // report-only summary (useful when burning down divergences).
-        // CHK's trap paths are exempt: ~200 negative-bound cases disagree
-        // by 2 clocks and the exact microcode rule is not yet understood
-        // (see exec_chk).
         if !t.has_addr_error_txn
             && let m68k::StepResult::Ok { cycles } = result
         {
             if audit_cycles() {
                 audit.record(opcode, &t.name, t.num_cycles, cycles);
-            } else if cycles as i64 != t.num_cycles as i64 && !is_chk_file(path) {
+            } else if cycles as i64 != t.num_cycles as i64 {
                 failures.push(format!(
                     "{}[{idx}] {}: cycles: expected {}, got {cycles}",
                     path.display(),


### PR DESCRIPTION
The README and `exec_chk` document the last ~200 SingleStepTests cycle divergences as a 2-clock CHK quirk on negative bounds whose "exact microcode rule is unclear". We hit the same wall building a cycle-exact 68000 out of this core in the Copperline Amiga emulator and eventually found the rule, so here it is:

The upper-bound comparison runs first as a **signed word subtract**. A negative Dn whose `Dn - bound` subtraction **overflows** looks "above the bound" to that subtract, so it leaves on the shorter 38-clock upper-bound trap path even though the architectural trap condition it satisfies is `Dn < 0`. Only values that pass the subtract without overflow reach the 40-clock negative path. (That is also why the divergent cases cluster around large-magnitude bound/value pairs.)

With the rule in place all 261,894 SST m68000 cases match the real-hardware clock counts exactly, so this PR also removes the CHK exemption from the fixture harness (the cycle check is now enforced for CHK like every other file) and updates the README accuracy note from 99.92% to exact.

`tests/cycle_timing_chk_68000_tests.rs` pins the pass path, both trap paths, the negative-value-above-negative-bound case, and the overflowing-subtract case that previously mis-billed. Verified against our fork's independent implementation of the same rule, which sits at 0 cycle and 0 bus-access mismatches over the full corpus.
