### PR TITLE
perf: fast-path classic Mac displacement memory ops

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -147,6 +147,37 @@ fn bench_loop<B: BenchBus>(
     );
 }
 
+fn bench_batch_loop(label: &str, name: &str, words: &[u16], instrs: u32) {
+    let mut bus = LinearMemoryBus::new(0x10000);
+    for (i, word) in words.iter().enumerate() {
+        bus.write_word_at((i * 2) as u32, *word);
+    }
+
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = 0;
+        cpu.set_a(5, 0x1000);
+        cpu.set_a(7, 0x8000);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    let warm = warm_cpu.run_batch(&mut bus, 5_000_000, &[]);
+    assert_eq!(warm.instructions, 5_000_000);
+
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    let result = cpu.run_batch(&mut bus, instrs, &[]);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(result.instructions, instrs);
+    println!(
+        "{label:9} {name:18} {:8.1} M instr/s",
+        instrs as f64 / elapsed / 1_000_000.0
+    );
+}
+
 fn bench_set<B: BenchBus>(label: &str) {
     bench_linear::<B>(label, "linear NOP", 0x4E71, 4, 40_000_000);
     bench_linear::<B>(label, "linear ADDQ", 0x5280, 4, 40_000_000);
@@ -173,6 +204,30 @@ fn bench_set<B: BenchBus>(label: &str) {
 
 fn main() {
     println!("m68k microbench");
-    bench_set::<PlainBenchBus>("plain");
-    bench_set::<LinearMemoryBus>("linearbus");
+    let only = std::env::args().nth(1);
+    if only.as_deref() != Some("batch") {
+        bench_set::<PlainBenchBus>("plain");
+        bench_set::<LinearMemoryBus>("linearbus");
+    }
+    // A5-relative globals and stack temporaries dominate classic Mac code.
+    // This loop mirrors the hottest Lemmings opcode forms found by runtime
+    // profiling while remaining deterministic and self-contained.
+    if only.as_deref() != Some("legacy") {
+        bench_batch_loop(
+            "batch",
+            "classic Mac mix",
+            &[
+                0x4A2D, 0x0100, // TST.B $0100(A5)
+                0x082D, 0x0003, 0x0100, // BTST #3,$0100(A5)
+                0x1B40, 0x0100, // MOVE.B D0,$0100(A5)
+                0x422D, 0x0100, // CLR.B $0100(A5)
+                0x322D, 0x0100, // MOVE.W $0100(A5),D1
+                0x526D, 0x0100, // ADDQ.W #1,$0100(A5)
+                0x2F2D, 0x0100, // MOVE.L $0100(A5),-(A7)
+                0x588F, // ADDQ.L #4,A7
+                0x60DE, // BRA.B back to the first instruction
+            ],
+            200_000_000,
+        );
+    }
 }

--- a/src/core/mem_ops.rs
+++ b/src/core/mem_ops.rs
@@ -773,6 +773,236 @@ fn fast_move(cpu: &mut CpuCore, win: Win, size: Size, src: FastEa, dst: FastEa) 
     Some(true)
 }
 
+/// Specialized execution for the common A5-relative data accesses emitted
+/// by classic Mac compilers. AnDisp is unusually hot because A5 is the
+/// application's global-data base. Keeping the extension cursor, resolved
+/// offset and value in locals avoids the generic Ctx/Pending/Loc state
+/// machine while retaining its all-checks-before-commit fallback contract.
+#[inline]
+fn fast_an_disp(cpu: &mut CpuCore, win: Win, op: DecodedMemOp) -> Option<bool> {
+    let read_word = |cpu: &CpuCore, pc: u32| -> Result<u32, ()> {
+        let off = win.off(cpu.address(pc), 2).ok_or(())?;
+        Ok(win.read(off, Size::Word))
+    };
+    let locate = |cpu: &CpuCore, reg: u8, disp: u32, size: Size| -> Result<usize, ()> {
+        let raw = (cpu.dar[8 + reg as usize] as i32).wrapping_add(disp as u16 as i16 as i32) as u32;
+        if cpu.is_pre_68020 && size != Size::Byte && (raw & 1) != 0 {
+            return Err(());
+        }
+        win.off(cpu.address(raw), size.bytes()).ok_or(())
+    };
+
+    match op {
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::DataReg(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, src, ext, size) else {
+                return Some(false);
+            };
+            let value = win.read(off, size);
+            let mask = size.mask();
+            let dst = dst as usize;
+            cpu.dar[dst] = (cpu.dar[dst] & !mask) | value;
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::AddrReg(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, src, ext, size) else {
+                return Some(false);
+            };
+            let value = win.read(off, size);
+            cpu.dar[8 + dst as usize] = if size == Size::Word {
+                value as u16 as i16 as i32 as u32
+            } else {
+                value
+            };
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::DataReg(src),
+            dst: FastEa::AnDisp(dst),
+        }
+        | DecodedMemOp::Move {
+            size,
+            src: FastEa::AddrReg(src),
+            dst: FastEa::AnDisp(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, dst, ext, size) else {
+                return Some(false);
+            };
+            let src_index = if matches!(
+                op,
+                DecodedMemOp::Move {
+                    src: FastEa::DataReg(_),
+                    ..
+                }
+            ) {
+                src as usize
+            } else {
+                8 + src as usize
+            };
+            let value = cpu.dar[src_index] & size.mask();
+            win.write(off, size, value);
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::AnPreDec(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(src_off) = locate(cpu, src, ext, size) else {
+                return Some(false);
+            };
+            let dst_addr = cpu.dar[8 + dst as usize].wrapping_sub(ea_step(size, dst));
+            if cpu.is_pre_68020 && size != Size::Byte && (dst_addr & 1) != 0 {
+                return Some(false);
+            }
+            let Some(dst_off) = win.off(cpu.address(dst_addr), size.bytes()) else {
+                return Some(false);
+            };
+            let value = win.read(src_off, size);
+            cpu.dar[8 + dst as usize] = dst_addr;
+            win.write(dst_off, size, value);
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::AnDisp(dst),
+        } => {
+            let Ok(src_ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(dst_ext) = read_word(cpu, cpu.pc.wrapping_add(2)) else {
+                return Some(false);
+            };
+            let Ok(src_off) = locate(cpu, src, src_ext, size) else {
+                return Some(false);
+            };
+            let Ok(dst_off) = locate(cpu, dst, dst_ext, size) else {
+                return Some(false);
+            };
+            let value = win.read(src_off, size);
+            win.write(dst_off, size, value);
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(4);
+            Some(true)
+        }
+        DecodedMemOp::Tst {
+            size,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, size) else {
+                return Some(false);
+            };
+            cpu.set_logic_flags(win.read(off, size), size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Clr {
+            size,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, size) else {
+                return Some(false);
+            };
+            win.write(off, size, 0);
+            cpu.n_flag = 0;
+            cpu.not_z_flag = 0;
+            cpu.v_flag = 0;
+            cpu.c_flag = 0;
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::AddqSubq {
+            data,
+            size,
+            ea: FastEa::AnDisp(reg),
+            is_sub,
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, size) else {
+                return Some(false);
+            };
+            let dst = win.read(off, size);
+            let result = if is_sub {
+                dst.wrapping_sub(data)
+            } else {
+                dst.wrapping_add(data)
+            };
+            win.write(off, size, result & size.mask());
+            if is_sub {
+                cpu.set_sub_flags(data, dst, result, size);
+            } else {
+                cpu.set_add_flags(data, dst, result, size);
+            }
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::BitMem {
+            op,
+            bit: BitSource::Imm,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let Ok(bit) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(ext) = read_word(cpu, cpu.pc.wrapping_add(2)) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, Size::Byte) else {
+                return Some(false);
+            };
+            let bit = bit & 7;
+            let mask = 1 << bit;
+            let value = win.read(off, Size::Byte);
+            cpu.not_z_flag = u32::from(value & mask != 0);
+            match op {
+                BitOp::Test => {}
+                BitOp::Set => win.write(off, Size::Byte, value | mask),
+                BitOp::Clear => win.write(off, Size::Byte, value & !mask),
+                BitOp::Change => win.write(off, Size::Byte, value ^ mask),
+            }
+            cpu.pc = cpu.pc.wrapping_add(4);
+            Some(true)
+        }
+        _ => None,
+    }
+}
+
 /// Specialized DBcc/BSR/RTS/Bcc.W execution: at most one extension word,
 /// no EA resolution, so the `Ctx` plumbing is skipped. Mirrors the generic
 /// arms exactly (which remain the single source of truth for the other
@@ -1057,6 +1287,10 @@ pub(crate) fn execute_mem_op(cpu: &mut CpuCore, op: DecodedMemOp) -> bool {
     if let DecodedMemOp::Move { size, src, dst } = op
         && let Some(handled) = fast_move(cpu, win, size, src, dst)
     {
+        return handled;
+    }
+
+    if let Some(handled) = fast_an_disp(cpu, win, op) {
         return handled;
     }
 
@@ -1479,5 +1713,112 @@ fn apply_binary_to_reg(
             cpu.dar[reg] = (cpu.dar[reg] & !mask) | (result & mask);
             cpu.set_logic_flags(result, size);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cpu_with_window(mem: &mut [u8]) -> CpuCore {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.fm_ptr = mem.as_mut_ptr() as usize;
+        cpu.fm_base = 0;
+        cpu.fm_len = mem.len() as u32;
+        cpu.pc = 0x100;
+        cpu.set_a(5, 0x400);
+        cpu
+    }
+
+    #[test]
+    fn fast_an_disp_tst_and_clr_advance_extension_cursor() {
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x100..0x102].copy_from_slice(&0x0012u16.to_be_bytes());
+        mem[0x412] = 0x80;
+        let mut cpu = cpu_with_window(&mut mem);
+
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Tst {
+                size: Size::Byte,
+                ea: FastEa::AnDisp(5),
+            }
+        ));
+        assert_eq!(cpu.pc, 0x102);
+        assert_ne!(cpu.n_flag, 0);
+        assert_ne!(cpu.not_z_flag, 0);
+
+        cpu.pc = 0x100;
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Clr {
+                size: Size::Byte,
+                ea: FastEa::AnDisp(5),
+            }
+        ));
+        assert_eq!(mem[0x412], 0);
+        assert_eq!(cpu.pc, 0x102);
+        assert_eq!(cpu.not_z_flag, 0);
+    }
+
+    #[test]
+    fn fast_an_disp_immediate_bit_uses_both_extension_words() {
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x100..0x102].copy_from_slice(&3u16.to_be_bytes());
+        mem[0x102..0x104].copy_from_slice(&0x0012u16.to_be_bytes());
+        mem[0x412] = 0b0000_1000;
+        let mut cpu = cpu_with_window(&mut mem);
+
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::BitMem {
+                op: BitOp::Test,
+                bit: BitSource::Imm,
+                ea: FastEa::AnDisp(5),
+            }
+        ));
+        assert_eq!(cpu.pc, 0x104);
+        assert_eq!(cpu.not_z_flag, 1);
+        assert_eq!(mem[0x412], 0b0000_1000);
+    }
+
+    #[test]
+    fn fast_an_disp_move_checks_both_operands_before_commit() {
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x100..0x102].copy_from_slice(&0x0012u16.to_be_bytes());
+        mem[0x412..0x416].copy_from_slice(&0xDEAD_BEEFu32.to_be_bytes());
+        let mut cpu = cpu_with_window(&mut mem);
+        cpu.set_a(7, 0x800);
+
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Move {
+                size: Size::Long,
+                src: FastEa::AnDisp(5),
+                dst: FastEa::AnPreDec(7),
+            }
+        ));
+        assert_eq!(cpu.a(7), 0x7FC);
+        assert_eq!(&mem[0x7FC..0x800], &0xDEAD_BEEFu32.to_be_bytes());
+        assert_eq!(cpu.pc, 0x102);
+
+        cpu.pc = 0x100;
+        cpu.set_a(7, 2);
+        let old_flags = (cpu.n_flag, cpu.not_z_flag, cpu.v_flag, cpu.c_flag);
+        assert!(!execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Move {
+                size: Size::Long,
+                src: FastEa::AnDisp(5),
+                dst: FastEa::AnPreDec(7),
+            }
+        ));
+        assert_eq!(cpu.a(7), 2);
+        assert_eq!(cpu.pc, 0x100);
+        assert_eq!(
+            (cpu.n_flag, cpu.not_z_flag, cpu.v_flag, cpu.c_flag),
+            old_flags
+        );
     }
 }


