### PR TITLE
perf: JIT hot memory-source CMP loops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ exclude = [
 
 [dependencies]
 
+[features]
+default = []
+# Opt-in trace-opportunity accounting for emulator profiling. Disabled builds
+# contain none of the counters or reporting code.
+trace-profile = []
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 cranelift-codegen = "0.132.0"
 cranelift-frontend = "0.132.0"

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -152,6 +152,14 @@ fn bench_batch_loop(label: &str, name: &str, words: &[u16], instrs: u32) {
 }
 
 fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code_base: usize) {
+    let elapsed = measure_batch_loop_at(words, instrs, code_base);
+    println!(
+        "{label:9} {name:18} {:8.1} M instr/s",
+        instrs as f64 / elapsed / 1_000_000.0
+    );
+}
+
+fn measure_batch_loop_at(words: &[u16], instrs: u32, code_base: usize) -> f64 {
     let mut bus = LinearMemoryBus::new(0x10000);
     for (i, word) in words.iter().enumerate() {
         bus.write_word_at((code_base + i * 2) as u32, *word);
@@ -162,8 +170,11 @@ fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code
         cpu.set_cpu_type(CpuType::M68040);
         cpu.set_sr(0x2700);
         cpu.pc = code_base as u32;
+        cpu.set_a(0, 0x4000);
         cpu.set_a(5, 0x1000);
+        cpu.set_a(6, 0x5000);
         cpu.set_a(7, 0x8000);
+        cpu.set_d(7, 1);
         cpu
     };
 
@@ -179,10 +190,7 @@ fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code
     let result = cpu.run_batch(&mut bus, instrs, &[0]);
     let elapsed = start.elapsed().as_secs_f64();
     assert_eq!(result.instructions, instrs);
-    println!(
-        "{label:9} {name:18} {:8.1} M instr/s",
-        instrs as f64 / elapsed / 1_000_000.0
-    );
+    elapsed
 }
 
 fn bench_one_shot_trace(head_ops: usize, instrs: u32) {
@@ -233,6 +241,149 @@ fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
         &words,
         instrs,
         0x800 + head_ops * 0x40,
+    );
+}
+
+/// Exercise the complete application-style trace round trip: validate and
+/// enter one non-self-looping native trace, return to the decoded Rust loop,
+/// execute a short tail, and take a backward branch to probe the trace again.
+fn bench_trace_roundtrip(head_ops: usize, instrs: u32) {
+    assert!((3..=16).contains(&head_ops));
+    let mut words = vec![0x5280; head_ops - 1]; // ADDQ.L #1,D0
+    words.extend_from_slice(&[
+        0x51CF, 0x0004, // DBF D7, reset (terminal non-self-loop trace op)
+        0x4E71, // padding, skipped by the taken DBF
+        0x7E01, // reset: MOVEQ #1,D7 (interpreted tail)
+    ]);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+
+    bench_batch_loop_at(
+        "batch",
+        &format!("roundtrip {head_ops}"),
+        &words,
+        instrs,
+        0x1000 + head_ops * 0x40,
+    );
+}
+
+fn blocked_roundtrip(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
+    let mut words = vec![0x5280; prefix_ops]; // traceable ADDQ.L #1,D0 prefix
+    words.extend_from_slice(blocker);
+    words.extend_from_slice(&[
+        0x51CF, 0x0004, // DBF D7, reset (terminal non-self-loop trace op)
+        0x4E71, // padding, skipped by the taken DBF
+        0x7E01, // reset: MOVEQ #1,D7 (interpreted tail)
+    ]);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    words
+}
+
+fn blocked_self_loop(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
+    let mut words = vec![0x5280; prefix_ops];
+    words.extend_from_slice(blocker);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    words
+}
+
+/// Replay the three dominant rejected-trace shapes observed during a
+/// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
+/// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
+/// dynamic backedges minus the initial visit that installs each trace
+/// candidate; consulting the actual trace slot avoids undercounting when the
+/// PC falls out of the CPU's four-entry skip filter. Each case's instruction
+/// budget also includes its full synthetic loop length, avoiding the prefix-
+/// length double-weighting that a projected-dispatch ratio causes.
+fn bench_lemmings_opportunities() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "CMP.B (A0),D1 p5",
+            blocked_roundtrip(5, &[0xB210]),
+            483_003u32,
+            9u32,
+        ),
+        (
+            "CMP.W d16(A6) p4",
+            blocked_roundtrip(4, &[0xBC6E, 0x0100]),
+            399_980u32,
+            8u32,
+        ),
+        (
+            "CMP.B (A0),D1 p2",
+            blocked_roundtrip(2, &[0xB210]),
+            407_271u32,
+            6u32,
+        ),
+    ];
+
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, rejected_hits, instrs_per_iteration)) in cases.iter().enumerate() {
+        let instrs = rejected_hits * instrs_per_iteration * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x2000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:18} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings weighted  {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
+    );
+}
+
+/// Optimistic counterpart to `lemmings-opportunities`: the same measured
+/// blocker mix when the instruction following the captured prefix eventually
+/// closes directly back to the trace head. This is the only topology for
+/// which memory CMP traces are admitted after the round-trip regression test.
+fn bench_lemmings_self_loops() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "CMP.B self p5",
+            blocked_self_loop(5, &[0xB210]),
+            483_003u32,
+            7u32,
+        ),
+        (
+            "CMP.W self p4",
+            blocked_self_loop(4, &[0xBC6E, 0x0100]),
+            399_980u32,
+            6u32,
+        ),
+        (
+            "CMP.B self p2",
+            blocked_self_loop(2, &[0xB210]),
+            407_271u32,
+            4u32,
+        ),
+    ];
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, rejected_hits, instrs_per_iteration)) in cases.iter().enumerate() {
+        let instrs = rejected_hits * instrs_per_iteration * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x3000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:18} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings self-loop {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
     );
 }
 
