### PR TITLE
perf: inline generic memory helpers

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -147,6 +147,37 @@ fn bench_loop<B: BenchBus>(
     );
 }
 
+fn bench_batch_loop(label: &str, name: &str, words: &[u16], instrs: u32) {
+    let mut bus = LinearMemoryBus::new(0x10000);
+    for (i, word) in words.iter().enumerate() {
+        bus.write_word_at((i * 2) as u32, *word);
+    }
+
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = 0;
+        cpu.set_a(5, 0x1000);
+        cpu.set_a(7, 0x8000);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    let warm = warm_cpu.run_batch(&mut bus, 5_000_000, &[]);
+    assert_eq!(warm.instructions, 5_000_000);
+
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    let result = cpu.run_batch(&mut bus, instrs, &[]);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(result.instructions, instrs);
+    println!(
+        "{label:9} {name:18} {:8.1} M instr/s",
+        instrs as f64 / elapsed / 1_000_000.0
+    );
+}
+
 fn bench_set<B: BenchBus>(label: &str) {
     bench_linear::<B>(label, "linear NOP", 0x4E71, 4, 40_000_000);
     bench_linear::<B>(label, "linear ADDQ", 0x5280, 4, 40_000_000);
@@ -173,6 +204,30 @@ fn bench_set<B: BenchBus>(label: &str) {
 
 fn main() {
     println!("m68k microbench");
-    bench_set::<PlainBenchBus>("plain");
-    bench_set::<LinearMemoryBus>("linearbus");
+    let only = std::env::args().nth(1);
+    if only.as_deref() != Some("batch") {
+        bench_set::<PlainBenchBus>("plain");
+        bench_set::<LinearMemoryBus>("linearbus");
+    }
+    // A5-relative globals and stack temporaries dominate classic Mac code.
+    // This loop mirrors the hottest Lemmings opcode forms found by runtime
+    // profiling while remaining deterministic and self-contained.
+    if only.as_deref() != Some("legacy") {
+        bench_batch_loop(
+            "batch",
+            "classic Mac mix",
+            &[
+                0x4A2D, 0x0100, // TST.B $0100(A5)
+                0x082D, 0x0003, 0x0100, // BTST #3,$0100(A5)
+                0x1B40, 0x0100, // MOVE.B D0,$0100(A5)
+                0x422D, 0x0100, // CLR.B $0100(A5)
+                0x322D, 0x0100, // MOVE.W $0100(A5),D1
+                0x526D, 0x0100, // ADDQ.W #1,$0100(A5)
+                0x2F2D, 0x0100, // MOVE.L $0100(A5),-(A7)
+                0x588F, // ADDQ.L #4,A7
+                0x60DE, // BRA.B back to the first instruction
+            ],
+            200_000_000,
+        );
+    }
 }

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -148,33 +148,91 @@ fn bench_loop<B: BenchBus>(
 }
 
 fn bench_batch_loop(label: &str, name: &str, words: &[u16], instrs: u32) {
+    bench_batch_loop_at(label, name, words, instrs, 0x100);
+}
+
+fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code_base: usize) {
     let mut bus = LinearMemoryBus::new(0x10000);
     for (i, word) in words.iter().enumerate() {
-        bus.write_word_at((i * 2) as u32, *word);
+        bus.write_word_at((code_base + i * 2) as u32, *word);
     }
 
     let prepare_cpu = || {
         let mut cpu = CpuCore::new();
         cpu.set_cpu_type(CpuType::M68040);
         cpu.set_sr(0x2700);
-        cpu.pc = 0;
+        cpu.pc = code_base as u32;
         cpu.set_a(5, 0x1000);
         cpu.set_a(7, 0x8000);
         cpu
     };
 
     let mut warm_cpu = prepare_cpu();
-    let warm = warm_cpu.run_batch(&mut bus, 5_000_000, &[]);
+    // Systemless always watches PC 0 as its clean-exit sentinel. An
+    // unrelated watched PC must not force a nonzero self-loop to execute
+    // only one iteration per native trace call.
+    let warm = warm_cpu.run_batch(&mut bus, 5_000_000, &[0]);
     assert_eq!(warm.instructions, 5_000_000);
 
     let mut cpu = prepare_cpu();
     let start = Instant::now();
-    let result = cpu.run_batch(&mut bus, instrs, &[]);
+    let result = cpu.run_batch(&mut bus, instrs, &[0]);
     let elapsed = start.elapsed().as_secs_f64();
     assert_eq!(result.instructions, instrs);
     println!(
         "{label:9} {name:18} {:8.1} M instr/s",
         instrs as f64 / elapsed / 1_000_000.0
+    );
+}
+
+fn bench_one_shot_trace(head_ops: usize, instrs: u32) {
+    assert!((2..=16).contains(&head_ops));
+    let mut words = vec![0x5280; head_ops - 1]; // ADDQ.L #1,D0
+    words.push(0x6002); // BRA.B over the padding word
+    words.push(0x4E71); // padding, never executed
+    words.push(0x5381); // SUBQ.L #1,D1 (interpreted return path)
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+
+    bench_batch_loop_at(
+        "batch",
+        &format!("one-shot {head_ops}"),
+        &words,
+        instrs,
+        0x100 + head_ops * 0x40,
+    );
+}
+
+fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
+    assert!((2..=9).contains(&head_ops));
+    let a5_ops: &[&[u16]] = &[
+        &[0x4A2D, 0x0100],         // TST.B $0100(A5)
+        &[0x526D, 0x0100],         // ADDQ.W #1,$0100(A5)
+        &[0x322D, 0x0100],         // MOVE.W $0100(A5),D1
+        &[0x422D, 0x0100],         // CLR.B $0100(A5)
+        &[0x1B40, 0x0100],         // MOVE.B D0,$0100(A5)
+        &[0x082D, 0x0003, 0x0100], // BTST #3,$0100(A5)
+    ];
+    let mut words = Vec::new();
+    for i in 0..head_ops - 1 {
+        words.extend_from_slice(a5_ops[i % a5_ops.len()]);
+    }
+    words.push(0x6002); // BRA.B over the padding word
+    words.push(0x4E71); // padding, never executed
+    words.push(0x5381); // SUBQ.L #1,D1 (interpreted return path)
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+
+    bench_batch_loop_at(
+        "batch",
+        &format!("A5 one-shot {head_ops}"),
+        &words,
+        instrs,
+        0x800 + head_ops * 0x40,
     );
 }
 