### PR DESCRIPTION
## Summary

- specialize the decoded fast-memory path for the displacement addressing form `d16(An)`
- cover the common move, test, clear, quick arithmetic, and immediate bit-operation forms
- preserve the generic executor as the fallback for out-of-window and alignment cases
- add a deterministic M68040 `run_batch()` benchmark based on the hottest instructions observed while running the classic Mac version of Lemmings

Classic Mac compilers conventionally use A5 as the application's global-data base. Runtime profiling showed that A5-relative memory instructions dominate Lemmings' decoded-memory workload, but the generic fast-memory executor still resolved them through the full `Ctx`/`Pending`/`Loc` state machine for every instruction. The specialized path keeps extension words, resolved offsets, and values in locals while retaining the existing all-checks-before-commit fallback contract.

This is not game-specific: the implementation handles `d16(An)` for every address register. Lemmings supplied a representative real-world workload that exposed the missing specialization.

## Workload profiling

A profiled Lemmings run retired 80,562,511 non-trap instructions:

| Execution path | Instructions | Share |
| --- | ---: | ---: |
| Trace JIT | 20,518,639 | 25.5% |
| Decoded simple | 25,291,356 | 31.4% |
| Decoded memory | 34,176,960 | 42.4% |
| Full dispatch | 575,556 | 0.7% |