@@ -306,12 +457,27 @@ fn main() {
     println!("m68k microbench");
     let only = std::env::args().nth(1);
     if only.as_deref() == Some("trace-calls") {
-        // Unlike a self-loop, each native trace here executes once before
-        // returning to Rust. This isolates the call-boundary break-even
-        // point seen in branch-heavy application code such as Lemmings.
+        // The trace function returns to the Rust self-loop driver after each
+        // iteration, isolating the native call-boundary break-even point.
+        // `trace-roundtrips` additionally includes validation, cache probing,
+        // and decoded-loop re-entry, as real non-self-loop traces do.
         for head_ops in 2..=9 {
             bench_one_shot_trace(head_ops, 50_000_000);
         }
+        return;
+    }
+    if only.as_deref() == Some("trace-roundtrips") {
+        for head_ops in 3..=9 {
+            bench_trace_roundtrip(head_ops, 50_000_000);
+        }
+        return;
+    }
+    if only.as_deref() == Some("lemmings-opportunities") {
+        bench_lemmings_opportunities();
+        return;
+    }
+    if only.as_deref() == Some("lemmings-self-loops") {
+        bench_lemmings_self_loops();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,4 +17,6 @@ pub mod registers;
 pub mod status;
 pub mod timing;
 pub mod trace_jit;
+#[cfg(feature = "trace-profile")]
+pub mod trace_profile;
 pub mod types;

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -965,7 +965,10 @@ impl CpuCore {
             self.ir = opcode as u32;
 
             let Some(op) = self.decoded_simple_op(opcode, cpu_type) else {
+                #[cfg(not(feature = "trace-profile"))]
                 trace_jit::stop_recording(self);
+                #[cfg(feature = "trace-profile")]
+                trace_jit::stop_recording_at_blocker(self, self.ppc, opcode);
                 return CachedRunResult::Miss(opcode);
             };
             let branch_pc = if matches!(op, DecodedSimpleOp::BranchShort { .. }) {
@@ -1109,7 +1112,10 @@ impl CpuCore {
                     }
                 }
                 CachedOp::Complex => {
+                    #[cfg(not(feature = "trace-profile"))]
                     trace_jit::stop_recording(self);
+                    #[cfg(feature = "trace-profile")]
+                    trace_jit::stop_recording_at_blocker(self, self.ppc, opcode);
                     return BatchInnerExit::Miss(opcode);
                 }
             }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -9,7 +9,7 @@ use super::cpu::{CpuCore, NFLAG_SET};
 use super::execute::RUN_MODE_BERR_AERR_RESET;
 use super::mem_ops::{BitSource, DecodedMemOp, FastEa};
 use super::memory::AddressBus;
-use super::op_cache::{BitOp, CachedRunResult, DecodedSimpleOp};
+use super::op_cache::{BinaryOp, BitOp, CachedRunResult, DecodedSimpleOp};
 use super::types::{CpuType, Size};
 #[cfg(not(target_family = "wasm"))]
 use cranelift_codegen::Context;
@@ -233,6 +233,15 @@ pub(crate) enum JitTraceOp {
         size: Size,
         src: JitEa,
         dst: JitEa,
+    },
+    /// Read-only ALU operation from fast memory to a data register. The
+    /// initial decoder deliberately admits only CMP with `(An)`/`d16(An)`
+    /// sources; the generic shape leaves room for other read-only forms.
+    AluMemToReg {
+        op: JitBinaryOp,
+        size: Size,
+        src: JitEa,
+        dst: u8,
     },
     /// Hot Classic Mac memory forms using the A5-relative global-data
     /// convention. These require extension words, so they are represented
@@ -540,6 +549,8 @@ impl TraceJit {
                     execute_portable_trace(cpu, &trace.ops, trace.code_start, trace.code_end);
                 cycles_total += (packed as u32) as i64;
                 let ops_done = (packed >> 32) as u32;
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_native_call(pc, cpu_type, ops_done);
                 retired += ops_done;
                 if ops_done < ops_len {
                     // A memory check bailed before its op, or a guarded
@@ -582,6 +593,8 @@ impl TraceJit {
                     cpu_type,
                     ops: Vec::with_capacity(TRACE_MAX_OPS),
                 });
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_recording(pc, cpu_type);
                 cpu.trace_recording = true;
                 None
             }
@@ -631,6 +644,17 @@ impl TraceJit {
         }
     }
 
+    #[cfg(feature = "trace-profile")]
+    fn is_rejected(&self, pc: u32, cpu_type: CpuType) -> bool {
+        matches!(
+            &self.slots[trace_cache_index(pc)],
+            TraceSlot::Rejected {
+                pc: rejected_pc,
+                cpu_type: rejected_type,
+            } if *rejected_pc == pc && *rejected_type == cpu_type
+        )
+    }
+
     fn reject_recording(&mut self, cpu: &mut CpuCore) {
         if let Some(recording) = self.recording.take() {
             let idx = trace_cache_index(recording.start_pc);
@@ -661,6 +685,8 @@ impl TraceJit {
         let idx = trace_cache_index(recording.start_pc);
         let start_pc = recording.start_pc;
         let cpu_type = recording.cpu_type;
+        #[cfg(feature = "trace-profile")]
+        let recorded_ops = recording.ops.len();
         self.slots[idx] =
             match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
                 Some(trace) => TraceSlot::Compiled(trace),
@@ -672,6 +698,10 @@ impl TraceJit {
                     }
                 }
             };
+        #[cfg(feature = "trace-profile")]
+        if matches!(self.slots[idx], TraceSlot::Compiled(_)) {
+            super::trace_profile::note_compiled(start_pc, cpu_type, recorded_ops);
+        }
     }
 
     fn record_executed<B: AddressBus>(
@@ -693,6 +723,14 @@ impl TraceJit {
         }
 
         let Some(mut op) = decode_trace_op(cpu, bus, executed_pc, cpu_type) else {
+            #[cfg(feature = "trace-profile")]
+            super::trace_profile::note_blocker(
+                start_pc,
+                cpu_type,
+                recording.ops.len(),
+                executed_pc,
+                cpu.ir as u16,
+            );
             self.finish_recording(cpu, executed_pc);
             return;
         };
@@ -776,10 +814,24 @@ impl TraceJit {
                 .last()
                 .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
 
+        // A checked memory CMP does not amortize trace validation and the
+        // native/Rust boundary in the short non-self-loop regions measured
+        // from Lemmings. Keep those on the already-fast decoded-memory path;
+        // native compilation is profitable only when one validation can be
+        // reused across repeated self-loop iterations.
+        if !self_loop
+            && ops
+                .iter()
+                .any(|op| matches!(op.op, JitTraceOp::AluMemToReg { .. }))
+        {
+            return None;
+        }
+
         let needs_window = ops.iter().any(|op| {
             matches!(
                 op.op,
                 JitTraceOp::MoveMem { .. }
+                    | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
@@ -917,6 +969,10 @@ impl TraceJit {
                             &mut bails,
                             bail_at,
                         )
+                    }
+                    JitTraceOp::AluMemToReg { .. } => {
+                        let env = mem_env.as_ref().expect("AluMemToReg implies a window env");
+                        emit_alu_mem_to_reg(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
                     JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
@@ -1065,6 +1121,27 @@ pub(crate) fn stop_recording(cpu: &mut CpuCore) {
     }
 }
 
+/// End a recording because the decoded fast loop reached an opcode that it
+/// cannot execute. Profiling builds retain the stranded prefix and blocker;
+/// ordinary builds are identical to `stop_recording`.
+#[cfg(feature = "trace-profile")]
+pub(crate) fn stop_recording_at_blocker(cpu: &mut CpuCore, pc: u32, opcode: u16) {
+    if cpu.trace_recording {
+        TRACE_JIT.with_borrow_mut(|jit| {
+            if let Some(recording) = jit.recording.as_ref() {
+                super::trace_profile::note_blocker(
+                    recording.start_pc,
+                    recording.cpu_type,
+                    recording.ops.len(),
+                    pc,
+                    opcode,
+                );
+            }
+            jit.finish_recording(cpu, pc);
+        });
+    }
+}
+
 /// Note that execution just took a backward branch to `cpu.pc` (a potential
 /// trace head) and return whether the caller should probe the trace cache.
 ///
@@ -1076,6 +1153,14 @@ pub(crate) fn stop_recording(cpu: &mut CpuCore) {
 #[inline]
 pub(crate) fn note_backward_branch(cpu: &mut CpuCore, cpu_type: CpuType) -> bool {
     let pc = cpu.pc;
+    #[cfg(feature = "trace-profile")]
+    {
+        // Consult the actual direct-mapped slot instead of relying only on
+        // the CPU's four-entry skip cache: a busy workload can evict a PC
+        // from that tiny filter even though its trace remains rejected.
+        let rejected = TRACE_JIT.with_borrow(|jit| jit.is_rejected(pc, cpu_type));
+        super::trace_profile::note_backward_edge(pc, cpu_type, rejected);
+    }
     if cpu.trace_probe_skip.contains(&pc) {
         // Known-uncompilable target: recording is a no-op and probing
         // cannot succeed.
@@ -1196,6 +1281,7 @@ impl JitTraceOp {
                 };
                 4 + src_c + dst_c
             }
+            Self::AluMemToReg { .. } => 24,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::AnDispUnary { .. } | Self::AnDispAddqSubq { .. } | Self::AnDispBit { .. } => 24,
@@ -1234,6 +1320,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_an_disp_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_alu_mem_to_reg_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
@@ -1469,6 +1558,47 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
+/// CMP `<ea>,Dn` for the two addressing forms that dominate the rejected
+/// Lemmings traces. The access itself is emitted against the fastmem window;
+/// the extension word is captured for validation and displacement baking.
+fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let DecodedMemOp::AluToReg {
+        op: BinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = DecodedMemOp::decode(cpu_type, opcode)?
+    else {
+        return None;
+    };
+    let (src, extension) = match src {
+        FastEa::AnInd(reg) => (JitEa::Ind(reg), None),
+        FastEa::AnDisp(reg) => {
+            let displacement = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (JitEa::Disp(reg, displacement as i16), Some(displacement))
+        }
+        _ => return None,
+    };
+    Some(TraceBuildOp {
+        opcode,
+        extension,
+        extension2: None,
+        pc,
+        op: JitTraceOp::AluMemToReg {
+            op: JitBinaryOp::Cmp,
+            size,
+            src,
+            dst,
+        },
+    })
+}
+
 fn decode_jit_ea(mode: u16, reg: u16, displacement: i16) -> Option<JitEa> {
     Some(match mode & 7 {
         0 => JitEa::Data(reg as u8),
@@ -1533,6 +1663,9 @@ fn execute_portable_op(
 ) -> Option<i32> {
     if let JitTraceOp::MoveMem { size, src, dst } = op.op {
         return execute_portable_move_mem(cpu, size, src, dst, code_start, code_end);
+    }
+    if matches!(op.op, JitTraceOp::AluMemToReg { .. }) {
+        return execute_portable_alu_mem_to_reg(cpu, op);
     }
     if matches!(
         op.op,
@@ -1629,6 +1762,40 @@ fn execute_portable_an_disp(
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
     if super::mem_ops::execute_mem_op(cpu, op) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
+    let JitTraceOp::AluMemToReg {
+        op: JitBinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = trace.op
+    else {
+        return None;
+    };
+    let src = match src {
+        JitEa::Ind(reg) => FastEa::AnInd(reg),
+        JitEa::Disp(reg, _) => FastEa::AnDisp(reg),
+        _ => return None,
+    };
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::AluToReg {
+            op: BinaryOp::Cmp,
+            size,
+            src,
+            dst,
+        },
+    ) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -2086,6 +2253,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::MoveMem { .. } => {
             unreachable!("MoveMem is handled by execute_portable_move_mem")
         }
+        JitTraceOp::AluMemToReg { .. } => {
+            unreachable!("AluMemToReg is handled by execute_portable_alu_mem_to_reg")
+        }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
         | JitTraceOp::AnDispBit { .. } => {
@@ -2412,6 +2582,9 @@ fn emit_jit_op(
         }
         JitTraceOp::ShiftReg { .. } => unreachable!("ShiftReg traces are wasm-only"),
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
+        JitTraceOp::AluMemToReg { .. } => {
+            unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
+        }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
         | JitTraceOp::AnDispBit { .. } => {
@@ -2577,6 +2750,53 @@ fn guard_store_not_code(
         .icmp_imm(IntCC::UnsignedGreaterThan, past, env.code_start as i64);
     let bad = builder.ins().band(lt_end, gt_start);
     branch_guard(builder, bail, bad);
+}
+
+/// Emit a read-only memory-to-register ALU operation. All address checks run
+/// before flags are committed, so a miss can re-execute the instruction via
+/// full dispatch without rolling back architectural state.
+#[cfg(not(target_family = "wasm"))]
+fn emit_alu_mem_to_reg(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::AluMemToReg {
+        op: JitBinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = trace.op
+    else {
+        unreachable!("only CMP memory-to-register traces are decoded")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let base_reg = match src {
+        JitEa::Ind(reg) | JitEa::Disp(reg, _) => reg,
+        _ => unreachable!("CMP trace decoder only admits (An) and d16(An)"),
+    };
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(base_reg));
+    let addr = match src {
+        JitEa::Ind(_) => base,
+        JitEa::Disp(_, displacement) => builder.ins().iadd_imm(base, displacement as i64),
+        _ => unreachable!(),
+    };
+    let (off, _) = checked_window_off(builder, env, bail, addr, size);
+    let src_value = window_load(builder, env, off, size);
+    let dst_value = load_reg(builder, cpu, JitDirectReg::Data(dst));
+    let dst_value = mask_value(builder, dst_value, size);
+    let result = builder.ins().isub(dst_value, src_value);
+    set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+    cycles_const(builder, trace.op.max_cycles())
 }
 
 /// Emit the displacement-memory operations that dominate Classic Mac code.
@@ -3587,6 +3807,94 @@ mod portable_tests {
         assert!(cycles.is_some());
         assert_eq!(&mem[0x202..0x204], &0xBEEFu16.to_be_bytes());
         assert_eq!(cpu.a(0), 0x204);
+    }
+
+    #[test]
+    fn decodes_hot_cmp_memory_sources() {
+        let cpu = cpu();
+        let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
+        mem.write_word(0x0100, 0xB210); // CMP.B (A0),D1
+        let indirect = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(indirect.extension, None);
+        assert!(matches!(
+            indirect.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Byte,
+                src: JitEa::Ind(0),
+                dst: 1,
+            }
+        ));
+
+        mem.write_word(0x0100, 0xBC6E); // CMP.W $0010(A6),D6
+        mem.write_word(0x0102, 0x0010);
+        let displacement = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(displacement.extension, Some(0x0010));
+        assert!(matches!(
+            displacement.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Disp(6, 0x0010),
+                dst: 6,
+            }
+        ));
+    }
+
+    #[test]
+    fn portable_cmp_memory_sets_nzvc_and_preserves_x() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0200);
+        cpu.set_d(1, 0x1234_567F);
+        cpu.set_ccr(0x10); // X set; CMP must preserve it.
+        mem[0x0200] = 0x80;
+
+        let op = TraceBuildOp {
+            opcode: 0xB210,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Byte,
+                src: JitEa::Ind(0),
+                dst: 1,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102).is_some());
+        assert_eq!(cpu.d(1), 0x1234_567F, "CMP does not write its destination");
+        assert_eq!(cpu.get_ccr(), 0x1B, "X/N/V/C set and Z clear");
+    }
+
+    #[test]
+    fn portable_cmp_displacement_bails_without_changing_state() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(6, 0x00FF_F000); // displacement remains outside the window
+        cpu.set_d(6, 0xCAFE_BEEF);
+        cpu.set_ccr(0x15);
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+
+        let op = TraceBuildOp {
+            opcode: 0xBC6E,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Disp(6, 0x0010),
+                dst: 6,
+            },
+        };
+        cpu.pc = 0x0444;
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104), None);
+        assert_eq!(cpu.pc, 0x0444);
+        assert_eq!(cpu.d(6), 0xCAFE_BEEF);
+        assert_eq!(cpu.get_ccr(), 0x15);
     }
 
     #[test]

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -1,0 +1,321 @@
+//! Opt-in trace-JIT opportunity profiling.
+//!
+//! Enable the `trace-profile` Cargo feature and set `M68K_TRACE_PROFILE=1`
+//! to print a report when the CPU thread exits. The normal build contains
+//! none of this module or its hot-path hooks.
+
+use super::types::CpuType;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceProfileRow {
+    pub start_pc: u32,
+    pub cpu_type: CpuType,
+    pub backward_hits: u64,
+    pub rejected_hits: u64,
+    pub recording_attempts: u64,
+    pub prefix_ops: u32,
+    pub blocker_pc: Option<u32>,
+    pub blocker_opcode: Option<u16>,
+    pub compiled_ops: u32,
+    pub native_calls: u64,
+    pub jit_retired: u64,
+}
+
+impl TraceProfileRow {
+    /// Approximate interpreter dispatches made eligible by supporting the
+    /// blocker. This deliberately excludes the blocker itself: some control-
+    /// flow instructions should terminate a trace rather than execute in it.
+    pub fn projected_dispatches(&self) -> u64 {
+        self.rejected_hits
+            .saturating_mul(u64::from(self.prefix_ops))
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TraceProfileSnapshot {
+    pub rows: Vec<TraceProfileRow>,
+    pub backward_hits: u64,
+    pub rejected_hits: u64,
+    pub native_calls: u64,
+    pub jit_retired: u64,
+}
+
+impl TraceProfileSnapshot {
+    pub fn report(&self) -> String {
+        let mut rows = self.rows.clone();
+        rows.sort_unstable_by(|a, b| {
+            b.projected_dispatches()
+                .cmp(&a.projected_dispatches())
+                .then_with(|| b.backward_hits.cmp(&a.backward_hits))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+
+        let average = if self.native_calls == 0 {
+            0.0
+        } else {
+            self.jit_retired as f64 / self.native_calls as f64
+        };
+        let mut out = String::new();
+        let _ = writeln!(out, "m68k trace opportunity profile");
+        let _ = writeln!(
+            out,
+            "totals: backward_hits={} rejected_hits={} native_calls={} jit_retired={} avg_ops_per_native_call={average:.2}",
+            self.backward_hits, self.rejected_hits, self.native_calls, self.jit_retired
+        );
+        let _ = writeln!(
+            out,
+            "rank  start_pc  hits       rejected   attempts prefix projected   blocker_pc opcode  compiled calls      retired"
+        );
+        for (rank, row) in rows.iter().take(40).enumerate() {
+            let blocker_pc = row
+                .blocker_pc
+                .map_or_else(|| "--------".to_owned(), |pc| format!("{pc:08X}"));
+            let blocker_opcode = row
+                .blocker_opcode
+                .map_or_else(|| "----".to_owned(), |opcode| format!("{opcode:04X}"));
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:>10}  {:>10}  {:>8} {:>6} {:>10}   {}  {}  {:>8} {:>10} {:>12}",
+                rank + 1,
+                row.start_pc,
+                row.backward_hits,
+                row.rejected_hits,
+                row.recording_attempts,
+                row.prefix_ops,
+                row.projected_dispatches(),
+                blocker_pc,
+                blocker_opcode,
+                row.compiled_ops,
+                row.native_calls,
+                row.jit_retired
+            );
+        }
+
+        let mut compiled_rows: Vec<_> = self
+            .rows
+            .iter()
+            .filter(|row| row.native_calls != 0)
+            .collect();
+        compiled_rows.sort_unstable_by(|a, b| {
+            b.jit_retired
+                .cmp(&a.jit_retired)
+                .then_with(|| b.native_calls.cmp(&a.native_calls))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+        let _ = writeln!(out, "compiled traces by retired instructions");
+        let _ = writeln!(out, "rank  start_pc  ops      calls      retired avg_ops");
+        for (rank, row) in compiled_rows.iter().take(40).enumerate() {
+            let average = row.jit_retired as f64 / row.native_calls as f64;
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2}",
+                rank + 1,
+                row.start_pc,
+                row.compiled_ops,
+                row.native_calls,
+                row.jit_retired,
+                average
+            );
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct Row {
+    cpu_type: u32,
+    backward_hits: u64,
+    rejected_hits: u64,
+    recording_attempts: u64,
+    prefix_ops: u32,
+    blocker_pc: Option<u32>,
+    blocker_opcode: Option<u16>,
+    compiled_ops: u32,
+    native_calls: u64,
+    jit_retired: u64,
+}
+
+#[derive(Default)]
+struct Profile {
+    rows: BTreeMap<(u32, u32), Row>,
+}
+
+impl Profile {
+    fn row(&mut self, pc: u32, cpu_type: CpuType) -> &mut Row {
+        self.rows
+            .entry((pc, cpu_type as u32))
+            .or_insert_with(|| Row {
+                cpu_type: cpu_type as u32,
+                ..Row::default()
+            })
+    }
+
+    fn snapshot(&self) -> TraceProfileSnapshot {
+        let rows: Vec<_> = self
+            .rows
+            .iter()
+            .map(|(&(start_pc, _), row)| TraceProfileRow {
+                start_pc,
+                cpu_type: cpu_type_from_repr(row.cpu_type),
+                backward_hits: row.backward_hits,
+                rejected_hits: row.rejected_hits,
+                recording_attempts: row.recording_attempts,
+                prefix_ops: row.prefix_ops,
+                blocker_pc: row.blocker_pc,
+                blocker_opcode: row.blocker_opcode,
+                compiled_ops: row.compiled_ops,
+                native_calls: row.native_calls,
+                jit_retired: row.jit_retired,
+            })
+            .collect();
+        TraceProfileSnapshot {
+            backward_hits: rows.iter().map(|row| row.backward_hits).sum(),
+            rejected_hits: rows.iter().map(|row| row.rejected_hits).sum(),
+            native_calls: rows.iter().map(|row| row.native_calls).sum(),
+            jit_retired: rows.iter().map(|row| row.jit_retired).sum(),
+            rows,
+        }
+    }
+}
+
+struct ProfileState(Profile);
+
+impl Drop for ProfileState {
+    fn drop(&mut self) {
+        if std::env::var_os("M68K_TRACE_PROFILE").is_some() {
+            eprintln!("{}", self.0.snapshot().report());
+        }
+    }
+}
+
+thread_local! {
+    static PROFILE: RefCell<ProfileState> = RefCell::new(ProfileState(Profile::default()));
+}
+
+pub fn reset() {
+    PROFILE.with_borrow_mut(|profile| profile.0 = Profile::default());
+}
+
+pub fn snapshot() -> TraceProfileSnapshot {
+    PROFILE.with_borrow(|profile| profile.0.snapshot())
+}
+
+pub(crate) fn note_backward_edge(pc: u32, cpu_type: CpuType, rejected: bool) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.backward_hits = row.backward_hits.saturating_add(1);
+        if rejected {
+            row.rejected_hits = row.rejected_hits.saturating_add(1);
+        }
+    });
+}
+
+pub(crate) fn note_recording(pc: u32, cpu_type: CpuType) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.recording_attempts = row.recording_attempts.saturating_add(1);
+    });
+}
+
+pub(crate) fn note_blocker(
+    start_pc: u32,
+    cpu_type: CpuType,
+    prefix_ops: usize,
+    blocker_pc: u32,
+    blocker_opcode: u16,
+) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(start_pc, cpu_type);
+        // Keep the longest observed prefix for this trace head. It is the
+        // conservative amount of already-supported work stranded behind the
+        // blocker; path variation is visible through repeated recordings.
+        if prefix_ops as u32 >= row.prefix_ops {
+            row.prefix_ops = prefix_ops as u32;
+            row.blocker_pc = Some(blocker_pc);
+            row.blocker_opcode = Some(blocker_opcode);
+        }
+    });
+}
+
+pub(crate) fn note_compiled(pc: u32, cpu_type: CpuType, ops: usize) {
+    PROFILE.with_borrow_mut(|profile| {
+        profile.0.row(pc, cpu_type).compiled_ops = ops as u32;
+    });
+}
+
+pub(crate) fn note_native_call(pc: u32, cpu_type: CpuType, retired: u32) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.native_calls = row.native_calls.saturating_add(1);
+        row.jit_retired = row.jit_retired.saturating_add(u64::from(retired));
+    });
+}
+
+fn cpu_type_from_repr(value: u32) -> CpuType {
+    match value {
+        1 => CpuType::M68000,
+        2 => CpuType::M68010,
+        3 => CpuType::M68EC020,
+        4 => CpuType::M68020,
+        5 => CpuType::M68EC030,
+        6 => CpuType::M68030,
+        7 => CpuType::M68EC040,
+        8 => CpuType::M68LC040,
+        9 => CpuType::M68040,
+        10 => CpuType::SCC68070,
+        _ => CpuType::Invalid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AddressBus, CpuCore, LinearMemoryBus};
+
+    #[test]
+    fn report_ranks_stranded_dispatches_not_raw_hits() {
+        reset();
+        note_backward_edge(0x100, CpuType::M68040, true);
+        note_blocker(0x100, CpuType::M68040, 2, 0x104, 0x4ead);
+        for _ in 0..3 {
+            note_backward_edge(0x200, CpuType::M68040, true);
+        }
+        note_blocker(0x200, CpuType::M68040, 1, 0x202, 0x486d);
+
+        let report = snapshot().report();
+        assert!(report.find("00000200").unwrap() < report.find("00000100").unwrap());
+    }
+
+    #[test]
+    fn rejected_trace_keeps_counting_dynamic_backward_edges() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        bus.write_word(0, 0x5280); // ADDQ.L #1,D0: traceable prefix
+        bus.write_word(2, 0x0640); // ADDI.W #1,D0: untraceable blocker
+        bus.write_word(4, 0x0001);
+        bus.write_word(6, 0x60F8); // BRA.S $0000
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 120, &[]);
+        assert_eq!(result.instructions, 120);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("loop head was profiled");
+        assert_eq!(row.backward_hits, 40);
+        assert_eq!(row.rejected_hits, 39);
+        assert_eq!(row.recording_attempts, 1);
+        assert_eq!(row.prefix_ops, 1);
+        assert_eq!(row.blocker_pc, Some(2));
+        assert_eq!(row.blocker_opcode, Some(0x0640));
+        assert_eq!(row.projected_dispatches(), row.rejected_hits);
+    }
+}

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1246,3 +1246,39 @@ fn mem_trace_unaligned_matches_step_on_68020() {
         cpu.set_d(2, 0x0BAD_0001);
     });
 }