@@ -205,6 +263,21 @@ fn bench_set<B: BenchBus>(label: &str) {
 fn main() {
     println!("m68k microbench");
     let only = std::env::args().nth(1);
+    if only.as_deref() == Some("trace-calls") {
+        // Unlike a self-loop, each native trace here executes once before
+        // returning to Rust. This isolates the call-boundary break-even
+        // point seen in branch-heavy application code such as Lemmings.
+        for head_ops in 2..=9 {
+            bench_one_shot_trace(head_ops, 50_000_000);
+        }
+        return;
+    }
+    if only.as_deref() == Some("a5-trace-calls") {
+        for head_ops in 2..=9 {
+            bench_one_shot_a5_trace(head_ops, 50_000_000);
+        }
+        return;
+    }
     if only.as_deref() != Some("batch") {
         bench_set::<PlainBenchBus>("plain");
         bench_set::<LinearMemoryBus>("linearbus");

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -278,6 +278,21 @@ fn main() {
         }
         return;
     }
+    if only.as_deref() == Some("region") {
+        bench_batch_loop(
+            "batch",
+            "multi-block region",
+            &[
+                0x5280, // ADDQ.L #1,D0
+                0x6602, // BNE.S skip
+                0x4E71, // uncommon fallthrough
+                0x5281, // skip: ADDQ.L #1,D1
+                0x60F6, // BRA.S loop
+            ],
+            200_000_000,
+        );
+        return;
+    }
     if only.as_deref() != Some("batch") {
         bench_set::<PlainBenchBus>("plain");
         bench_set::<LinearMemoryBus>("linearbus");

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -236,6 +236,48 @@ fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
     );
 }
 
+/// Measure decoded generic memory operations without allowing a backward
+/// branch to turn the workload into a native JIT loop. Each pass walks the
+/// same straight-line code, retaining the decoded-op cache while resetting
+/// only the architectural state changed by the instruction stream.
+fn bench_generic_memory(name: &str, words: &[u16], instrs_per_pattern: u32) {
+    const CODE_BASE: usize = 0x100;
+    const PATTERNS: u32 = 16_384;
+    const PASSES: u32 = 512;
+    let mut bus = LinearMemoryBus::new(0x10_0000);
+    for pattern in 0..PATTERNS as usize {
+        for (word, value) in words.iter().enumerate() {
+            bus.write_word_at(
+                (CODE_BASE + (pattern * words.len() + word) * 2) as u32,
+                *value,
+            );
+        }
+    }
+
+    let instrs_per_pass = PATTERNS * instrs_per_pattern;
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    cpu.set_sr(0x2700);
+    cpu.pc = CODE_BASE as u32;
+    cpu.set_a(0, 0x80000);
+    let warm = cpu.run_batch(&mut bus, instrs_per_pass, &[0]);
+    assert_eq!(warm.instructions, instrs_per_pass);
+
+    let start = Instant::now();
+    for _ in 0..PASSES {
+        cpu.pc = CODE_BASE as u32;
+        cpu.set_a(0, 0x80000);
+        let result = cpu.run_batch(&mut bus, instrs_per_pass, &[0]);
+        assert_eq!(result.instructions, instrs_per_pass);
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    let instrs = u64::from(instrs_per_pass) * u64::from(PASSES);
+    println!(
+        "batch     {name:18} {:8.1} M instr/s",
+        instrs as f64 / elapsed / 1_000_000.0
+    );
+}
+
 fn bench_set<B: BenchBus>(label: &str) {
     bench_linear::<B>(label, "linear NOP", 0x4E71, 4, 40_000_000);
     bench_linear::<B>(label, "linear ADDQ", 0x5280, 4, 40_000_000);
@@ -276,6 +318,13 @@ fn main() {
         for head_ops in 2..=9 {
             bench_one_shot_a5_trace(head_ops, 50_000_000);
         }
+        return;
+    }
+    if only.as_deref() == Some("generic-memory") {
+        bench_generic_memory("TST.B (A0)", &[0x4A10], 1);
+        bench_generic_memory("TST.B (A0)+", &[0x4A18], 1);
+        bench_generic_memory("TST.B index", &[0x4A30, 0x0000], 1);
+        bench_generic_memory("ADD.W (A0),D0", &[0xD050], 1);
         return;
     }
     if only.as_deref() == Some("region") {

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -209,6 +209,10 @@ pub struct CpuCore {
     pub(crate) trace_probe_skip: [u32; 4],
     pub(crate) trace_record_skip_at: u8,
     pub(crate) trace_probe_skip_at: u8,
+    /// True while the trace JIT is recording an executed multi-block path.
+    /// Kept on the CPU so the normal instruction loop avoids a TLS lookup
+    /// when no recording is active.
+    pub(crate) trace_recording: bool,
 
     /// When enabled, use SingleStepTests/MAME-derived semantics for a few edge cases where
     /// Musashi and MAME fixtures intentionally differ (notably BCD "invalid digit" behavior and
@@ -264,6 +268,7 @@ impl CpuCore {
             trace_probe_skip: [super::trace_jit::TRACE_PC_NONE; 4],
             trace_record_skip_at: 0,
             trace_probe_skip_at: 0,
+            trace_recording: false,
             change_of_flow: false,
             pref_addr: 0,
             pref_data: 0,

--- a/src/core/mem_ops.rs
+++ b/src/core/mem_ops.rs
@@ -1146,6 +1146,7 @@ fn brief_index(cpu: &CpuCore, pending: &Pending, base: u32, ext: u32) -> Option<
 
 /// Resolve one EA to a location, reading extension words and recording
 /// pending register updates. No CPU state is modified.
+#[inline(always)]
 fn resolve(cpu: &CpuCore, win: Win, ea: FastEa, size: Size, ctx: &mut Ctx) -> Option<Loc> {
     let mem = |cpu: &CpuCore, ctx: &Ctx, raw: u32| -> Option<Loc> {
         if ctx.aligned_only && size != Size::Byte && (raw & 1) != 0 {
@@ -1249,7 +1250,7 @@ fn resolve_control_addr(cpu: &CpuCore, win: Win, ea: FastEa, ctx: &mut Ctx) -> O
     }
 }
 
-#[inline]
+#[inline(always)]
 fn load(cpu: &CpuCore, win: Win, loc: &Loc, size: Size) -> u32 {
     match *loc {
         Loc::Reg(i) => cpu.dar[i] & size.mask(),
@@ -1258,7 +1259,7 @@ fn load(cpu: &CpuCore, win: Win, loc: &Loc, size: Size) -> u32 {
     }
 }
 
-#[inline]
+#[inline(always)]
 fn store(cpu: &mut CpuCore, win: Win, loc: &Loc, size: Size, value: u32) {
     match *loc {
         Loc::Reg(i) => {

--- a/src/core/mem_ops.rs
+++ b/src/core/mem_ops.rs
@@ -773,6 +773,236 @@ fn fast_move(cpu: &mut CpuCore, win: Win, size: Size, src: FastEa, dst: FastEa) 
     Some(true)
 }
 
+/// Specialized execution for the common A5-relative data accesses emitted
+/// by classic Mac compilers. AnDisp is unusually hot because A5 is the
+/// application's global-data base. Keeping the extension cursor, resolved
+/// offset and value in locals avoids the generic Ctx/Pending/Loc state
+/// machine while retaining its all-checks-before-commit fallback contract.
+#[inline]
+fn fast_an_disp(cpu: &mut CpuCore, win: Win, op: DecodedMemOp) -> Option<bool> {
+    let read_word = |cpu: &CpuCore, pc: u32| -> Result<u32, ()> {
+        let off = win.off(cpu.address(pc), 2).ok_or(())?;
+        Ok(win.read(off, Size::Word))
+    };
+    let locate = |cpu: &CpuCore, reg: u8, disp: u32, size: Size| -> Result<usize, ()> {
+        let raw = (cpu.dar[8 + reg as usize] as i32).wrapping_add(disp as u16 as i16 as i32) as u32;
+        if cpu.is_pre_68020 && size != Size::Byte && (raw & 1) != 0 {
+            return Err(());
+        }
+        win.off(cpu.address(raw), size.bytes()).ok_or(())
+    };
+
+    match op {
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::DataReg(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, src, ext, size) else {
+                return Some(false);
+            };
+            let value = win.read(off, size);
+            let mask = size.mask();
+            let dst = dst as usize;
+            cpu.dar[dst] = (cpu.dar[dst] & !mask) | value;
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::AddrReg(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, src, ext, size) else {
+                return Some(false);
+            };
+            let value = win.read(off, size);
+            cpu.dar[8 + dst as usize] = if size == Size::Word {
+                value as u16 as i16 as i32 as u32
+            } else {
+                value
+            };
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::DataReg(src),
+            dst: FastEa::AnDisp(dst),
+        }
+        | DecodedMemOp::Move {
+            size,
+            src: FastEa::AddrReg(src),
+            dst: FastEa::AnDisp(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, dst, ext, size) else {
+                return Some(false);
+            };
+            let src_index = if matches!(
+                op,
+                DecodedMemOp::Move {
+                    src: FastEa::DataReg(_),
+                    ..
+                }
+            ) {
+                src as usize
+            } else {
+                8 + src as usize
+            };
+            let value = cpu.dar[src_index] & size.mask();
+            win.write(off, size, value);
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::AnPreDec(dst),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(src_off) = locate(cpu, src, ext, size) else {
+                return Some(false);
+            };
+            let dst_addr = cpu.dar[8 + dst as usize].wrapping_sub(ea_step(size, dst));
+            if cpu.is_pre_68020 && size != Size::Byte && (dst_addr & 1) != 0 {
+                return Some(false);
+            }
+            let Some(dst_off) = win.off(cpu.address(dst_addr), size.bytes()) else {
+                return Some(false);
+            };
+            let value = win.read(src_off, size);
+            cpu.dar[8 + dst as usize] = dst_addr;
+            win.write(dst_off, size, value);
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Move {
+            size,
+            src: FastEa::AnDisp(src),
+            dst: FastEa::AnDisp(dst),
+        } => {
+            let Ok(src_ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(dst_ext) = read_word(cpu, cpu.pc.wrapping_add(2)) else {
+                return Some(false);
+            };
+            let Ok(src_off) = locate(cpu, src, src_ext, size) else {
+                return Some(false);
+            };
+            let Ok(dst_off) = locate(cpu, dst, dst_ext, size) else {
+                return Some(false);
+            };
+            let value = win.read(src_off, size);
+            win.write(dst_off, size, value);
+            cpu.set_logic_flags(value, size);
+            cpu.pc = cpu.pc.wrapping_add(4);
+            Some(true)
+        }
+        DecodedMemOp::Tst {
+            size,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, size) else {
+                return Some(false);
+            };
+            cpu.set_logic_flags(win.read(off, size), size);
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::Clr {
+            size,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, size) else {
+                return Some(false);
+            };
+            win.write(off, size, 0);
+            cpu.n_flag = 0;
+            cpu.not_z_flag = 0;
+            cpu.v_flag = 0;
+            cpu.c_flag = 0;
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::AddqSubq {
+            data,
+            size,
+            ea: FastEa::AnDisp(reg),
+            is_sub,
+        } => {
+            let Ok(ext) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, size) else {
+                return Some(false);
+            };
+            let dst = win.read(off, size);
+            let result = if is_sub {
+                dst.wrapping_sub(data)
+            } else {
+                dst.wrapping_add(data)
+            };
+            win.write(off, size, result & size.mask());
+            if is_sub {
+                cpu.set_sub_flags(data, dst, result, size);
+            } else {
+                cpu.set_add_flags(data, dst, result, size);
+            }
+            cpu.pc = cpu.pc.wrapping_add(2);
+            Some(true)
+        }
+        DecodedMemOp::BitMem {
+            op,
+            bit: BitSource::Imm,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let Ok(bit) = read_word(cpu, cpu.pc) else {
+                return Some(false);
+            };
+            let Ok(ext) = read_word(cpu, cpu.pc.wrapping_add(2)) else {
+                return Some(false);
+            };
+            let Ok(off) = locate(cpu, reg, ext, Size::Byte) else {
+                return Some(false);
+            };
+            let bit = bit & 7;
+            let mask = 1 << bit;
+            let value = win.read(off, Size::Byte);
+            cpu.not_z_flag = u32::from(value & mask != 0);
+            match op {
+                BitOp::Test => {}
+                BitOp::Set => win.write(off, Size::Byte, value | mask),
+                BitOp::Clear => win.write(off, Size::Byte, value & !mask),
+                BitOp::Change => win.write(off, Size::Byte, value ^ mask),
+            }
+            cpu.pc = cpu.pc.wrapping_add(4);
+            Some(true)
+        }
+        _ => None,
+    }
+}
+
 /// Specialized DBcc/BSR/RTS/Bcc.W execution: at most one extension word,
 /// no EA resolution, so the `Ctx` plumbing is skipped. Mirrors the generic
 /// arms exactly (which remain the single source of truth for the other
@@ -1057,6 +1287,10 @@ pub(crate) fn execute_mem_op(cpu: &mut CpuCore, op: DecodedMemOp) -> bool {
     if let DecodedMemOp::Move { size, src, dst } = op
         && let Some(handled) = fast_move(cpu, win, size, src, dst)
     {
+        return handled;
+    }
+
+    if let Some(handled) = fast_an_disp(cpu, win, op) {
         return handled;
     }
 
@@ -1479,5 +1713,112 @@ fn apply_binary_to_reg(
             cpu.dar[reg] = (cpu.dar[reg] & !mask) | (result & mask);
             cpu.set_logic_flags(result, size);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cpu_with_window(mem: &mut [u8]) -> CpuCore {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.fm_ptr = mem.as_mut_ptr() as usize;
+        cpu.fm_base = 0;
+        cpu.fm_len = mem.len() as u32;
+        cpu.pc = 0x100;
+        cpu.set_a(5, 0x400);
+        cpu
+    }
+
+    #[test]
+    fn fast_an_disp_tst_and_clr_advance_extension_cursor() {
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x100..0x102].copy_from_slice(&0x0012u16.to_be_bytes());
+        mem[0x412] = 0x80;
+        let mut cpu = cpu_with_window(&mut mem);
+
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Tst {
+                size: Size::Byte,
+                ea: FastEa::AnDisp(5),
+            }
+        ));
+        assert_eq!(cpu.pc, 0x102);
+        assert_ne!(cpu.n_flag, 0);
+        assert_ne!(cpu.not_z_flag, 0);
+
+        cpu.pc = 0x100;
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Clr {
+                size: Size::Byte,
+                ea: FastEa::AnDisp(5),
+            }
+        ));
+        assert_eq!(mem[0x412], 0);
+        assert_eq!(cpu.pc, 0x102);
+        assert_eq!(cpu.not_z_flag, 0);
+    }
+
+    #[test]
+    fn fast_an_disp_immediate_bit_uses_both_extension_words() {
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x100..0x102].copy_from_slice(&3u16.to_be_bytes());
+        mem[0x102..0x104].copy_from_slice(&0x0012u16.to_be_bytes());
+        mem[0x412] = 0b0000_1000;
+        let mut cpu = cpu_with_window(&mut mem);
+
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::BitMem {
+                op: BitOp::Test,
+                bit: BitSource::Imm,
+                ea: FastEa::AnDisp(5),
+            }
+        ));
+        assert_eq!(cpu.pc, 0x104);
+        assert_eq!(cpu.not_z_flag, 1);
+        assert_eq!(mem[0x412], 0b0000_1000);
+    }
+
+    #[test]
+    fn fast_an_disp_move_checks_both_operands_before_commit() {
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x100..0x102].copy_from_slice(&0x0012u16.to_be_bytes());
+        mem[0x412..0x416].copy_from_slice(&0xDEAD_BEEFu32.to_be_bytes());
+        let mut cpu = cpu_with_window(&mut mem);
+        cpu.set_a(7, 0x800);
+
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Move {
+                size: Size::Long,
+                src: FastEa::AnDisp(5),
+                dst: FastEa::AnPreDec(7),
+            }
+        ));
+        assert_eq!(cpu.a(7), 0x7FC);
+        assert_eq!(&mem[0x7FC..0x800], &0xDEAD_BEEFu32.to_be_bytes());
+        assert_eq!(cpu.pc, 0x102);
+
+        cpu.pc = 0x100;
+        cpu.set_a(7, 2);
+        let old_flags = (cpu.n_flag, cpu.not_z_flag, cpu.v_flag, cpu.c_flag);
+        assert!(!execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::Move {
+                size: Size::Long,
+                src: FastEa::AnDisp(5),
+                dst: FastEa::AnPreDec(7),
+            }
+        ));
+        assert_eq!(cpu.a(7), 2);
+        assert_eq!(cpu.pc, 0x100);
+        assert_eq!(
+            (cpu.n_flag, cpu.not_z_flag, cpu.v_flag, cpu.c_flag),
+            old_flags
+        );
     }
 }

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -419,6 +419,7 @@ impl DecodedSimpleOp {
                 condition,
                 displacement: displacement as i32,
                 length: 2,
+                expected_taken: None,
             }),
             _ => None,
         }