The decoded-memory path was the largest bucket. A longer opcode histogram then identified these especially hot displacement forms:

| Opcode | Form | Dynamic count |
| --- | --- | ---: |
| `$4A2D` | `TST.B d16(A5)` | 25,813,636 |
| `$082D` | `BTST #imm,d16(A5)` | 18,738,301 |
| `$1B40` | `MOVE.B D0,d16(A5)` | 18,738,297 |
| `$422D` | `CLR.B d16(A5)` | 14,064,802 |
| `$302D` | `MOVE.W d16(A5),D0` | 9,430,244 |

This is why the change targets decoded displacement memory operations rather than expanding the JIT: the JIT was already retiring roughly a quarter of the workload, while decoded memory accounted for more than two fifths.

## Microbenchmark

The existing microbenchmarks predate `run_batch()` and exercise the cycle-budgeted `execute()` API with register-only programs. They do not enter `execute_mem_op()` or execute a `d16(An)` data-memory operand. This PR adds a separate M68040 batch loop containing the profiled instruction forms plus a stack temporary.

The focused benchmark can be reproduced with:

```sh
cargo bench --bench microbench -- batch
```

Five before/after pairs were run in alternating order on an Intel MacBookPro16,1 using the optimized benchmark profile:

| Pair | Before (M instr/s) | After (M instr/s) | Gain |
| ---: | ---: | ---: | ---: |
| 1 | 39.8 | 57.5 | 44.5% |
| 2 | 34.8 | 51.6 | 48.3% |
| 3 | 34.0 | 51.7 | 52.1% |
| 4 | 33.0 | 49.7 | 50.6% |
| 5 | 32.9 | 49.6 | 50.8% |
| **Mean** | **34.9** | **52.0** | **49.1%** |