+
+/// The two memory-source CMP forms found at the hottest rejected Lemmings
+/// trace heads must compile without changing architectural behavior.
+#[test]
+fn mem_trace_cmp_sources_match_step() {
+    let indirect = &[
+        0xB210, // $1000: CMP.B (A0),D1
+        0x4E71, // $1002: NOP (three-op minimum with DBRA)
+        0x51C8, 0xFFFA, // $1004: DBRA D0,$1000
+        0xA000, // $1008: sentinel
+    ];
+    assert_fastmem_matches_step("mem-trace cmp indirect", indirect, CpuType::M68000, |cpu| {
+        cpu.set_a(0, 0x2000);
+        cpu.set_d(0, 127);
+        cpu.set_d(1, 0x1234_567F);
+        cpu.set_ccr(0x10);
+    });
+
+    let displacement = &[
+        0xBC6E, 0x0010, // $1000: CMP.W $0010(A6),D6
+        0x4E71, // $1004: NOP
+        0x51C8, 0xFFF8, // $1006: DBRA D0,$1000
+        0xA000, // $100A: sentinel
+    ];
+    assert_fastmem_matches_step(
+        "mem-trace cmp displacement",
+        displacement,
+        CpuType::M68000,
+        |cpu| {
+            cpu.set_a(6, 0x2100);
+            cpu.set_d(0, 127);
+            cpu.set_d(6, 0xCAFE_BEEF);
+            cpu.set_ccr(0x10);
+        },
+    );
+}