@@ -943,7 +944,7 @@ impl CpuCore {
             if probe {
                 probe = false;
                 if let Some((result, _instructions)) =
-                    trace_jit::try_execute_trace(self, bus, cpu_type, u32::MAX, false)
+                    trace_jit::try_execute_trace(self, bus, cpu_type, u32::MAX, false, &[])
                 {
                     match result {
                         CachedRunResult::Ran => {
@@ -964,6 +965,7 @@ impl CpuCore {
             self.ir = opcode as u32;
 
             let Some(op) = self.decoded_simple_op(opcode, cpu_type) else {
+                trace_jit::stop_recording(self);
                 return CachedRunResult::Miss(opcode);
             };
             let branch_pc = if matches!(op, DecodedSimpleOp::BranchShort { .. }) {
@@ -972,6 +974,7 @@ impl CpuCore {
                 None
             };
             let cycles = op.execute(self);
+            trace_jit::record_executed(self, bus, self.ppc, self.pc);
             if let Some(branch_pc) = branch_pc
                 && self.pc <= branch_pc
             {
@@ -980,6 +983,7 @@ impl CpuCore {
             self.cycles_remaining -= cycles;
         }
 
+        trace_jit::stop_recording(self);
         CachedRunResult::Ran
     }
 
@@ -990,9 +994,9 @@ impl CpuCore {
     /// - `budget` counts retired instructions, and `*retired` is
     ///   incremented in place so the caller keeps an exact count even
     ///   when JIT traces retire many instructions per call.
-    /// - Traces are only attempted while at least `TRACE_MAX_OPS`
-    ///   instructions of budget remain, so a trace can never overshoot
-    ///   the budget.
+    /// - Traces are only attempted while at least `TRACE_MIN_OPS`
+    ///   instructions remain; the trace itself checks its exact length
+    ///   before entry, so it cannot overshoot the budget.
     /// - After every retired instruction (or trace), the new PC is
     ///   checked against `watch_pcs`.
     pub(crate) fn run_decoded_simple_batch<B: AddressBus>(
@@ -1011,7 +1015,7 @@ impl CpuCore {
         let mut probe = probe_on_entry && trace_jit::has_trace_candidates();
 
         while remaining > 0 {
-            if probe && remaining >= trace_jit::TRACE_MAX_OPS as u32 {
+            if probe && remaining >= trace_jit::TRACE_MIN_OPS as u32 {
                 // run_batch is instruction-budgeted, not cycle-budgeted.
                 // A long-running self-loop can consume the synthetic cycle
                 // headroom in one trace call; replenish it before every
@@ -1025,9 +1029,14 @@ impl CpuCore {
                 // having an unrelated watch (Systemless always watches PC
                 // 0 for clean exit) must not serialize every JIT iteration.
                 let single_iter = watch && watch_pcs.contains(&self.pc);
-                if let Some((result, instructions)) =
-                    trace_jit::try_execute_trace(self, bus, cpu_type, remaining, single_iter)
-                {
+                if let Some((result, instructions)) = trace_jit::try_execute_trace(
+                    self,
+                    bus,
+                    cpu_type,
+                    remaining,
+                    single_iter,
+                    watch_pcs,
+                ) {
                     match result {
                         CachedRunResult::Ran => {
                             remaining -= instructions;
@@ -1082,6 +1091,7 @@ impl CpuCore {
                         None
                     };
                     let _cycles = op.execute(self);
+                    trace_jit::record_executed(self, bus, self.ppc, self.pc);
                     if let Some(branch_pc) = branch_pc
                         && self.pc <= branch_pc
                     {
@@ -1090,21 +1100,28 @@ impl CpuCore {
                 }
                 CachedOp::Mem(op) => {
                     if !super::mem_ops::execute_mem_op(self, op) {
+                        trace_jit::stop_recording(self);
                         return BatchInnerExit::Miss(opcode);
                     }
+                    trace_jit::record_executed(self, bus, self.ppc, self.pc);
                     if self.pc <= self.ppc {
                         probe = trace_jit::note_backward_branch(self, cpu_type);
                     }
                 }
-                CachedOp::Complex => return BatchInnerExit::Miss(opcode),
+                CachedOp::Complex => {
+                    trace_jit::stop_recording(self);
+                    return BatchInnerExit::Miss(opcode);
+                }
             }
             remaining -= 1;
             *retired += 1;
             if watch && watch_pcs.contains(&self.pc) {
+                trace_jit::stop_recording(self);
                 return BatchInnerExit::Watched(self.pc);
             }
         }
 
+        trace_jit::stop_recording(self);
         BatchInnerExit::Budget
     }
 

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1012,9 +1012,21 @@ impl CpuCore {
 
         while remaining > 0 {
             if probe && remaining >= trace_jit::TRACE_MAX_OPS as u32 {
+                // run_batch is instruction-budgeted, not cycle-budgeted.
+                // A long-running self-loop can consume the synthetic cycle
+                // headroom in one trace call; replenish it before every
+                // probe so subsequent iterations do not silently fall back
+                // to the interpreter. Cycle-budgeted callers use the other
+                // decoded-op loop and retain their real remaining budget.
+                self.cycles_remaining = i32::MAX / 2;
                 probe = false;
+                // A self-loop only needs to stop after one iteration when
+                // returning to its own head would hit a watched PC. Merely
+                // having an unrelated watch (Systemless always watches PC
+                // 0 for clean exit) must not serialize every JIT iteration.
+                let single_iter = watch && watch_pcs.contains(&self.pc);
                 if let Some((result, instructions)) =
-                    trace_jit::try_execute_trace(self, bus, cpu_type, remaining, watch)
+                    trace_jit::try_execute_trace(self, bus, cpu_type, remaining, single_iter)
                 {
                     match result {
                         CachedRunResult::Ran => {

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -425,7 +425,7 @@ impl DecodedSimpleOp {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub(crate) fn execute(self, cpu: &mut CpuCore) -> i32 {
         match self {
             Self::Nop => 4,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -7,8 +7,9 @@
 use super::cpu::{CFLAG_SET, VFLAG_SET};
 use super::cpu::{CpuCore, NFLAG_SET};
 use super::execute::RUN_MODE_BERR_AERR_RESET;
+use super::mem_ops::{BitSource, DecodedMemOp, FastEa};
 use super::memory::AddressBus;
-use super::op_cache::{CachedRunResult, DecodedSimpleOp};
+use super::op_cache::{BitOp, CachedRunResult, DecodedSimpleOp};
 use super::types::{CpuType, Size};
 #[cfg(not(target_family = "wasm"))]
 use cranelift_codegen::Context;
@@ -31,6 +32,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 const TRACE_CACHE_SIZE: usize = 4096;
 pub(crate) const TRACE_MAX_OPS: usize = 16;
+const TRACE_MIN_OPS: usize = 3;
 const TRACE_HOT_THRESHOLD: u8 = 2;
 
 /// Sentinel for `CpuCore::trace_record_skip` / `trace_probe_skip`: no PC.
@@ -67,11 +69,16 @@ pub(crate) enum JitEa {
     PostInc(u8),
     /// -(An)
     PreDec(u8),
+    /// (d16,An), with the extension word captured in the trace.
+    Disp(u8, i16),
 }
 
 impl JitEa {
     fn is_mem(self) -> bool {
-        matches!(self, Self::Ind(_) | Self::PostInc(_) | Self::PreDec(_))
+        matches!(
+            self,
+            Self::Ind(_) | Self::PostInc(_) | Self::PreDec(_) | Self::Disp(_, _)
+        )
     }
 }
 
@@ -117,6 +124,12 @@ pub(crate) enum JitBitOp {
     Change,
     Clear,
     Set,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JitBitSource {
+    Reg(u8),
+    Imm(u8),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -217,14 +230,43 @@ pub(crate) enum JitTraceOp {
         src: JitEa,
         dst: JitEa,
     },
+    /// Hot Classic Mac memory forms using the A5-relative global-data
+    /// convention. These require extension words, so they are represented
+    /// explicitly rather than going through the register-only trace ops.
+    AnDispUnary {
+        op: JitUnaryOp,
+        size: Size,
+        reg: u8,
+        displacement: i16,
+    },
+    AnDispAddqSubq {
+        data: u32,
+        size: Size,
+        reg: u8,
+        displacement: i16,
+        is_sub: bool,
+    },
+    AnDispBit {
+        op: JitBitOp,
+        bit: JitBitSource,
+        reg: u8,
+        displacement: i16,
+    },
 }
 
 #[derive(Debug, Clone, Copy)]
 struct TraceBuildOp {
     opcode: u16,
     extension: Option<u16>,
+    extension2: Option<u16>,
     pc: u32,
     op: JitTraceOp,
+}
+
+impl TraceBuildOp {
+    fn length(self) -> u8 {
+        2 + 2 * u8::from(self.extension.is_some()) + 2 * u8::from(self.extension2.is_some())
+    }
 }
 
 struct CompiledTrace {
@@ -404,6 +446,17 @@ impl TraceJit {
                             Err(_) => return None,
                         }
                     }
+                    if let Some(expected) = op.extension2 {
+                        let addr = cpu.address(op.pc.wrapping_add(4));
+                        match bus.try_read_word(addr) {
+                            Ok(extension) if extension == expected => {}
+                            Ok(_) => {
+                                miss = Some((index, op.pc, op.opcode));
+                                break;
+                            }
+                            Err(_) => return None,
+                        }
+                    }
                 }
             }
 
@@ -562,13 +615,13 @@ impl TraceJit {
             ops.push(op);
 
             let jit_op = op.op;
-            pc = pc.wrapping_add(jit_op.length() as u32);
+            pc = pc.wrapping_add(op.length() as u32);
             if jit_op.ends_trace() {
                 break;
             }
         }
 
-        if ops.len() < 2 || !ops.last().is_some_and(|op| op.op.ends_trace()) {
+        if ops.len() < TRACE_MIN_OPS || !ops.last().is_some_and(|op| op.op.ends_trace()) {
             return None;
         }
 
@@ -578,6 +631,9 @@ impl TraceJit {
             if let Some(extension) = op.extension {
                 code.extend_from_slice(&extension.to_be_bytes());
             }
+            if let Some(extension) = op.extension2 {
+                code.extend_from_slice(&extension.to_be_bytes());
+            }
         }
         debug_assert_eq!(code.len() as u32, pc.wrapping_sub(start_pc));
 
@@ -585,9 +641,15 @@ impl TraceJit {
             .last()
             .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
 
-        let needs_window = ops
-            .iter()
-            .any(|op| matches!(op.op, JitTraceOp::MoveMem { .. }));
+        let needs_window = ops.iter().any(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::MoveMem { .. }
+                    | JitTraceOp::AnDispUnary { .. }
+                    | JitTraceOp::AnDispAddqSubq { .. }
+                    | JitTraceOp::AnDispBit { .. }
+            )
+        });
 
         // Address-masked code range, used by the store-overlap (SMC) bail
         // checks. Reject the exotic case of a trace wrapping the address
@@ -678,26 +740,34 @@ impl TraceJit {
             let mut cycles_before: i64 = 0;
             let mut cycles_value = builder.ins().iconst(types::I32, 0);
             for (index, op) in ops.iter().enumerate() {
-                let op_cycles = if let JitTraceOp::MoveMem { size, src, dst } = op.op {
-                    let env = mem_env.as_ref().expect("MoveMem implies a window env");
-                    emit_move_mem(
-                        &mut builder,
-                        cpu_ptr,
-                        MoveMemOp {
-                            pc: op.pc,
-                            size,
-                            src,
-                            dst,
-                        },
-                        env,
-                        &mut bails,
-                        BailAt {
-                            ops_before: index as u32,
-                            cycles_before,
-                        },
-                    )
-                } else {
-                    emit_jit_op(&mut builder, cpu_ptr, *op, aligned_only)
+                let bail_at = BailAt {
+                    ops_before: index as u32,
+                    cycles_before,
+                };
+                let op_cycles = match op.op {
+                    JitTraceOp::MoveMem { size, src, dst } => {
+                        let env = mem_env.as_ref().expect("MoveMem implies a window env");
+                        emit_move_mem(
+                            &mut builder,
+                            cpu_ptr,
+                            MoveMemOp {
+                                pc: op.pc,
+                                size,
+                                src,
+                                dst,
+                            },
+                            env,
+                            &mut bails,
+                            bail_at,
+                        )
+                    }
+                    JitTraceOp::AnDispUnary { .. }
+                    | JitTraceOp::AnDispAddqSubq { .. }
+                    | JitTraceOp::AnDispBit { .. } => {
+                        let env = mem_env.as_ref().expect("AnDisp implies a window env");
+                        emit_an_disp_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
+                    _ => emit_jit_op(&mut builder, cpu_ptr, *op, aligned_only),
                 };
                 cycles_value = builder.ins().iadd(cycles_value, op_cycles);
                 // Exact for every op that can precede a bail (MoveMem and
@@ -912,14 +982,36 @@ impl JitTraceOp {
                             6
                         }
                     }
+                    JitEa::Disp(_, _) => {
+                        if long {
+                            12
+                        } else {
+                            8
+                        }
+                    }
                 };
-                let dst_c = if dst.is_mem() {
-                    if long { 8 } else { 4 }
-                } else {
-                    0
+                let dst_c = match dst {
+                    JitEa::Disp(_, _) => {
+                        if long {
+                            12
+                        } else {
+                            8
+                        }
+                    }
+                    _ if dst.is_mem() => {
+                        if long {
+                            8
+                        } else {
+                            4
+                        }
+                    }
+                    _ => 0,
                 };
                 4 + src_c + dst_c
             }
+            // These ops only execute in instruction-budgeted fastmem mode;
+            // conservative cycle maxima preserve the trace headroom guard.
+            Self::AnDispUnary { .. } | Self::AnDispAddqSubq { .. } | Self::AnDispBit { .. } => 24,
         }
     }
 
@@ -939,14 +1031,6 @@ impl JitTraceOp {
             _ => None,
         }
     }
-
-    fn length(self) -> u8 {
-        match self {
-            Self::Branch { length, .. } => length,
-            Self::Dbcc { .. } => 4,
-            _ => 2,
-        }
-    }
 }
 
 fn decode_trace_op<B: AddressBus>(
@@ -962,7 +1046,10 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_branch_word_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
-    if let Some(op) = decode_move_mem_trace_op(pc, opcode) {
+    if let Some(op) = decode_an_disp_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
 
@@ -971,6 +1058,7 @@ fn decode_trace_op<B: AddressBus>(
     Some(TraceBuildOp {
         opcode,
         extension: None,
+        extension2: None,
         pc,
         op,
     })
@@ -990,6 +1078,7 @@ fn decode_dbcc_trace_op<B: AddressBus>(
     Some(TraceBuildOp {
         opcode,
         extension: Some(extension),
+        extension2: None,
         pc,
         op: JitTraceOp::Dbcc {
             condition: ((opcode >> 8) & 0xF) as u8,
@@ -1018,6 +1107,7 @@ fn decode_branch_word_trace_op<B: AddressBus>(
     Some(TraceBuildOp {
         opcode,
         extension: Some(extension),
+        extension2: None,
         pc,
         op: JitTraceOp::Branch {
             condition,
@@ -1027,18 +1117,154 @@ fn decode_branch_word_trace_op<B: AddressBus>(
     })
 }
 
-/// MOVE/MOVEA (groups 1-3) where both EAs are register or register-indirect
-/// forms — no extension words. At least one side must be memory
-/// (register-to-register MOVEs are simple ops already).
-fn decode_move_mem_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
+fn decode_an_disp_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let decoded = DecodedMemOp::decode(cpu_type, opcode)?;
+    let read_ext =
+        |offset: u32, bus: &mut B| bus.try_read_word(cpu.address(pc.wrapping_add(offset))).ok();
+    let (extension, extension2, op) = match decoded {
+        DecodedMemOp::Tst {
+            size,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let displacement = read_ext(2, bus)?;
+            (
+                displacement,
+                None,
+                JitTraceOp::AnDispUnary {
+                    op: JitUnaryOp::Tst,
+                    size,
+                    reg,
+                    displacement: displacement as i16,
+                },
+            )
+        }
+        DecodedMemOp::Clr {
+            size,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let displacement = read_ext(2, bus)?;
+            (
+                displacement,
+                None,
+                JitTraceOp::AnDispUnary {
+                    op: JitUnaryOp::Clr,
+                    size,
+                    reg,
+                    displacement: displacement as i16,
+                },
+            )
+        }
+        DecodedMemOp::AddqSubq {
+            data,
+            size,
+            ea: FastEa::AnDisp(reg),
+            is_sub,
+        } => {
+            let displacement = read_ext(2, bus)?;
+            (
+                displacement,
+                None,
+                JitTraceOp::AnDispAddqSubq {
+                    data,
+                    size,
+                    reg,
+                    displacement: displacement as i16,
+                    is_sub,
+                },
+            )
+        }
+        DecodedMemOp::BitMem {
+            op,
+            bit,
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let op = match op {
+                BitOp::Test => JitBitOp::Test,
+                BitOp::Change => JitBitOp::Change,
+                BitOp::Clear => JitBitOp::Clear,
+                BitOp::Set => JitBitOp::Set,
+            };
+            match bit {
+                BitSource::Reg(bit_reg) => {
+                    let displacement = read_ext(2, bus)?;
+                    (
+                        displacement,
+                        None,
+                        JitTraceOp::AnDispBit {
+                            op,
+                            bit: JitBitSource::Reg(bit_reg),
+                            reg,
+                            displacement: displacement as i16,
+                        },
+                    )
+                }
+                BitSource::Imm => {
+                    let bit_word = read_ext(2, bus)?;
+                    let displacement = read_ext(4, bus)?;
+                    (
+                        bit_word,
+                        Some(displacement),
+                        JitTraceOp::AnDispBit {
+                            op,
+                            bit: JitBitSource::Imm((bit_word & 7) as u8),
+                            reg,
+                            displacement: displacement as i16,
+                        },
+                    )
+                }
+            }
+        }
+        _ => return None,
+    };
+    Some(TraceBuildOp {
+        opcode,
+        extension: Some(extension),
+        extension2,
+        pc,
+        op,
+    })
+}
+
+/// MOVE/MOVEA (groups 1-3) using register, register-indirect, or d16(An)
+/// EAs. At least one side must be memory; displacement words are captured
+/// in execution order for validation and self-modification checks.
+fn decode_move_mem_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+) -> Option<TraceBuildOp> {
     let size = match opcode >> 12 {
         1 => Size::Byte,
         2 => Size::Long,
         3 => Size::Word,
         _ => return None,
     };
-    let src = decode_jit_ea((opcode >> 3) & 7, opcode & 7)?;
-    let dst = decode_jit_ea((opcode >> 6) & 7, (opcode >> 9) & 7)?;
+    let src_mode = (opcode >> 3) & 7;
+    let dst_mode = (opcode >> 6) & 7;
+    let mut next_ext = pc.wrapping_add(2);
+    let mut extensions = [None, None];
+    let mut extension_count = 0usize;
+    let mut read_disp = |mode: u16| -> Option<i16> {
+        if mode != 5 {
+            return Some(0);
+        }
+        let value = bus.try_read_word(cpu.address(next_ext)).ok()?;
+        next_ext = next_ext.wrapping_add(2);
+        extensions[extension_count] = Some(value);
+        extension_count += 1;
+        Some(value as i16)
+    };
+    let src_disp = read_disp(src_mode)?;
+    let dst_disp = read_disp(dst_mode)?;
+    let src = decode_jit_ea(src_mode, opcode & 7, src_disp)?;
+    let dst = decode_jit_ea(dst_mode, (opcode >> 9) & 7, dst_disp)?;
     if !src.is_mem() && !dst.is_mem() {
         return None;
     }
@@ -1048,19 +1274,21 @@ fn decode_move_mem_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
     }
     Some(TraceBuildOp {
         opcode,
-        extension: None,
+        extension: extensions[0],
+        extension2: extensions[1],
         pc,
         op: JitTraceOp::MoveMem { size, src, dst },
     })
 }
 
-fn decode_jit_ea(mode: u16, reg: u16) -> Option<JitEa> {
+fn decode_jit_ea(mode: u16, reg: u16, displacement: i16) -> Option<JitEa> {
     Some(match mode & 7 {
         0 => JitEa::Data(reg as u8),
         1 => JitEa::Addr(reg as u8),
         2 => JitEa::Ind(reg as u8),
         3 => JitEa::PostInc(reg as u8),
         4 => JitEa::PreDec(reg as u8),
+        5 => JitEa::Disp(reg as u8, displacement),
         _ => return None,
     })
 }
@@ -1104,7 +1332,106 @@ fn execute_portable_op(
     if let JitTraceOp::MoveMem { size, src, dst } = op.op {
         return execute_portable_move_mem(cpu, size, src, dst, code_start, code_end);
     }
+    if matches!(
+        op.op,
+        JitTraceOp::AnDispUnary { .. }
+            | JitTraceOp::AnDispAddqSubq { .. }
+            | JitTraceOp::AnDispBit { .. }
+    ) {
+        return execute_portable_an_disp(cpu, op, code_start, code_end);
+    }
     Some(execute_portable_reg_op(cpu, op))
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_an_disp(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    code_start: u32,
+    code_end: u32,
+) -> Option<i32> {
+    let store = match trace.op {
+        JitTraceOp::AnDispUnary {
+            op: JitUnaryOp::Clr,
+            size,
+            reg,
+            displacement,
+        }
+        | JitTraceOp::AnDispAddqSubq {
+            size,
+            reg,
+            displacement,
+            ..
+        } => Some((size, reg, displacement)),
+        JitTraceOp::AnDispBit {
+            op: JitBitOp::Change | JitBitOp::Clear | JitBitOp::Set,
+            reg,
+            displacement,
+            ..
+        } => Some((Size::Byte, reg, displacement)),
+        _ => None,
+    };
+    if let Some((size, reg, displacement)) = store {
+        let raw = cpu.dar[8 + reg as usize].wrapping_add(displacement as i32 as u32);
+        let masked = raw & cpu.address_mask;
+        if masked < code_end && masked.wrapping_add(size.bytes()) > code_start {
+            return None;
+        }
+    }
+    let op = match trace.op {
+        JitTraceOp::AnDispUnary {
+            op: JitUnaryOp::Tst,
+            size,
+            reg,
+            ..
+        } => DecodedMemOp::Tst {
+            size,
+            ea: FastEa::AnDisp(reg),
+        },
+        JitTraceOp::AnDispUnary {
+            op: JitUnaryOp::Clr,
+            size,
+            reg,
+            ..
+        } => DecodedMemOp::Clr {
+            size,
+            ea: FastEa::AnDisp(reg),
+        },
+        JitTraceOp::AnDispAddqSubq {
+            data,
+            size,
+            reg,
+            is_sub,
+            ..
+        } => DecodedMemOp::AddqSubq {
+            data,
+            size,
+            ea: FastEa::AnDisp(reg),
+            is_sub,
+        },
+        JitTraceOp::AnDispBit { op, bit, reg, .. } => DecodedMemOp::BitMem {
+            op: match op {
+                JitBitOp::Test => BitOp::Test,
+                JitBitOp::Change => BitOp::Change,
+                JitBitOp::Clear => BitOp::Clear,
+                JitBitOp::Set => BitOp::Set,
+            },
+            bit: match bit {
+                JitBitSource::Reg(reg) => BitSource::Reg(reg),
+                JitBitSource::Imm(_) => BitSource::Imm,
+            },
+            ea: FastEa::AnDisp(reg),
+        },
+        _ => return None,
+    };
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(cpu, op) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
 }
 
 /// Portable MoveMem, mirroring `emit_move_mem` exactly: all checks before
@@ -1162,6 +1489,10 @@ fn execute_portable_move_mem(
             staged = Some((8 + r as usize, a));
             read(cpu, off)
         }
+        JitEa::Disp(r, displacement) => {
+            let a = cpu.dar[8 + r as usize].wrapping_add(displacement as i32 as u32);
+            read(cpu, locate(cpu, a)?)
+        }
     };
 
     let dst_base = |cpu: &CpuCore, r: u8| match staged {
@@ -1188,7 +1519,7 @@ fn execute_portable_move_mem(
                 value
             };
         }
-        JitEa::Ind(r) | JitEa::PostInc(r) | JitEa::PreDec(r) => {
+        JitEa::Ind(r) | JitEa::PostInc(r) | JitEa::PreDec(r) | JitEa::Disp(r, _) => {
             let base = dst_base(cpu, r);
             let (addr, new_reg) = match dst {
                 JitEa::Ind(_) => (base, None),
@@ -1196,6 +1527,9 @@ fn execute_portable_move_mem(
                 JitEa::PreDec(_) => {
                     let a = base.wrapping_sub(jit_ea_step(size, r));
                     (a, Some(a))
+                }
+                JitEa::Disp(_, displacement) => {
+                    (base.wrapping_add(displacement as i32 as u32), None)
                 }
                 _ => unreachable!(),
             };
@@ -1549,6 +1883,11 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::MoveMem { .. } => {
             unreachable!("MoveMem is handled by execute_portable_move_mem")
         }
+        JitTraceOp::AnDispUnary { .. }
+        | JitTraceOp::AnDispAddqSubq { .. }
+        | JitTraceOp::AnDispBit { .. } => {
+            unreachable!("AnDisp ops are handled by execute_portable_an_disp")
+        }
     }
 }
 
@@ -1870,6 +2209,11 @@ fn emit_jit_op(
         }
         JitTraceOp::ShiftReg { .. } => unreachable!("ShiftReg traces are wasm-only"),
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
+        JitTraceOp::AnDispUnary { .. }
+        | JitTraceOp::AnDispAddqSubq { .. }
+        | JitTraceOp::AnDispBit { .. } => {
+            unreachable!("AnDisp ops are emitted by emit_an_disp_mem")
+        }
         JitTraceOp::Branch {
             condition,
             displacement,
@@ -2012,6 +2356,133 @@ fn window_store(
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
+fn guard_store_not_code(
+    builder: &mut FunctionBuilder<'_>,
+    env: &MemEnv,
+    bail: Block,
+    masked: Value,
+    size: Size,
+) {
+    let lt_end = builder
+        .ins()
+        .icmp_imm(IntCC::UnsignedLessThan, masked, env.code_end as i64);
+    let past = builder.ins().iadd_imm(masked, size.bytes() as i64);
+    let gt_start = builder
+        .ins()
+        .icmp_imm(IntCC::UnsignedGreaterThan, past, env.code_start as i64);
+    let bad = builder.ins().band(lt_end, gt_start);
+    branch_guard(builder, bail, bad);
+}
+
+/// Emit the displacement-memory operations that dominate Classic Mac code.
+/// The displacement is baked into the trace; only the live An value and
+/// fastmem bounds need checking at runtime.
+#[cfg(not(target_family = "wasm"))]
+fn emit_an_disp_mem(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+    let (reg, displacement, size) = match trace.op {
+        JitTraceOp::AnDispUnary {
+            reg,
+            displacement,
+            size,
+            ..
+        }
+        | JitTraceOp::AnDispAddqSubq {
+            reg,
+            displacement,
+            size,
+            ..
+        } => (reg, displacement, size),
+        JitTraceOp::AnDispBit {
+            reg, displacement, ..
+        } => (reg, displacement, Size::Byte),
+        _ => unreachable!(),
+    };
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+    let addr = builder.ins().iadd_imm(base, displacement as i64);
+    let (off, masked) = checked_window_off(builder, env, bail, addr, size);
+    let value = window_load(builder, env, off, size);
+
+    match trace.op {
+        JitTraceOp::AnDispUnary {
+            op: JitUnaryOp::Tst,
+            ..
+        } => set_logic_flags(builder, cpu, value, size),
+        JitTraceOp::AnDispUnary {
+            op: JitUnaryOp::Clr,
+            ..
+        } => {
+            guard_store_not_code(builder, env, bail, masked, size);
+            let zero = iconst_u32(builder, 0);
+            window_store(builder, env, off, size, zero);
+            store_u32(builder, cpu, offset_of!(CpuCore, n_flag), 0);
+            store_u32(builder, cpu, offset_of!(CpuCore, not_z_flag), 0);
+            store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+            store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
+        }
+        JitTraceOp::AnDispAddqSubq { data, is_sub, .. } => {
+            guard_store_not_code(builder, env, bail, masked, size);
+            let src = iconst_u32(builder, data);
+            let result = if is_sub {
+                builder.ins().isub(value, src)
+            } else {
+                builder.ins().iadd(value, src)
+            };
+            window_store(builder, env, off, size, result);
+            if is_sub {
+                set_sub_flags(builder, cpu, src, value, result, size);
+            } else {
+                set_add_flags(builder, cpu, src, value, result, size);
+            }
+        }
+        JitTraceOp::AnDispBit { op, bit, .. } => {
+            let bit = match bit {
+                JitBitSource::Reg(reg) => {
+                    let value = load_reg(builder, cpu, JitDirectReg::Data(reg));
+                    builder.ins().band_imm(value, 7)
+                }
+                JitBitSource::Imm(bit) => iconst_u32(builder, bit as u32),
+            };
+            let one = iconst_u32(builder, 1);
+            let mask = builder.ins().ishl(one, bit);
+            let tested = builder.ins().band(value, mask);
+            let not_z = flag_from_nonzero(builder, tested, 1);
+            match op {
+                JitBitOp::Test => {}
+                JitBitOp::Change | JitBitOp::Clear | JitBitOp::Set => {
+                    guard_store_not_code(builder, env, bail, masked, Size::Byte);
+                    let result = match op {
+                        JitBitOp::Change => builder.ins().bxor(value, mask),
+                        JitBitOp::Clear => {
+                            let inverted = builder.ins().bxor_imm(mask, -1);
+                            builder.ins().band(value, inverted)
+                        }
+                        JitBitOp::Set => builder.ins().bor(value, mask),
+                        JitBitOp::Test => unreachable!(),
+                    };
+                    window_store(builder, env, off, Size::Byte, result);
+                }
+            }
+            store_value_u32(builder, cpu, offset_of!(CpuCore, not_z_flag), not_z);
+        }
+        _ => unreachable!(),
+    }
+    cycles_const(builder, trace.op.max_cycles())
+}
+
 /// Emit a MOVE/MOVEA with memory operands. All alignment/window/code-overlap
 /// checks run before anything commits; each check branches to a bail block
 /// that sets `pc = op.pc` and returns the ops retired before this one, so a
@@ -2067,6 +2538,12 @@ fn emit_move_mem(
             staged = Some((r, a));
             window_load(builder, env, off, size)
         }
+        JitEa::Disp(r, displacement) => {
+            let base = load_an(builder, r);
+            let a = builder.ins().iadd_imm(base, displacement as i64);
+            let (off, _) = checked_window_off(builder, env, bail, a, size);
+            window_load(builder, env, off, size)
+        }
     };
 
     // A destination base register must observe a same-register source
@@ -2097,7 +2574,7 @@ fn emit_move_mem(
             };
             store_reg(builder, cpu, JitDirectReg::Addr(r), v);
         }
-        JitEa::Ind(r) | JitEa::PostInc(r) | JitEa::PreDec(r) => {
+        JitEa::Ind(r) | JitEa::PostInc(r) | JitEa::PreDec(r) | JitEa::Disp(r, _) => {
             let base = dst_base(builder, r);
             let (addr, new_reg) = match op.dst {
                 JitEa::Ind(_) => (base, None),
@@ -2108,6 +2585,9 @@ fn emit_move_mem(
                 JitEa::PreDec(_) => {
                     let a = builder.ins().iadd_imm(base, -(jit_ea_step(size, r) as i64));
                     (a, Some(a))
+                }
+                JitEa::Disp(_, displacement) => {
+                    (builder.ins().iadd_imm(base, displacement as i64), None)
                 }
                 _ => unreachable!(),
             };
@@ -2741,6 +3221,7 @@ mod portable_tests {
             TraceBuildOp {
                 opcode: 0x22D8,
                 extension: None,
+                extension2: None,
                 pc: 0x0100,
                 op: JitTraceOp::MoveMem {
                     size: Size::Long,
@@ -2751,6 +3232,7 @@ mod portable_tests {
             TraceBuildOp {
                 opcode: 0x51C8,
                 extension: Some(0xFFFC),
+                extension2: None,
                 pc: 0x0102,
                 op: JitTraceOp::Dbcc {
                     condition: 1,
@@ -2833,6 +3315,7 @@ mod portable_tests {
         let op = TraceBuildOp {
             opcode: 0x30D8,
             extension: None,
+            extension2: None,
             pc: 0x0100,
             op: JitTraceOp::MoveMem {
                 size: Size::Word,
@@ -2850,12 +3333,152 @@ mod portable_tests {
     }
 
     #[test]
+    fn portable_trace_executes_classic_mac_a5_mix() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x10000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x1000);
+        cpu.set_a(7, 0x8000);
+        cpu.set_d(0, 0x34);
+        mem[0x1100] = 0x08;
+
+        let ops = [
+            TraceBuildOp {
+                opcode: 0x4A2D,
+                extension: Some(0x0100),
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::AnDispUnary {
+                    op: JitUnaryOp::Tst,
+                    size: Size::Byte,
+                    reg: 5,
+                    displacement: 0x0100,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x082D,
+                extension: Some(3),
+                extension2: Some(0x0100),
+                pc: 0x0104,
+                op: JitTraceOp::AnDispBit {
+                    op: JitBitOp::Test,
+                    bit: JitBitSource::Imm(3),
+                    reg: 5,
+                    displacement: 0x0100,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x1B40,
+                extension: Some(0x0100),
+                extension2: None,
+                pc: 0x010A,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Byte,
+                    src: JitEa::Data(0),
+                    dst: JitEa::Disp(5, 0x0100),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x422D,
+                extension: Some(0x0100),
+                extension2: None,
+                pc: 0x010E,
+                op: JitTraceOp::AnDispUnary {
+                    op: JitUnaryOp::Clr,
+                    size: Size::Byte,
+                    reg: 5,
+                    displacement: 0x0100,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x322D,
+                extension: Some(0x0100),
+                extension2: None,
+                pc: 0x0112,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Word,
+                    src: JitEa::Disp(5, 0x0100),
+                    dst: JitEa::Data(1),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x526D,
+                extension: Some(0x0100),
+                extension2: None,
+                pc: 0x0116,
+                op: JitTraceOp::AnDispAddqSubq {
+                    data: 1,
+                    size: Size::Word,
+                    reg: 5,
+                    displacement: 0x0100,
+                    is_sub: false,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x2F2D,
+                extension: Some(0x0100),
+                extension2: None,
+                pc: 0x011A,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Long,
+                    src: JitEa::Disp(5, 0x0100),
+                    dst: JitEa::PreDec(7),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x588F,
+                extension: None,
+                extension2: None,
+                pc: 0x011E,
+                op: JitTraceOp::AddqSubqAddr {
+                    reg: 7,
+                    data: 4,
+                    is_sub: false,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x60DE,
+                extension: None,
+                extension2: None,
+                pc: 0x0120,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -34,
+                    length: 2,
+                },
+            },
+        ];
+        // The portable memory helpers read the live extension words just as
+        // the native trace validates them before executing.
+        for op in ops {
+            let at = op.pc as usize;
+            mem[at..at + 2].copy_from_slice(&op.opcode.to_be_bytes());
+            if let Some(extension) = op.extension {
+                mem[at + 2..at + 4].copy_from_slice(&extension.to_be_bytes());
+            }
+            if let Some(extension) = op.extension2 {
+                mem[at + 4..at + 6].copy_from_slice(&extension.to_be_bytes());
+            }
+        }
+
+        let packed = execute_portable_trace(&mut cpu, &ops, 0x0100, 0x0122);
+
+        assert_eq!((packed >> 32) as usize, ops.len());
+        assert_eq!(cpu.pc, 0x0100);
+        assert_eq!(cpu.d(1) & 0xFFFF, 0);
+        assert_eq!(&mem[0x1100..0x1102], &1u16.to_be_bytes());
+        assert_eq!(&mem[0x7FFC..0x8000], &0x0001_0000u32.to_be_bytes());
+        assert_eq!(cpu.a(7), 0x8000);
+    }
+
+    #[test]
     fn portable_trace_executes_unconditional_loop_iteration() {
         let mut cpu = cpu();
         let ops = [
             TraceBuildOp {
                 opcode: 0x5280,
                 extension: None,
+                extension2: None,
                 pc: 0x0100,
                 op: JitTraceOp::AddqSubqReg {
                     reg: 0,
@@ -2867,6 +3490,7 @@ mod portable_tests {
             TraceBuildOp {
                 opcode: 0x60FC,
                 extension: None,
+                extension2: None,
                 pc: 0x0102,
                 op: JitTraceOp::Branch {
                     condition: 0,
@@ -2895,6 +3519,7 @@ mod portable_tests {
             TraceBuildOp {
                 opcode: 0x5340,
                 extension: None,
+                extension2: None,
                 pc: 0x0100,
                 op: JitTraceOp::AddqSubqReg {
                     reg: 0,
@@ -2906,6 +3531,7 @@ mod portable_tests {
             TraceBuildOp {
                 opcode: 0x66FC,
                 extension: None,
+                extension2: None,
                 pc: 0x0102,
                 op: JitTraceOp::Branch {
                     condition: 6,
@@ -2934,6 +3560,7 @@ mod portable_tests {
         let ops = [TraceBuildOp {
             opcode: 0xE188,
             extension: None,
+            extension2: None,
             pc: 0x0100,
             op: JitTraceOp::ShiftReg {
                 reg: 0,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -31,8 +31,8 @@ use std::mem::{offset_of, size_of, transmute};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 const TRACE_CACHE_SIZE: usize = 4096;
-pub(crate) const TRACE_MAX_OPS: usize = 16;
-const TRACE_MIN_OPS: usize = 3;
+pub(crate) const TRACE_MAX_OPS: usize = 128;
+pub(crate) const TRACE_MIN_OPS: usize = 3;
 const TRACE_HOT_THRESHOLD: u8 = 2;
 
 /// Sentinel for `CpuCore::trace_record_skip` / `trace_probe_skip`: no PC.
@@ -214,6 +214,10 @@ pub(crate) enum JitTraceOp {
         condition: u8,
         displacement: i32,
         length: u8,
+        /// Recorded direction for an interior conditional branch. `None`
+        /// means this branch ends the trace; `Some` emits a guarded side
+        /// exit and continues along the recorded path on a match.
+        expected_taken: Option<bool>,
     },
     Dbcc {
         condition: u8,
@@ -274,9 +278,10 @@ struct CompiledTrace {
     cpu_type: CpuType,
     ops: Vec<TraceBuildOp>,
     /// The exact instruction bytes the trace was compiled from (ops are
-    /// contiguous from `pc`). Lets validation be a single compare against
-    /// a fastmem window instead of per-op bus reads.
+    /// in execution order. Contiguous traces can validate this with one
+    /// compare; recorded multi-block paths validate each instruction.
     code: Vec<u8>,
+    contiguous_code: bool,
     max_cycles: i32,
     /// The final branch's taken-target is the trace head, so the trace is
     /// a whole loop iteration and can be re-run (budget permitting)
@@ -297,6 +302,12 @@ struct CompiledTrace {
     code_end: u32,
     #[cfg(not(target_family = "wasm"))]
     func: TraceFn,
+}
+
+struct TraceRecording {
+    start_pc: u32,
+    cpu_type: CpuType,
+    ops: Vec<TraceBuildOp>,
 }
 
 enum TraceSlot {
@@ -321,6 +332,7 @@ pub(crate) struct TraceJit {
     #[cfg(not(target_family = "wasm"))]
     next_func: u32,
     slots: Vec<TraceSlot>,
+    recording: Option<TraceRecording>,
 }
 
 impl fmt::Debug for TraceJit {
@@ -353,6 +365,7 @@ impl TraceJit {
             #[cfg(not(target_family = "wasm"))]
             next_func: 0,
             slots: (0..TRACE_CACHE_SIZE).map(|_| TraceSlot::Empty).collect(),
+            recording: None,
         }
     }
 
@@ -374,11 +387,18 @@ impl TraceJit {
         cpu_type: CpuType,
         instr_budget: u32,
         single_iter: bool,
+        watch_pcs: &[u32],
     ) -> Option<(CachedRunResult, u32)> {
         #[cfg(not(target_family = "wasm"))]
         self.module.as_ref()?;
 
         if cpu.has_pmmu && cpu.pmmu_enabled || cpu.cycles_remaining <= 0 {
+            return None;
+        }
+        if cpu.trace_recording || self.recording.is_some() {
+            // A recorder is already following an executed path on this
+            // thread. Nested backward edges and interleaved CPU instances
+            // stay in the interpreter until that path closes.
             return None;
         }
 
@@ -389,6 +409,20 @@ impl TraceJit {
             && trace.pc == pc
             && trace.cpu_type == cpu_type
         {
+            // run_batch observes watched PCs between guest instructions.
+            // If a recorded region reaches one internally, leave it to the
+            // interpreter so the watch fires before that instruction. The
+            // entry PC is intentionally excluded: run_batch does not check
+            // watches on entry, and self-loop entry watches are handled by
+            // `single_iter` after one complete iteration.
+            if watch_pcs.iter().any(|&watched| {
+                let masked = cpu.address(watched);
+                masked >= trace.code_start
+                    && masked < trace.code_end
+                    && trace.ops.iter().skip(1).any(|op| op.pc == watched)
+            }) {
+                return None;
+            }
             if trace.needs_window && cpu.fm_len == 0 {
                 // Memory traces only run against a fastmem window (i.e.
                 // inside run_batch). Stop this cycle-budgeted caller from
@@ -406,7 +440,7 @@ impl TraceJit {
             // replaces per-op bus reads. (SMC through the window is still
             // caught: we compare the actual RAM.)
             let mut validated = false;
-            if cpu.fm_len != 0 {
+            if trace.contiguous_code && cpu.fm_len != 0 {
                 let n = trace.code.len() as u32;
                 let off = cpu.address(pc).wrapping_sub(cpu.fm_base);
                 if n <= cpu.fm_len && off <= cpu.fm_len - n {
@@ -481,6 +515,9 @@ impl TraceJit {
             }
 
             let ops_len = trace.ops.len() as u32;
+            if instr_budget < ops_len {
+                return None;
+            }
             // How many whole iterations fit in both budgets. The guards
             // above ensure at least one; the instruction budget is the
             // caller's (u32::MAX on the cycle-budgeted paths).
@@ -505,9 +542,9 @@ impl TraceJit {
                 let ops_done = (packed >> 32) as u32;
                 retired += ops_done;
                 if ops_done < ops_len {
-                    // A mem op bailed mid-trace (window/alignment miss or a
-                    // store into code). PC points at the un-executed op;
-                    // the interpreter takes over from there.
+                    // A memory check bailed before its op, or a guarded
+                    // interior branch took a different path. PC identifies
+                    // the correct interpreter/next-trace continuation.
                     break;
                 }
                 full_iters += 1;
@@ -540,6 +577,13 @@ impl TraceJit {
                 if *hits < TRACE_HOT_THRESHOLD {
                     return None;
                 }
+                self.recording = Some(TraceRecording {
+                    start_pc: pc,
+                    cpu_type,
+                    ops: Vec::with_capacity(TRACE_MAX_OPS),
+                });
+                cpu.trace_recording = true;
+                None
             }
             TraceSlot::Rejected {
                 pc: rejected_pc,
@@ -548,21 +592,10 @@ impl TraceJit {
                 // Known-uncompilable target: tell the loop to stop probing
                 // it (note_backward_branch consults this filter).
                 push_probe_skip(cpu, pc);
-                return None;
+                None
             }
-            _ => {
-                return None;
-            }
+            _ => None,
         }
-
-        let Some(trace) = self.compile_trace(cpu, bus, pc, cpu_type) else {
-            self.slots[idx] = TraceSlot::Rejected { pc, cpu_type };
-            push_probe_skip(cpu, pc);
-            return None;
-        };
-
-        self.slots[idx] = TraceSlot::Compiled(trace);
-        None
     }
 
     fn record_trace_target(&mut self, pc: u32, cpu_type: CpuType) {
@@ -598,32 +631,125 @@ impl TraceJit {
         }
     }
 
-    fn compile_trace<B: AddressBus>(
-        &mut self,
-        cpu: &CpuCore,
-        bus: &mut B,
-        start_pc: u32,
-        cpu_type: CpuType,
-    ) -> Option<CompiledTrace> {
-        let mut pc = start_pc;
-        let mut ops = Vec::with_capacity(TRACE_MAX_OPS);
-        let mut max_cycles = 0i32;
+    fn reject_recording(&mut self, cpu: &mut CpuCore) {
+        if let Some(recording) = self.recording.take() {
+            let idx = trace_cache_index(recording.start_pc);
+            self.slots[idx] = TraceSlot::Rejected {
+                pc: recording.start_pc,
+                cpu_type: recording.cpu_type,
+            };
+            push_probe_skip(cpu, recording.start_pc);
+        }
+        cpu.trace_recording = false;
+    }
 
-        for _ in 0..TRACE_MAX_OPS {
-            let op = decode_trace_op(cpu, bus, pc, cpu_type)?;
-            max_cycles += op.op.max_cycles();
-            ops.push(op);
+    fn finish_recording(&mut self, cpu: &mut CpuCore, exit_pc: u32) {
+        let Some(mut recording) = self.recording.take() else {
+            cpu.trace_recording = false;
+            return;
+        };
+        cpu.trace_recording = false;
 
-            let jit_op = op.op;
-            pc = pc.wrapping_add(op.length() as u32);
-            if jit_op.ends_trace() {
-                break;
-            }
+        // An interior recorded branch becomes the region's ordinary final
+        // branch when recording stops at its destination.
+        if let Some(last) = recording.ops.last_mut()
+            && let JitTraceOp::Branch { expected_taken, .. } = &mut last.op
+        {
+            *expected_taken = None;
         }
 
+        let idx = trace_cache_index(recording.start_pc);
+        let start_pc = recording.start_pc;
+        let cpu_type = recording.cpu_type;
+        self.slots[idx] =
+            match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
+                Some(trace) => TraceSlot::Compiled(trace),
+                None => {
+                    push_probe_skip(cpu, start_pc);
+                    TraceSlot::Rejected {
+                        pc: start_pc,
+                        cpu_type,
+                    }
+                }
+            };
+    }
+
+    fn record_executed<B: AddressBus>(
+        &mut self,
+        cpu: &mut CpuCore,
+        bus: &mut B,
+        executed_pc: u32,
+        next_pc: u32,
+    ) {
+        let Some(recording) = self.recording.as_ref() else {
+            cpu.trace_recording = false;
+            return;
+        };
+        let start_pc = recording.start_pc;
+        let cpu_type = recording.cpu_type;
+        if cpu_type != cpu.cpu_type {
+            self.reject_recording(cpu);
+            return;
+        }
+
+        let Some(mut op) = decode_trace_op(cpu, bus, executed_pc, cpu_type) else {
+            self.finish_recording(cpu, executed_pc);
+            return;
+        };
+        let op_len = op.length();
+        let taken_target = op.op.taken_target(op.pc);
+
+        match &mut op.op {
+            JitTraceOp::Branch { expected_taken, .. } => {
+                if next_pc != start_pc {
+                    let taken = taken_target == Some(next_pc);
+                    *expected_taken = Some(taken);
+                }
+            }
+            // DBcc remains a natural region boundary for now. Its data-
+            // dependent counter update is already compiled efficiently.
+            JitTraceOp::Dbcc { .. } => {
+                self.recording.as_mut().unwrap().ops.push(op);
+                self.finish_recording(cpu, next_pc);
+                return;
+            }
+            _ if next_pc != executed_pc.wrapping_add(op_len as u32) => {
+                self.finish_recording(cpu, executed_pc);
+                return;
+            }
+            _ => {}
+        }
+
+        let recording = self.recording.as_mut().unwrap();
+        recording.ops.push(op);
+        if next_pc == start_pc {
+            self.finish_recording(cpu, next_pc);
+            return;
+        }
+
+        let repeated = recording.ops.iter().any(|op| op.pc == next_pc);
+        if recording.ops.len() >= TRACE_MAX_OPS || repeated {
+            self.finish_recording(cpu, next_pc);
+        }
+    }
+
+    fn compile_decoded_ops(
+        &mut self,
+        cpu: &CpuCore,
+        start_pc: u32,
+        cpu_type: CpuType,
+        ops: Vec<TraceBuildOp>,
+        recorded_exit_pc: Option<u32>,
+    ) -> Option<CompiledTrace> {
         if ops.len() < TRACE_MIN_OPS || !ops.last().is_some_and(|op| op.op.ends_trace()) {
             return None;
         }
+
+        let max_cycles = ops.iter().map(|op| op.op.max_cycles()).sum();
+        let contiguous_code = ops.first().is_some_and(|op| op.pc == start_pc)
+            && ops
+                .windows(2)
+                .all(|pair| pair[0].pc.wrapping_add(pair[0].length() as u32) == pair[1].pc);
 
         let mut code = Vec::with_capacity(ops.len() * 4);
         for op in &ops {
@@ -635,11 +761,20 @@ impl TraceJit {
                 code.extend_from_slice(&extension.to_be_bytes());
             }
         }
-        debug_assert_eq!(code.len() as u32, pc.wrapping_sub(start_pc));
+        if contiguous_code {
+            debug_assert_eq!(
+                code.len() as u32,
+                ops.last()
+                    .map(|op| op.pc.wrapping_add(op.length() as u32))
+                    .unwrap_or(start_pc)
+                    .wrapping_sub(start_pc)
+            );
+        }
 
-        let self_loop = ops
-            .last()
-            .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
+        let self_loop = recorded_exit_pc == Some(start_pc)
+            || ops
+                .last()
+                .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
 
         let needs_window = ops.iter().any(|op| {
             matches!(
@@ -654,18 +789,24 @@ impl TraceJit {
         // Address-masked code range, used by the store-overlap (SMC) bail
         // checks. Reject the exotic case of a trace wrapping the address
         // space so the range stays a simple interval.
-        let code_start = start_pc & cpu.address_mask;
-        let code_end = code_start as u64 + code.len() as u64;
-        if code_end > cpu.address_mask as u64 + 1 {
-            return None;
+        let mut code_start = u32::MAX;
+        let mut code_end = 0u32;
+        for op in &ops {
+            let start = cpu.address(op.pc);
+            let end = start as u64 + op.length() as u64;
+            if end > cpu.address_mask as u64 + 1 || end > u32::MAX as u64 {
+                return None;
+            }
+            code_start = code_start.min(start);
+            code_end = code_end.max(end as u32);
         }
-        let code_end = code_end as u32;
 
         self.compile_ops(CompileParams {
             start_pc,
             cpu_type,
             ops: &ops,
             code,
+            contiguous_code,
             max_cycles,
             self_loop,
             needs_window,
@@ -683,6 +824,7 @@ impl TraceJit {
             cpu_type,
             ops,
             code,
+            contiguous_code,
             max_cycles,
             self_loop,
             needs_window,
@@ -737,14 +879,29 @@ impl TraceJit {
             };
 
             let mut bails: Vec<BailReq> = Vec::new();
-            let mut cycles_before: i64 = 0;
             let mut cycles_value = builder.ins().iconst(types::I32, 0);
             for (index, op) in ops.iter().enumerate() {
                 let bail_at = BailAt {
                     ops_before: index as u32,
-                    cycles_before,
+                    cycles_before: cycles_value,
                 };
                 let op_cycles = match op.op {
+                    JitTraceOp::Branch {
+                        condition,
+                        displacement,
+                        length,
+                        expected_taken: Some(expected_taken),
+                    } => emit_guarded_branch(
+                        &mut builder,
+                        cpu_ptr,
+                        op.pc,
+                        condition,
+                        displacement,
+                        length,
+                        expected_taken,
+                        cycles_value,
+                        (index + 1) as u32,
+                    ),
                     JitTraceOp::MoveMem { size, src, dst } => {
                         let env = mem_env.as_ref().expect("MoveMem implies a window env");
                         emit_move_mem(
@@ -770,10 +927,6 @@ impl TraceJit {
                     _ => emit_jit_op(&mut builder, cpu_ptr, *op, aligned_only),
                 };
                 cycles_value = builder.ins().iadd(cycles_value, op_cycles);
-                // Exact for every op that can precede a bail (MoveMem and
-                // register ops have constant cycles; only the closing
-                // branch is dynamic, and nothing bails after it).
-                cycles_before += op.op.max_cycles() as i64;
             }
 
             if let Some(last) = ops.last() {
@@ -797,10 +950,11 @@ impl TraceJit {
             for bail in bails {
                 builder.switch_to_block(bail.block);
                 store_u32(&mut builder, cpu_ptr, offset_of!(CpuCore, pc), bail.pc);
-                let packed = builder.ins().iconst(
-                    types::I64,
-                    ((bail.at.ops_before as i64) << 32) | bail.at.cycles_before,
-                );
+                let cycles64 = builder.ins().uextend(types::I64, bail.at.cycles_before);
+                let retired = builder
+                    .ins()
+                    .iconst(types::I64, (bail.at.ops_before as i64) << 32);
+                let packed = builder.ins().bor(cycles64, retired);
                 builder.ins().return_(&[packed]);
             }
 
@@ -819,6 +973,7 @@ impl TraceJit {
             cpu_type,
             ops: ops.to_vec(),
             code,
+            contiguous_code,
             max_cycles,
             self_loop,
             needs_window,
@@ -835,6 +990,7 @@ impl TraceJit {
             cpu_type: params.cpu_type,
             ops: params.ops.to_vec(),
             code: params.code,
+            contiguous_code: params.contiguous_code,
             max_cycles: params.max_cycles,
             self_loop: params.self_loop,
             needs_window: params.needs_window,
@@ -850,6 +1006,7 @@ struct CompileParams<'a> {
     cpu_type: CpuType,
     ops: &'a [TraceBuildOp],
     code: Vec<u8>,
+    contiguous_code: bool,
     max_cycles: i32,
     self_loop: bool,
     needs_window: bool,
@@ -870,16 +1027,42 @@ pub(crate) fn try_execute_trace<B: AddressBus>(
     cpu_type: CpuType,
     instr_budget: u32,
     single_iter: bool,
+    watch_pcs: &[u32],
 ) -> Option<(CachedRunResult, u32)> {
     if cpu.run_mode == RUN_MODE_BERR_AERR_RESET {
         return None;
     }
 
-    TRACE_JIT.with_borrow_mut(|jit| jit.try_execute(cpu, bus, cpu_type, instr_budget, single_iter))
+    TRACE_JIT.with_borrow_mut(|jit| {
+        jit.try_execute(cpu, bus, cpu_type, instr_budget, single_iter, watch_pcs)
+    })
 }
 
 pub(crate) fn record_trace_target(pc: u32, cpu_type: CpuType) {
     TRACE_JIT.with_borrow_mut(|jit| jit.record_trace_target(pc, cpu_type));
+}
+
+/// Append one instruction that the interpreter just executed while a hot
+/// multi-block path is being recorded. The normal path checks the CPU flag
+/// first, so no TLS access occurs when recording is inactive.
+pub(crate) fn record_executed<B: AddressBus>(
+    cpu: &mut CpuCore,
+    bus: &mut B,
+    executed_pc: u32,
+    next_pc: u32,
+) {
+    if cpu.trace_recording {
+        TRACE_JIT.with_borrow_mut(|jit| jit.record_executed(cpu, bus, executed_pc, next_pc));
+    }
+}
+
+/// End an in-progress recording before control leaves the fast decoded-op
+/// path. A usable prefix ending in a branch is compiled; otherwise the
+/// target is marked rejected.
+pub(crate) fn stop_recording(cpu: &mut CpuCore) {
+    if cpu.trace_recording {
+        TRACE_JIT.with_borrow_mut(|jit| jit.finish_recording(cpu, cpu.pc));
+    }
 }
 
 /// Note that execution just took a backward branch to `cpu.pc` (a potential
@@ -961,7 +1144,11 @@ impl JitTraceOp {
                     6 + 2 * count as i32
                 }
             }
-            Self::Branch { .. } => 10,
+            Self::Branch { length, .. } => {
+                // Taken branches cost 10 cycles; a not-taken word branch
+                // costs 12. This is a headroom bound, so use the slower arm.
+                if length == 4 { 12 } else { 10 }
+            }
             Self::Dbcc { .. } => 14,
             Self::MoveMem { size, src, dst } => {
                 // 4 + source-EA fetch + destination-EA store (M68000UM).
@@ -1113,6 +1300,7 @@ fn decode_branch_word_trace_op<B: AddressBus>(
             condition,
             displacement: extension as i16 as i32,
             length: 4,
+            expected_taken: None,
         },
     })
 }
@@ -1306,7 +1494,21 @@ fn execute_portable_trace(
     let mut cycles: i32 = 0;
     for (index, op) in ops.iter().enumerate() {
         match execute_portable_op(cpu, *op, code_start, code_end) {
-            Some(c) => cycles += c,
+            Some(c) => {
+                cycles += c;
+                if let JitTraceOp::Branch {
+                    expected_taken: Some(expected),
+                    ..
+                } = op.op
+                {
+                    let taken = op.op.taken_target(op.pc) == Some(cpu.pc);
+                    if taken != expected {
+                        cpu.ppc = op.pc;
+                        cpu.ir = op.opcode as u32;
+                        return (((index + 1) as u64) << 32) | cycles as u32 as u64;
+                    }
+                }
+            }
             None => {
                 cpu.pc = op.pc;
                 return ((index as u64) << 32) | cycles as u32 as u64;
@@ -1847,6 +2049,7 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
             condition,
             displacement,
             length,
+            ..
         } => {
             if condition == 0 || cpu.test_condition(condition) {
                 cpu.change_of_flow = true;
@@ -2218,6 +2421,7 @@ fn emit_jit_op(
             condition,
             displacement,
             length,
+            ..
         } => emit_branch(builder, cpu, trace_pc, condition, displacement, length),
         JitTraceOp::Dbcc {
             condition,
@@ -2244,7 +2448,7 @@ struct MemEnv {
 #[derive(Clone, Copy)]
 struct BailAt {
     ops_before: u32,
-    cycles_before: i64,
+    cycles_before: Value,
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -3058,6 +3262,59 @@ fn emit_branch(
 }
 
 #[cfg(not(target_family = "wasm"))]
+#[allow(clippy::too_many_arguments)]
+fn emit_guarded_branch(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace_pc: u32,
+    condition: u8,
+    displacement: i32,
+    length: u8,
+    expected_taken: bool,
+    cycles_before: Value,
+    ops_done: u32,
+) -> Value {
+    let target_pc = (trace_pc.wrapping_add(2) as i32).wrapping_add(displacement) as u32;
+    let taken = if condition == 0 {
+        bool_const(builder, true)
+    } else {
+        emit_condition(builder, cpu, condition)
+    };
+    let target = iconst_u32(builder, target_pc);
+    let next = iconst_u32(builder, trace_pc.wrapping_add(length as u32));
+    let pc = builder.ins().select(taken, target, next);
+    store_pc_value(builder, cpu, pc);
+
+    let old_change = load_u8(builder, cpu, offset_of!(CpuCore, change_of_flow));
+    let true_change = builder.ins().iconst(types::I8, 1);
+    let change = builder.ins().select(taken, true_change, old_change);
+    store_value(builder, cpu, offset_of!(CpuCore, change_of_flow), change);
+
+    let taken_cycles = cycles_const(builder, 10);
+    let not_taken_cycles = cycles_const(builder, if length == 4 { 12 } else { 8 });
+    let op_cycles = builder.ins().select(taken, taken_cycles, not_taken_cycles);
+
+    let expected = bool_const(builder, expected_taken);
+    let matches = builder.ins().icmp(IntCC::Equal, taken, expected);
+    let continue_block = builder.create_block();
+    let side_exit = builder.create_block();
+    builder
+        .ins()
+        .brif(matches, continue_block, &[], side_exit, &[]);
+
+    builder.switch_to_block(side_exit);
+    store_u32(builder, cpu, offset_of!(CpuCore, ppc), trace_pc);
+    let total_cycles = builder.ins().iadd(cycles_before, op_cycles);
+    let cycles64 = builder.ins().uextend(types::I64, total_cycles);
+    let retired = builder.ins().iconst(types::I64, (ops_done as i64) << 32);
+    let packed = builder.ins().bor(cycles64, retired);
+    builder.ins().return_(&[packed]);
+
+    builder.switch_to_block(continue_block);
+    op_cycles
+}
+
+#[cfg(not(target_family = "wasm"))]
 fn emit_dbcc(
     builder: &mut FunctionBuilder<'_>,
     cpu: Value,
@@ -3445,6 +3702,7 @@ mod portable_tests {
                     condition: 0,
                     displacement: -34,
                     length: 2,
+                    expected_taken: None,
                 },
             },
         ];
@@ -3496,6 +3754,7 @@ mod portable_tests {
                     condition: 0,
                     displacement: -4,
                     length: 2,
+                    expected_taken: None,
                 },
             },
         ];
@@ -3537,6 +3796,7 @@ mod portable_tests {
                     condition: 6,
                     displacement: -4,
                     length: 2,
+                    expected_taken: None,
                 },
             },
         ];
@@ -3548,6 +3808,60 @@ mod portable_tests {
         assert_eq!(cycles, 12);
         assert_eq!(cpu.d(0), 0);
         assert!(cpu.flag_z());
+        assert_eq!(cpu.pc, 0x0104);
+        assert_eq!(cpu.ppc, 0x0102);
+        assert_eq!(cpu.ir, 0x66FC);
+    }
+
+    #[test]
+    fn portable_trace_guard_mismatch_exits_before_later_ops() {
+        let mut cpu = cpu();
+        cpu.set_d(0, 1);
+        let ops = [
+            TraceBuildOp {
+                opcode: 0x5340,
+                extension: None,
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 0,
+                    data: 1,
+                    size: Size::Word,
+                    is_sub: true,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x66FC,
+                extension: None,
+                extension2: None,
+                pc: 0x0102,
+                op: JitTraceOp::Branch {
+                    condition: 6,
+                    displacement: -4,
+                    length: 2,
+                    expected_taken: Some(true),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x5281,
+                extension: None,
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 1,
+                    data: 1,
+                    size: Size::Long,
+                    is_sub: false,
+                },
+            },
+        ];
+
+        let packed = execute_portable_trace(&mut cpu, &ops, 0x0100, 0x0106);
+
+        assert_eq!((packed >> 32) as u32, 2);
+        assert_eq!(packed as u32 as i32, 12);
+        assert_eq!(cpu.d(0), 0);
+        assert_eq!(cpu.d(1), 0);
         assert_eq!(cpu.pc, 0x0104);
         assert_eq!(cpu.ppc, 0x0102);
         assert_eq!(cpu.ir, 0x66FC);

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -77,6 +77,91 @@ fn unrelated_watch_keeps_jit_loop_budget_exact() {
 }
 
 #[test]
+fn multi_block_trace_follows_recorded_taken_branch() {
+    // loop: ADDQ D0; BNE skip; NOP; skip: ADDQ D1; BRA loop
+    // BNE is an interior branch. A region trace follows its observed taken
+    // edge, skips the NOP, and closes only at the final backward BRA.
+    let mut bus = bus_with(&[
+        (0x1000, 0x5280),
+        (0x1002, 0x6602),
+        (0x1004, 0x4E71),
+        (0x1006, 0x5281),
+        (0x1008, 0x60F6),
+    ]);
+    let mut cpu = cpu_at(0x1000);
+
+    let result = cpu.run_batch(&mut bus, 1_000_000, &[0]);
+
+    assert_eq!(result.exit, BatchExit::BudgetExhausted);
+    assert_eq!(result.instructions, 1_000_000);
+    assert_eq!(cpu.d(0), 250_000);
+    assert_eq!(cpu.d(1), 250_000);
+    assert_eq!(cpu.pc, 0x1000);
+}
+
+#[test]
+fn multi_block_trace_yields_before_interior_watched_pc() {
+    let mut bus = bus_with(&[
+        (0x1000, 0x5280), // ADDQ.L #1,D0
+        (0x1002, 0x6602), // BNE.S 0x1006
+        (0x1004, 0x4E71), // uncommon fallthrough
+        (0x1006, 0x5281), // ADDQ.L #1,D1
+        (0x1008, 0x60F6), // BRA.S 0x1000
+    ]);
+    let mut cpu = cpu_at(0x1000);
+
+    // Compile and exercise the region before enabling the watch.
+    let warmup = cpu.run_batch(&mut bus, 100, &[]);
+    assert_eq!(warmup.exit, BatchExit::BudgetExhausted);
+    assert_eq!(cpu.pc, 0x1000);
+    let d0_before = cpu.d(0);
+    let d1_before = cpu.d(1);
+
+    let result = cpu.run_batch(&mut bus, 100, &[0x1006]);
+
+    assert_eq!(result.exit, BatchExit::WatchedPc { pc: 0x1006 });
+    assert_eq!(result.instructions, 2);
+    assert_eq!(cpu.pc, 0x1006);
+    assert_eq!(cpu.d(0), d0_before + 1);
+    assert_eq!(cpu.d(1), d1_before);
+}
+
+#[test]
+fn multi_block_trace_guard_side_exit_matches_step() {
+    // The recorded BNE path is initially taken, but D0 reaches zero and
+    // forces one not-taken side exit through the NOP before paths rejoin.
+    let words = [
+        (0x1000, 0x5340), // SUBQ.W #1,D0
+        (0x1002, 0x6602), // BNE.S 0x1006
+        (0x1004, 0x4E71), // uncommon fallthrough
+        (0x1006, 0x5281), // ADDQ.L #1,D1
+        (0x1008, 0x60F6), // BRA.S 0x1000
+    ];
+    let mut batch_bus = bus_with(&words);
+    let mut batch_cpu = cpu_at(0x1000);
+    batch_cpu.set_d(0, 6);
+    let result = batch_cpu.run_batch(&mut batch_bus, 100_000, &[0]);
+    assert_eq!(result.instructions, 100_000);
+
+    let mut step_bus = bus_with(&words);
+    let mut step_cpu = cpu_at(0x1000);
+    step_cpu.set_d(0, 6);
+    for _ in 0..100_000 {
+        assert!(matches!(
+            step_cpu.step(&mut step_bus),
+            m68k::StepResult::Ok { .. }
+        ));
+    }
+
+    assert_eq!(batch_cpu.pc, step_cpu.pc);
+    assert_eq!(batch_cpu.get_sr(), step_cpu.get_sr());
+    for reg in 0..8 {
+        assert_eq!(batch_cpu.d(reg), step_cpu.d(reg), "D{reg}");
+        assert_eq!(batch_cpu.a(reg), step_cpu.a(reg), "A{reg}");
+    }
+}
+
+#[test]
 fn aline_trap_exits_without_counting_the_trap() {
     // NOP ; NOP ; A-line ; NOP
     let mut bus = bus_with(&[

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -61,6 +61,22 @@ fn budget_exhausted_count_is_exact_with_jit_traces() {
 }
 
 #[test]
+fn unrelated_watch_keeps_jit_loop_budget_exact() {
+    // Systemless always watches PC 0 for a clean exit. A trace whose loop
+    // head is elsewhere may run multiple iterations per native call, but
+    // must still stop at the exact requested instruction budget.
+    let mut bus = bus_with(&[(0x1000, 0x5280), (0x1002, 0x60FC)]);
+    let mut cpu = cpu_at(0x1000);
+
+    let result = cpu.run_batch(&mut bus, 1_000_001, &[0]);
+
+    assert_eq!(result.exit, BatchExit::BudgetExhausted);
+    assert_eq!(result.instructions, 1_000_001);
+    assert_eq!(cpu.d(0), 500_001);
+    assert_eq!(cpu.pc, 0x1002);
+}
+
+#[test]
 fn aline_trap_exits_without_counting_the_trap() {
     // NOP ; NOP ; A-line ; NOP
     let mut bus = bus_with(&[


### PR DESCRIPTION
## Stack

Depends on #16, which depends on #15, #14, and #13.

This branch starts at the head of #16. Until the lower PRs merge, GitHub will show their prerequisite commits in this PR. As each lower PR merges, this branch will be rebased so the final incremental diff contains only 128a6a2.

## Summary

- require generic effective-address resolution to inline into the decoded memory dispatcher
- require its small load and store helpers to inline at the same call sites
- add a permanent generic-memory benchmark covering indirect, postincrement, indexed, and memory-to-register operations
- preserve all fallback checks and 68k-visible behavior

## Motivation

After the specialized A5-relative paths and multi-block JIT improvements, profiles still showed separate `resolve`, `load`, and `store` symbols below `run_steps_internal`. These helpers sit inside the decoded generic memory-operation dispatcher. Calling them out of line repeatedly adds host call boundaries around work that is mostly a small addressing-mode or location match.

The annotations let the compiler specialize those matches at each operation arm. No guest state transition, addressing rule, alignment check, memory-window check, instruction count, or cycle count changes.

## Permanent benchmark

Run with:

```console
cargo bench --bench microbench -- generic-memory
```

The benchmark lays out repeated memory instructions in straight-line code. It intentionally has no backward branch, so a native JIT loop cannot hide the cost being measured. It warms and retains the decoded-op cache, resets the PC and affected address register between passes, and covers:

- `TST.B (A0)`
- `TST.B (A0)+`
- `TST.B (d8,A0,D0.W)`
- `ADD.W (A0),D0`

## Performance

Intel MacBookPro16,1, native x86-64 macOS optimized builds.

### Generic-memory benchmark

Five-run medians comparing #16 (`af33e5b`) with this change:

| Workload | af33e5b | 128a6a2 | Change |
| --- | ---: | ---: | ---: |
| `TST.B (A0)` | 30.9 MIPS | 41.1 MIPS | +33.0% |
| `TST.B (A0)+` | 28.4 MIPS | 38.8 MIPS | +36.6% |
| Indexed `TST.B` | 27.3 MIPS | 35.7 MIPS | +30.8% |
| `ADD.W (A0),D0` | 26.1 MIPS | 36.7 MIPS | +40.6% |

The existing Classic Mac A5 benchmark remains on its specialized path and measured 386.3 MIPS after the change. Existing register, branch, and bus rows remained in their normal range.

### Systemless and Lemmings

Matched 30-second `/usr/bin/sample` captures used Lemmings 1.5.2 level one after a five-second warm-up. Results are normalized by total main-thread samples.

| Revision | `run_steps_internal` samples | Main-thread samples | Normalized share |
| --- | ---: | ---: | ---: |
| #15 head, 7fa51ad | 561 | 24,592 | 2.281% |
| #16 head, af33e5b | 512 | 25,041 | 2.044% |
| This change | 376 | 24,088 | 1.561% |

Relative to #16, normalized emulator time fell by 23.6%. Relative to the #15 head, it fell by 31.6%.

Reproducibility hashes for the complete Systemless release binaries:

- #16 baseline: `47752c8119028b6d2a9bd105e6c4e76b8123d8694a6f72aa85919a402604eeca`
- candidate: `3b32d0326572c7cbe31892f212d5a109c67376a674be736ee5f023abad3207c6`

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --all-targets -- -D warnings`
- complete `cargo test`, including 127 SingleStep categories and 78 Musashi tests
- repeated optimized `generic-memory` benchmark runs
- Systemless release build and interactive Lemmings level-one profiling