The absolute rate follows the machine's thermal/frequency state, but the paired improvement persisted in every run.

The unchanged legacy rows can be run separately with:

```sh
cargo bench --bench microbench -- legacy
```

Across five order-balanced runs, 12 of 14 legacy rows remained within +/-3%. The two larger apparent changes (`plain linear ADDQ`, -4.6%; `linearbus loop ADDQ/BRA`, -6.5%) also had large after-run standard deviations (17.6 and 46.4 M instr/s respectively), with overlapping before/after ranges. There is no consistent regression signal, and those register-only `execute()` programs cannot enter the specialized function.

## Application-level sampling

Two 30-second macOS `sample` captures of Systemless running Lemmings were compared before and after the change:

| Stack/sample measure | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Emulation-inclusive main-thread samples | 1,748 | 1,073 | 38.6% |
| `run_steps_internal` leaf samples | 1,195 | 823 | 31.1% |
| Generic `mem_ops::resolve` leaf samples | 143 | 67 | 53.1% |

The game was also played interactively on the optimized build to check behavior under its normal input, graphics, and audio workload.

## Correctness and fallback behavior

The fast path resolves every required extension word, alignment condition, and fast-memory offset before changing architectural state. If any check fails, it returns to the existing generic executor without advancing PC, changing registers/flags, or performing a partial write.

New focused tests cover:

- extension cursor and flags for `TST`/`CLR`
- both extension words for immediate bit operations
- A5-relative move to predecrement stack storage
- no partial commit when the destination falls outside the fast-memory window

The existing deterministic and differential fast-memory tests also exercise displacement addressing across memory-operation families.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked`
- `cargo package --locked --allow-dirty --offline` (the PR branch was uncommitted during this local package check)
- Systemless `cargo check --bin systemless --offline` against this local m68k revision