### PR DESCRIPTION
## Summary

Extend the trace JIT with the two read-only memory-source CMP forms that blocked the hottest Lemmings loops:

- `CMP.<size> (An),Dn`
- `CMP.<size> d16(An),Dn`

The native emitter performs a checked, endian-correct fast-memory load and computes NZVC while preserving X. All bounds/alignment checks happen before architectural state changes, so a side exit can safely re-execute the instruction through normal dispatch. The portable executor uses the same trace representation for wasm and differential tests.

Memory-CMP traces are deliberately admitted only when the recording closes into a true self-loop. Measurements showed that short non-self-loop regions do not amortize fast-memory validation plus the native/Rust round trip; those stay on the decoded-memory path.

This also adds:

- an opt-in `trace-profile` feature, compiled out of normal builds;
- rejected-head/blocker and successful-trace attribution;
- a complete non-self-loop round-trip benchmark; and
- Lemmings-weighted rejected-loop and self-loop benchmarks derived from a real run.

## Why these instructions

A 206,780,516-instruction Lemmings baseline reported:

| Trace head | Dynamic rejected hits | Traceable prefix | Blocker |
|---|---:|---:|---|
| `$0002AD52` | 483,003 | 5 ops | `$B210` — `CMP.B (A0),D1` |
| `$00022DA2` | 399,980 | 4 ops | `$BC6E` — `CMP.W d16(A6),D6` |
| `$0002AF40` | 407,271 | 2 ops | `$B210` — `CMP.B (A0),D1` |

Those three heads stranded about 4.83 million already-supported decoded dispatches in that run.

## Performance

### Reproducible microbenchmark

Six alternating baseline/candidate runs of `lemmings-self-loops`:

| Build | Median throughput |
|---|---:|
| Baseline | 55.2 M guest instructions/s |
| This PR | 282.4 M guest instructions/s |

That is a **5.1x** improvement for the measured Lemmings instruction mix when it closes into self-loops.

Six alternating runs of the corresponding full non-self-loop validation/entry/exit/reprobe workload:

| Build | Median throughput |
|---|---:|
| Baseline | 53.05 M guest instructions/s |
| This PR | 52.7 M guest instructions/s |

The **-0.7%** difference is noise-level and confirms the topology guard keeps the unprofitable workload on its existing decoded path. The existing `classic Mac mix` row was also neutral in a paired run (284.7 vs. 288.5 M guest instructions/s).

### Real Lemmings trace coverage

The earlier baseline retired 17,587,832 of 206,780,516 guest instructions through native traces: **8.5% JIT coverage**.

A gameplay-focused candidate run retired 37,968,597 of 142,979,534 instructions through native traces: **26.6% coverage**. A much longer candidate run, including menus and between-level work, retired 172,109,406 of 915,992,784 instructions natively: **18.8% coverage**.

The longer run attributed the formerly blocked loops as follows:

| Trace | Compiled ops | Native calls | JIT-retired instructions | Average retired/call |
|---|---:|---:|---:|---:|
| `$00022DA2` | 19 | 366,996 | 3,818,294 | 10.40 |
| `$0002AF40` | 7 | 406,794 | 2,029,092 | 4.99 |
| `$0002AD48` | 7 | 191,462 | 1,311,309 | 6.85 |

`$0002AD48` is the enclosing trace that now absorbs the former `$0002AD52` CMP blocker.

### Matched host profile

I sampled the fixed pre-change binary and this release candidate back-to-back for 30 seconds at 1 ms while level 1 was active with Lemmings walking. Aggregating exclusive samples attributed to the Systemless binary:

| Exclusive samples | Baseline | This PR | Change |
|---|---:|---:|---:|
| All Systemless code | 1,090 | 728 | **-33.2%** |
| Emulator runner | 531 | 367 | **-30.9%** |
| Decoded memory executor | 359 | 209 | **-41.8%** |

The binaries were fixed before sampling (`e7379561...` baseline and `5084b025...` candidate) and used the same Lemmings 1.5.2 disk and Systemless configuration.

## Correctness and safety

- Decoder tests cover both hot opcodes and displacement capture.
- Portable tests verify CMP NZVC behavior, X preservation, and no state change on a failed window check.
- The integration test compares `run_batch` against instruction stepping for both forms.
- Native loads use the existing fast-memory bounds/alignment and big-endian helpers.
- Non-self-loop memory-CMP recordings are rejected before native compilation.

Validation completed:

- `cargo test --all-features --all-targets`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

After rebasing onto the `m68k 0.2.2` release, the focused integration test and full clippy pass were repeated successfully.
