### PR TITLE
perf: JIT two-instruction self-loops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ exclude = [
 
 [dependencies]
 
+[features]
+default = []
+# Opt-in trace-opportunity accounting for emulator profiling. Disabled builds
+# contain none of the counters or reporting code.
+trace-profile = []
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 cranelift-codegen = "0.132.0"
 cranelift-frontend = "0.132.0"

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -152,6 +152,14 @@ fn bench_batch_loop(label: &str, name: &str, words: &[u16], instrs: u32) {
 }
 
 fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code_base: usize) {
+    let elapsed = measure_batch_loop_at(words, instrs, code_base);
+    println!(
+        "{label:9} {name:18} {:8.1} M instr/s",
+        instrs as f64 / elapsed / 1_000_000.0
+    );
+}
+
+fn measure_batch_loop_at(words: &[u16], instrs: u32, code_base: usize) -> f64 {
     let mut bus = LinearMemoryBus::new(0x10000);
     for (i, word) in words.iter().enumerate() {
         bus.write_word_at((code_base + i * 2) as u32, *word);
@@ -162,8 +170,11 @@ fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code
         cpu.set_cpu_type(CpuType::M68040);
         cpu.set_sr(0x2700);
         cpu.pc = code_base as u32;
+        cpu.set_a(0, 0x4000);
         cpu.set_a(5, 0x1000);
+        cpu.set_a(6, 0x5000);
         cpu.set_a(7, 0x8000);
+        cpu.set_d(7, 1);
         cpu
     };
 
@@ -179,10 +190,7 @@ fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code
     let result = cpu.run_batch(&mut bus, instrs, &[0]);
     let elapsed = start.elapsed().as_secs_f64();
     assert_eq!(result.instructions, instrs);
-    println!(
-        "{label:9} {name:18} {:8.1} M instr/s",
-        instrs as f64 / elapsed / 1_000_000.0
-    );
+    elapsed
 }
 
 fn bench_one_shot_trace(head_ops: usize, instrs: u32) {
@@ -233,6 +241,149 @@ fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
         &words,
         instrs,
         0x800 + head_ops * 0x40,
+    );
+}
+
+/// Exercise the complete application-style trace round trip: validate and
+/// enter one non-self-looping native trace, return to the decoded Rust loop,
+/// execute a short tail, and take a backward branch to probe the trace again.
+fn bench_trace_roundtrip(head_ops: usize, instrs: u32) {
+    assert!((3..=16).contains(&head_ops));
+    let mut words = vec![0x5280; head_ops - 1]; // ADDQ.L #1,D0
+    words.extend_from_slice(&[
+        0x51CF, 0x0004, // DBF D7, reset (terminal non-self-loop trace op)
+        0x4E71, // padding, skipped by the taken DBF
+        0x7E01, // reset: MOVEQ #1,D7 (interpreted tail)
+    ]);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+
+    bench_batch_loop_at(
+        "batch",
+        &format!("roundtrip {head_ops}"),
+        &words,
+        instrs,
+        0x1000 + head_ops * 0x40,
+    );
+}
+
+fn blocked_roundtrip(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
+    let mut words = vec![0x5280; prefix_ops]; // traceable ADDQ.L #1,D0 prefix
+    words.extend_from_slice(blocker);
+    words.extend_from_slice(&[
+        0x51CF, 0x0004, // DBF D7, reset (terminal non-self-loop trace op)
+        0x4E71, // padding, skipped by the taken DBF
+        0x7E01, // reset: MOVEQ #1,D7 (interpreted tail)
+    ]);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    words
+}
+
+fn blocked_self_loop(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
+    let mut words = vec![0x5280; prefix_ops];
+    words.extend_from_slice(blocker);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    words
+}
+
+/// Replay the three dominant rejected-trace shapes observed during a
+/// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
+/// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
+/// dynamic backedges minus the initial visit that installs each trace
+/// candidate; consulting the actual trace slot avoids undercounting when the
+/// PC falls out of the CPU's four-entry skip filter. Each case's instruction
+/// budget also includes its full synthetic loop length, avoiding the prefix-
+/// length double-weighting that a projected-dispatch ratio causes.
+fn bench_lemmings_opportunities() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "CMP.B (A0),D1 p5",
+            blocked_roundtrip(5, &[0xB210]),
+            483_003u32,
+            9u32,
+        ),
+        (
+            "CMP.W d16(A6) p4",
+            blocked_roundtrip(4, &[0xBC6E, 0x0100]),
+            399_980u32,
+            8u32,
+        ),
+        (
+            "CMP.B (A0),D1 p2",
+            blocked_roundtrip(2, &[0xB210]),
+            407_271u32,
+            6u32,
+        ),
+    ];
+
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, rejected_hits, instrs_per_iteration)) in cases.iter().enumerate() {
+        let instrs = rejected_hits * instrs_per_iteration * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x2000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:18} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings weighted  {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
+    );
+}
+
+/// Optimistic counterpart to `lemmings-opportunities`: the same measured
+/// blocker mix when the instruction following the captured prefix eventually
+/// closes directly back to the trace head. This is the only topology for
+/// which memory CMP traces are admitted after the round-trip regression test.
+fn bench_lemmings_self_loops() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "CMP.B self p5",
+            blocked_self_loop(5, &[0xB210]),
+            483_003u32,
+            7u32,
+        ),
+        (
+            "CMP.W self p4",
+            blocked_self_loop(4, &[0xBC6E, 0x0100]),
+            399_980u32,
+            6u32,
+        ),
+        (
+            "CMP.B self p2",
+            blocked_self_loop(2, &[0xB210]),
+            407_271u32,
+            4u32,
+        ),
+    ];
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, rejected_hits, instrs_per_iteration)) in cases.iter().enumerate() {
+        let instrs = rejected_hits * instrs_per_iteration * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x3000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:18} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings self-loop {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
     );
 }
 
@@ -306,12 +457,27 @@ fn main() {
     println!("m68k microbench");
     let only = std::env::args().nth(1);
     if only.as_deref() == Some("trace-calls") {
-        // Unlike a self-loop, each native trace here executes once before
-        // returning to Rust. This isolates the call-boundary break-even
-        // point seen in branch-heavy application code such as Lemmings.
+        // The trace function returns to the Rust self-loop driver after each
+        // iteration, isolating the native call-boundary break-even point.
+        // `trace-roundtrips` additionally includes validation, cache probing,
+        // and decoded-loop re-entry, as real non-self-loop traces do.
         for head_ops in 2..=9 {
             bench_one_shot_trace(head_ops, 50_000_000);
         }
+        return;
+    }
+    if only.as_deref() == Some("trace-roundtrips") {
+        for head_ops in 3..=9 {
+            bench_trace_roundtrip(head_ops, 50_000_000);
+        }
+        return;
+    }
+    if only.as_deref() == Some("lemmings-opportunities") {
+        bench_lemmings_opportunities();
+        return;
+    }
+    if only.as_deref() == Some("lemmings-self-loops") {
+        bench_lemmings_self_loops();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -174,6 +174,7 @@ fn measure_batch_loop_at(words: &[u16], instrs: u32, code_base: usize) -> f64 {
         cpu.set_a(5, 0x1000);
         cpu.set_a(6, 0x5000);
         cpu.set_a(7, 0x8000);
+        cpu.set_d(2, 0x8000);
         cpu.set_d(7, 1);
         cpu
     };
@@ -387,6 +388,67 @@ fn bench_lemmings_self_loops() {
     );
 }
 
+/// The dominant decoded-memory sites remaining after memory-source CMP
+/// traces are two-instruction copy/fill loops. Each synthetic outer loop
+/// resets its pointers and counter so the measured inner DBRA loop can run
+/// indefinitely without leaving the fastmem window.
+fn bench_lemmings_two_op_memory_loops() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "MOVE.B D1,(A0)+",
+            vec![
+                0x2042, // MOVEA.L D2,A0
+                0x707F, // MOVEQ #127,D0
+                0x10C1, // inner: MOVE.B D1,(A0)+
+                0x51C8, 0xFFFC, // DBRA D0,inner
+                0x60F4, // BRA.S outer
+            ],
+            3_702_308u32,
+        ),
+        (
+            "MOVE.B (A4)+,(A0)+",
+            vec![
+                0x2042, // MOVEA.L D2,A0
+                0x2842, // MOVEA.L D2,A4
+                0x707F, // MOVEQ #127,D0
+                0x10DC, // inner: MOVE.B (A4)+,(A0)+
+                0x51C8, 0xFFFC, // DBRA D0,inner
+                0x60F2, // BRA.S outer
+            ],
+            4_532_090u32,
+        ),
+        (
+            "MOVE.L (A1)+,(A0)+",
+            vec![
+                0x2042, // MOVEA.L D2,A0
+                0x2242, // MOVEA.L D2,A1
+                0x707F, // MOVEQ #127,D0
+                0x20D9, // inner: MOVE.L (A1)+,(A0)+
+                0x51C8, 0xFFFC, // DBRA D0,inner
+                0x60F2, // BRA.S outer
+            ],
+            2_405_305u32,
+        ),
+    ];
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, loop_iterations)) in cases.iter().enumerate() {
+        let instrs = loop_iterations * 2 * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x4000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:23} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings two-op loops   {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
+    );
+}
+
 /// Measure decoded generic memory operations without allowing a backward
 /// branch to turn the workload into a native JIT loop. Each pass walks the
 /// same straight-line code, retaining the decoded-op cache while resetting
@@ -478,6 +540,10 @@ fn main() {
     }
     if only.as_deref() == Some("lemmings-self-loops") {
         bench_lemmings_self_loops();
+        return;
+    }
+    if only.as_deref() == Some("lemmings-two-op-loops") {
+        bench_lemmings_two_op_memory_loops();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,4 +17,6 @@ pub mod registers;
 pub mod status;
 pub mod timing;
 pub mod trace_jit;
+#[cfg(feature = "trace-profile")]
+pub mod trace_profile;
 pub mod types;

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -965,7 +965,10 @@ impl CpuCore {
             self.ir = opcode as u32;
 
             let Some(op) = self.decoded_simple_op(opcode, cpu_type) else {
+                #[cfg(not(feature = "trace-profile"))]
                 trace_jit::stop_recording(self);
+                #[cfg(feature = "trace-profile")]
+                trace_jit::stop_recording_at_blocker(self, self.ppc, opcode);
                 return CachedRunResult::Miss(opcode);
             };
             let branch_pc = if matches!(op, DecodedSimpleOp::BranchShort { .. }) {
@@ -1109,7 +1112,10 @@ impl CpuCore {
                     }
                 }
                 CachedOp::Complex => {
+                    #[cfg(not(feature = "trace-profile"))]
                     trace_jit::stop_recording(self);
+                    #[cfg(feature = "trace-profile")]
+                    trace_jit::stop_recording_at_blocker(self, self.ppc, opcode);
                     return BatchInnerExit::Miss(opcode);
                 }
             }

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1106,6 +1106,8 @@ impl CpuCore {
                         trace_jit::stop_recording(self);
                         return BatchInnerExit::Miss(opcode);
                     }
+                    #[cfg(feature = "trace-profile")]
+                    super::trace_profile::note_decoded_mem(self.ppc, opcode);
                     trace_jit::record_executed(self, bus, self.ppc, self.pc);
                     if self.pc <= self.ppc {
                         probe = trace_jit::note_backward_branch(self, cpu_type);

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -9,7 +9,7 @@ use super::cpu::{CpuCore, NFLAG_SET};
 use super::execute::RUN_MODE_BERR_AERR_RESET;
 use super::mem_ops::{BitSource, DecodedMemOp, FastEa};
 use super::memory::AddressBus;
-use super::op_cache::{BitOp, CachedRunResult, DecodedSimpleOp};
+use super::op_cache::{BinaryOp, BitOp, CachedRunResult, DecodedSimpleOp};
 use super::types::{CpuType, Size};
 #[cfg(not(target_family = "wasm"))]
 use cranelift_codegen::Context;
@@ -233,6 +233,15 @@ pub(crate) enum JitTraceOp {
         size: Size,
         src: JitEa,
         dst: JitEa,
+    },
+    /// Read-only ALU operation from fast memory to a data register. The
+    /// initial decoder deliberately admits only CMP with `(An)`/`d16(An)`
+    /// sources; the generic shape leaves room for other read-only forms.
+    AluMemToReg {
+        op: JitBinaryOp,
+        size: Size,
+        src: JitEa,
+        dst: u8,
     },
     /// Hot Classic Mac memory forms using the A5-relative global-data
     /// convention. These require extension words, so they are represented
@@ -540,6 +549,8 @@ impl TraceJit {
                     execute_portable_trace(cpu, &trace.ops, trace.code_start, trace.code_end);
                 cycles_total += (packed as u32) as i64;
                 let ops_done = (packed >> 32) as u32;
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_native_call(pc, cpu_type, ops_done);
                 retired += ops_done;
                 if ops_done < ops_len {
                     // A memory check bailed before its op, or a guarded
@@ -582,6 +593,8 @@ impl TraceJit {
                     cpu_type,
                     ops: Vec::with_capacity(TRACE_MAX_OPS),
                 });
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_recording(pc, cpu_type);
                 cpu.trace_recording = true;
                 None
             }
@@ -631,6 +644,17 @@ impl TraceJit {
         }
     }
 
+    #[cfg(feature = "trace-profile")]
+    fn is_rejected(&self, pc: u32, cpu_type: CpuType) -> bool {
+        matches!(
+            &self.slots[trace_cache_index(pc)],
+            TraceSlot::Rejected {
+                pc: rejected_pc,
+                cpu_type: rejected_type,
+            } if *rejected_pc == pc && *rejected_type == cpu_type
+        )
+    }
+
     fn reject_recording(&mut self, cpu: &mut CpuCore) {
         if let Some(recording) = self.recording.take() {
             let idx = trace_cache_index(recording.start_pc);
@@ -661,6 +685,8 @@ impl TraceJit {
         let idx = trace_cache_index(recording.start_pc);
         let start_pc = recording.start_pc;
         let cpu_type = recording.cpu_type;
+        #[cfg(feature = "trace-profile")]
+        let recorded_ops = recording.ops.len();
         self.slots[idx] =
             match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
                 Some(trace) => TraceSlot::Compiled(trace),
@@ -672,6 +698,10 @@ impl TraceJit {
                     }
                 }
             };
+        #[cfg(feature = "trace-profile")]
+        if matches!(self.slots[idx], TraceSlot::Compiled(_)) {
+            super::trace_profile::note_compiled(start_pc, cpu_type, recorded_ops);
+        }
     }
 
     fn record_executed<B: AddressBus>(
@@ -693,6 +723,14 @@ impl TraceJit {
         }
 
         let Some(mut op) = decode_trace_op(cpu, bus, executed_pc, cpu_type) else {
+            #[cfg(feature = "trace-profile")]
+            super::trace_profile::note_blocker(
+                start_pc,
+                cpu_type,
+                recording.ops.len(),
+                executed_pc,
+                cpu.ir as u16,
+            );
             self.finish_recording(cpu, executed_pc);
             return;
         };
@@ -776,10 +814,24 @@ impl TraceJit {
                 .last()
                 .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
 
+        // A checked memory CMP does not amortize trace validation and the
+        // native/Rust boundary in the short non-self-loop regions measured
+        // from Lemmings. Keep those on the already-fast decoded-memory path;
+        // native compilation is profitable only when one validation can be
+        // reused across repeated self-loop iterations.
+        if !self_loop
+            && ops
+                .iter()
+                .any(|op| matches!(op.op, JitTraceOp::AluMemToReg { .. }))
+        {
+            return None;
+        }
+
         let needs_window = ops.iter().any(|op| {
             matches!(
                 op.op,
                 JitTraceOp::MoveMem { .. }
+                    | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
@@ -917,6 +969,10 @@ impl TraceJit {
                             &mut bails,
                             bail_at,
                         )
+                    }
+                    JitTraceOp::AluMemToReg { .. } => {
+                        let env = mem_env.as_ref().expect("AluMemToReg implies a window env");
+                        emit_alu_mem_to_reg(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
                     JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
@@ -1065,6 +1121,27 @@ pub(crate) fn stop_recording(cpu: &mut CpuCore) {
     }
 }
 
+/// End a recording because the decoded fast loop reached an opcode that it
+/// cannot execute. Profiling builds retain the stranded prefix and blocker;
+/// ordinary builds are identical to `stop_recording`.
+#[cfg(feature = "trace-profile")]
+pub(crate) fn stop_recording_at_blocker(cpu: &mut CpuCore, pc: u32, opcode: u16) {
+    if cpu.trace_recording {
+        TRACE_JIT.with_borrow_mut(|jit| {
+            if let Some(recording) = jit.recording.as_ref() {
+                super::trace_profile::note_blocker(
+                    recording.start_pc,
+                    recording.cpu_type,
+                    recording.ops.len(),
+                    pc,
+                    opcode,
+                );
+            }
+            jit.finish_recording(cpu, pc);
+        });
+    }
+}
+
 /// Note that execution just took a backward branch to `cpu.pc` (a potential
 /// trace head) and return whether the caller should probe the trace cache.
 ///
@@ -1076,6 +1153,14 @@ pub(crate) fn stop_recording(cpu: &mut CpuCore) {
 #[inline]
 pub(crate) fn note_backward_branch(cpu: &mut CpuCore, cpu_type: CpuType) -> bool {
     let pc = cpu.pc;
+    #[cfg(feature = "trace-profile")]
+    {
+        // Consult the actual direct-mapped slot instead of relying only on
+        // the CPU's four-entry skip cache: a busy workload can evict a PC
+        // from that tiny filter even though its trace remains rejected.
+        let rejected = TRACE_JIT.with_borrow(|jit| jit.is_rejected(pc, cpu_type));
+        super::trace_profile::note_backward_edge(pc, cpu_type, rejected);
+    }
     if cpu.trace_probe_skip.contains(&pc) {
         // Known-uncompilable target: recording is a no-op and probing
         // cannot succeed.
@@ -1196,6 +1281,7 @@ impl JitTraceOp {
                 };
                 4 + src_c + dst_c
             }
+            Self::AluMemToReg { .. } => 24,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::AnDispUnary { .. } | Self::AnDispAddqSubq { .. } | Self::AnDispBit { .. } => 24,
@@ -1234,6 +1320,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_an_disp_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_alu_mem_to_reg_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
@@ -1469,6 +1558,47 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
+/// CMP `<ea>,Dn` for the two addressing forms that dominate the rejected
+/// Lemmings traces. The access itself is emitted against the fastmem window;
+/// the extension word is captured for validation and displacement baking.
+fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let DecodedMemOp::AluToReg {
+        op: BinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = DecodedMemOp::decode(cpu_type, opcode)?
+    else {
+        return None;
+    };
+    let (src, extension) = match src {
+        FastEa::AnInd(reg) => (JitEa::Ind(reg), None),
+        FastEa::AnDisp(reg) => {
+            let displacement = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (JitEa::Disp(reg, displacement as i16), Some(displacement))
+        }
+        _ => return None,
+    };
+    Some(TraceBuildOp {
+        opcode,
+        extension,
+        extension2: None,
+        pc,
+        op: JitTraceOp::AluMemToReg {
+            op: JitBinaryOp::Cmp,
+            size,
+            src,
+            dst,
+        },
+    })
+}
+
 fn decode_jit_ea(mode: u16, reg: u16, displacement: i16) -> Option<JitEa> {
     Some(match mode & 7 {
         0 => JitEa::Data(reg as u8),
@@ -1533,6 +1663,9 @@ fn execute_portable_op(
 ) -> Option<i32> {
     if let JitTraceOp::MoveMem { size, src, dst } = op.op {
         return execute_portable_move_mem(cpu, size, src, dst, code_start, code_end);
+    }
+    if matches!(op.op, JitTraceOp::AluMemToReg { .. }) {
+        return execute_portable_alu_mem_to_reg(cpu, op);
     }
     if matches!(
         op.op,
@@ -1629,6 +1762,40 @@ fn execute_portable_an_disp(
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
     if super::mem_ops::execute_mem_op(cpu, op) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
+    let JitTraceOp::AluMemToReg {
+        op: JitBinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = trace.op
+    else {
+        return None;
+    };
+    let src = match src {
+        JitEa::Ind(reg) => FastEa::AnInd(reg),
+        JitEa::Disp(reg, _) => FastEa::AnDisp(reg),
+        _ => return None,
+    };
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::AluToReg {
+            op: BinaryOp::Cmp,
+            size,
+            src,
+            dst,
+        },
+    ) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -2086,6 +2253,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::MoveMem { .. } => {
             unreachable!("MoveMem is handled by execute_portable_move_mem")
         }
+        JitTraceOp::AluMemToReg { .. } => {
+            unreachable!("AluMemToReg is handled by execute_portable_alu_mem_to_reg")
+        }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
         | JitTraceOp::AnDispBit { .. } => {
@@ -2412,6 +2582,9 @@ fn emit_jit_op(
         }
         JitTraceOp::ShiftReg { .. } => unreachable!("ShiftReg traces are wasm-only"),
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
+        JitTraceOp::AluMemToReg { .. } => {
+            unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
+        }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
         | JitTraceOp::AnDispBit { .. } => {
@@ -2577,6 +2750,53 @@ fn guard_store_not_code(
         .icmp_imm(IntCC::UnsignedGreaterThan, past, env.code_start as i64);
     let bad = builder.ins().band(lt_end, gt_start);
     branch_guard(builder, bail, bad);
+}
+
+/// Emit a read-only memory-to-register ALU operation. All address checks run
+/// before flags are committed, so a miss can re-execute the instruction via
+/// full dispatch without rolling back architectural state.
+#[cfg(not(target_family = "wasm"))]
+fn emit_alu_mem_to_reg(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::AluMemToReg {
+        op: JitBinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = trace.op
+    else {
+        unreachable!("only CMP memory-to-register traces are decoded")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let base_reg = match src {
+        JitEa::Ind(reg) | JitEa::Disp(reg, _) => reg,
+        _ => unreachable!("CMP trace decoder only admits (An) and d16(An)"),
+    };
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(base_reg));
+    let addr = match src {
+        JitEa::Ind(_) => base,
+        JitEa::Disp(_, displacement) => builder.ins().iadd_imm(base, displacement as i64),
+        _ => unreachable!(),
+    };
+    let (off, _) = checked_window_off(builder, env, bail, addr, size);
+    let src_value = window_load(builder, env, off, size);
+    let dst_value = load_reg(builder, cpu, JitDirectReg::Data(dst));
+    let dst_value = mask_value(builder, dst_value, size);
+    let result = builder.ins().isub(dst_value, src_value);
+    set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+    cycles_const(builder, trace.op.max_cycles())
 }
 
 /// Emit the displacement-memory operations that dominate Classic Mac code.
@@ -3587,6 +3807,94 @@ mod portable_tests {
         assert!(cycles.is_some());
         assert_eq!(&mem[0x202..0x204], &0xBEEFu16.to_be_bytes());
         assert_eq!(cpu.a(0), 0x204);
+    }
+
+    #[test]
+    fn decodes_hot_cmp_memory_sources() {
+        let cpu = cpu();
+        let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
+        mem.write_word(0x0100, 0xB210); // CMP.B (A0),D1
+        let indirect = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(indirect.extension, None);
+        assert!(matches!(
+            indirect.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Byte,
+                src: JitEa::Ind(0),
+                dst: 1,
+            }
+        ));
+
+        mem.write_word(0x0100, 0xBC6E); // CMP.W $0010(A6),D6
+        mem.write_word(0x0102, 0x0010);
+        let displacement = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(displacement.extension, Some(0x0010));
+        assert!(matches!(
+            displacement.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Disp(6, 0x0010),
+                dst: 6,
+            }
+        ));
+    }
+
+    #[test]
+    fn portable_cmp_memory_sets_nzvc_and_preserves_x() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0200);
+        cpu.set_d(1, 0x1234_567F);
+        cpu.set_ccr(0x10); // X set; CMP must preserve it.
+        mem[0x0200] = 0x80;
+
+        let op = TraceBuildOp {
+            opcode: 0xB210,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Byte,
+                src: JitEa::Ind(0),
+                dst: 1,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102).is_some());
+        assert_eq!(cpu.d(1), 0x1234_567F, "CMP does not write its destination");
+        assert_eq!(cpu.get_ccr(), 0x1B, "X/N/V/C set and Z clear");
+    }
+
+    #[test]
+    fn portable_cmp_displacement_bails_without_changing_state() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(6, 0x00FF_F000); // displacement remains outside the window
+        cpu.set_d(6, 0xCAFE_BEEF);
+        cpu.set_ccr(0x15);
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+
+        let op = TraceBuildOp {
+            opcode: 0xBC6E,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Disp(6, 0x0010),
+                dst: 6,
+            },
+        };
+        cpu.pc = 0x0444;
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104), None);
+        assert_eq!(cpu.pc, 0x0444);
+        assert_eq!(cpu.d(6), 0xCAFE_BEEF);
+        assert_eq!(cpu.get_ccr(), 0x15);
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -33,6 +33,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const TRACE_CACHE_SIZE: usize = 4096;
 pub(crate) const TRACE_MAX_OPS: usize = 128;
 pub(crate) const TRACE_MIN_OPS: usize = 3;
+const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
 const TRACE_HOT_THRESHOLD: u8 = 2;
 
 /// Sentinel for `CpuCore::trace_record_skip` / `trace_probe_skip`: no PC.
@@ -779,7 +780,20 @@ impl TraceJit {
         ops: Vec<TraceBuildOp>,
         recorded_exit_pc: Option<u32>,
     ) -> Option<CompiledTrace> {
-        if ops.len() < TRACE_MIN_OPS || !ops.last().is_some_and(|op| op.op.ends_trace()) {
+        if !ops.last().is_some_and(|op| op.op.ends_trace()) {
+            return None;
+        }
+
+        let self_loop = recorded_exit_pc == Some(start_pc)
+            || ops
+                .last()
+                .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
+        let min_ops = if self_loop {
+            TRACE_MIN_SELF_LOOP_OPS
+        } else {
+            TRACE_MIN_OPS
+        };
+        if ops.len() < min_ops {
             return None;
         }
 
@@ -808,11 +822,6 @@ impl TraceJit {
                     .wrapping_sub(start_pc)
             );
         }
-
-        let self_loop = recorded_exit_pc == Some(start_pc)
-            || ops
-                .last()
-                .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
 
         // A checked memory CMP does not amortize trace validation and the
         // native/Rust boundary in the short non-self-loop regions measured

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -6,8 +6,9 @@
 
 use super::types::CpuType;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write;
+use std::hash::{BuildHasherDefault, Hasher};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraceProfileRow {
@@ -24,6 +25,19 @@ pub struct TraceProfileRow {
     pub jit_retired: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedMemProfileRow {
+    pub opcode: u16,
+    pub executions: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedMemSiteProfileRow {
+    pub pc: u32,
+    pub opcode: u16,
+    pub executions: u64,
+}
+
 impl TraceProfileRow {
     /// Approximate interpreter dispatches made eligible by supporting the
     /// blocker. This deliberately excludes the blocker itself: some control-
@@ -37,6 +51,8 @@ impl TraceProfileRow {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TraceProfileSnapshot {
     pub rows: Vec<TraceProfileRow>,
+    pub decoded_mem_ops: Vec<DecodedMemProfileRow>,
+    pub decoded_mem_sites: Vec<DecodedMemSiteProfileRow>,
     pub backward_hits: u64,
     pub rejected_hits: u64,
     pub native_calls: u64,
@@ -120,6 +136,55 @@ impl TraceProfileSnapshot {
                 average
             );
         }
+
+        let mut decoded_mem_ops = self.decoded_mem_ops.clone();
+        decoded_mem_ops.sort_unstable_by(|a, b| {
+            b.executions
+                .cmp(&a.executions)
+                .then_with(|| a.opcode.cmp(&b.opcode))
+        });
+        let decoded_mem_total: u64 = decoded_mem_ops.iter().map(|row| row.executions).sum();
+        let _ = writeln!(
+            out,
+            "decoded memory operations: total={decoded_mem_total} distinct_opcodes={}",
+            decoded_mem_ops.len()
+        );
+        let _ = writeln!(out, "rank  opcode  executions percent");
+        for (rank, row) in decoded_mem_ops.iter().take(40).enumerate() {
+            let percent = if decoded_mem_total == 0 {
+                0.0
+            } else {
+                row.executions as f64 * 100.0 / decoded_mem_total as f64
+            };
+            let _ = writeln!(
+                out,
+                "{:>4}  {:04X} {:>11} {:>6.2}%",
+                rank + 1,
+                row.opcode,
+                row.executions,
+                percent
+            );
+        }
+
+        let mut decoded_mem_sites = self.decoded_mem_sites.clone();
+        decoded_mem_sites.sort_unstable_by(|a, b| {
+            b.executions
+                .cmp(&a.executions)
+                .then_with(|| a.pc.cmp(&b.pc))
+                .then_with(|| a.opcode.cmp(&b.opcode))
+        });
+        let _ = writeln!(out, "decoded memory sites by execution count");
+        let _ = writeln!(out, "rank  pc        opcode  executions");
+        for (rank, row) in decoded_mem_sites.iter().take(60).enumerate() {
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:04X} {:>11}",
+                rank + 1,
+                row.pc,
+                row.opcode,
+                row.executions
+            );
+        }
         out
     }
 }
@@ -138,9 +203,46 @@ struct Row {
     jit_retired: u64,
 }
 
+/// The site key is already a uniformly useful `(pc << 16) | opcode` integer,
+/// so hashing it again only adds overhead to this hot, feature-only profiler.
 #[derive(Default)]
+struct IdentityHasher(u64);
+
+impl Hasher for IdentityHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for &byte in bytes {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        self.0 = hash;
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.0 = value;
+    }
+}
+
+type SiteCounts = HashMap<u64, u64, BuildHasherDefault<IdentityHasher>>;
+
 struct Profile {
     rows: BTreeMap<(u32, u32), Row>,
+    decoded_mem_counts: Box<[u64]>,
+    decoded_mem_site_counts: SiteCounts,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Self {
+            rows: BTreeMap::new(),
+            decoded_mem_counts: vec![0; super::op_cache::DECODE_TABLE_SIZE].into_boxed_slice(),
+            decoded_mem_site_counts: SiteCounts::default(),
+        }
+    }
 }
 
 impl Profile {
@@ -171,12 +273,34 @@ impl Profile {
                 jit_retired: row.jit_retired,
             })
             .collect();
+        let decoded_mem_ops = self
+            .decoded_mem_counts
+            .iter()
+            .enumerate()
+            .filter_map(|(opcode, &executions)| {
+                (executions != 0).then_some(DecodedMemProfileRow {
+                    opcode: opcode as u16,
+                    executions,
+                })
+            })
+            .collect();
+        let decoded_mem_sites = self
+            .decoded_mem_site_counts
+            .iter()
+            .map(|(&key, &executions)| DecodedMemSiteProfileRow {
+                pc: (key >> 16) as u32,
+                opcode: key as u16,
+                executions,
+            })
+            .collect();
         TraceProfileSnapshot {
             backward_hits: rows.iter().map(|row| row.backward_hits).sum(),
             rejected_hits: rows.iter().map(|row| row.rejected_hits).sum(),
             native_calls: rows.iter().map(|row| row.native_calls).sum(),
             jit_retired: rows.iter().map(|row| row.jit_retired).sum(),
             rows,
+            decoded_mem_ops,
+            decoded_mem_sites,
         }
     }
 }
@@ -201,6 +325,20 @@ pub fn reset() {
 
 pub fn snapshot() -> TraceProfileSnapshot {
     PROFILE.with_borrow(|profile| profile.0.snapshot())
+}
+
+pub(crate) fn note_decoded_mem(pc: u32, opcode: u16) {
+    PROFILE.with_borrow_mut(|profile| {
+        let count = &mut profile.0.decoded_mem_counts[usize::from(opcode)];
+        *count = count.saturating_add(1);
+        let site_key = (u64::from(pc) << 16) | u64::from(opcode);
+        let site_count = profile
+            .0
+            .decoded_mem_site_counts
+            .entry(site_key)
+            .or_default();
+        *site_count = site_count.saturating_add(1);
+    });
 }
 
 pub(crate) fn note_backward_edge(pc: u32, cpu_type: CpuType, rejected: bool) {
@@ -317,5 +455,48 @@ mod tests {
         assert_eq!(row.blocker_pc, Some(2));
         assert_eq!(row.blocker_opcode, Some(0x0640));
         assert_eq!(row.projected_dispatches(), row.rejected_hits);
+    }
+
+    #[test]
+    fn two_op_self_loop_is_compiled_and_runs_natively() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x4000);
+        bus.write_word(0, 0x22D8); // MOVE.L (A0)+,(A1)+
+        bus.write_word(2, 0x51C8); // DBRA D0,$0000
+        bus.write_word(4, 0xFFFC);
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(0, 0x1000);
+        cpu.set_a(1, 0x2000);
+        cpu.set_d(0, 1000);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 120, &[]);
+        assert_eq!(result.instructions, 120);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("two-op loop head was profiled");
+        assert_eq!(row.compiled_ops, 2);
+        assert!(row.native_calls > 0);
+        assert!(row.jit_retired > 0);
+    }
+
+    #[test]
+    fn report_ranks_decoded_memory_opcodes_by_execution_count() {
+        reset();
+        note_decoded_mem(0x1000, 0x20d9);
+        note_decoded_mem(0x1002, 0x10dc);
+        note_decoded_mem(0x1000, 0x20d9);
+
+        let snapshot = snapshot();
+        assert_eq!(snapshot.decoded_mem_ops.len(), 2);
+        let report = snapshot.report();
+        assert!(report.contains("decoded memory operations: total=3 distinct_opcodes=2"));
+        assert!(report.find("20D9").unwrap() < report.find("10DC").unwrap());
+        assert!(report.contains("00001000  20D9           2"));
     }
 }

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -1,0 +1,321 @@
+//! Opt-in trace-JIT opportunity profiling.
+//!
+//! Enable the `trace-profile` Cargo feature and set `M68K_TRACE_PROFILE=1`
+//! to print a report when the CPU thread exits. The normal build contains
+//! none of this module or its hot-path hooks.
+
+use super::types::CpuType;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceProfileRow {
+    pub start_pc: u32,
+    pub cpu_type: CpuType,
+    pub backward_hits: u64,
+    pub rejected_hits: u64,
+    pub recording_attempts: u64,
+    pub prefix_ops: u32,
+    pub blocker_pc: Option<u32>,
+    pub blocker_opcode: Option<u16>,
+    pub compiled_ops: u32,
+    pub native_calls: u64,
+    pub jit_retired: u64,
+}
+
+impl TraceProfileRow {
+    /// Approximate interpreter dispatches made eligible by supporting the
+    /// blocker. This deliberately excludes the blocker itself: some control-
+    /// flow instructions should terminate a trace rather than execute in it.
+    pub fn projected_dispatches(&self) -> u64 {
+        self.rejected_hits
+            .saturating_mul(u64::from(self.prefix_ops))
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TraceProfileSnapshot {
+    pub rows: Vec<TraceProfileRow>,
+    pub backward_hits: u64,
+    pub rejected_hits: u64,
+    pub native_calls: u64,
+    pub jit_retired: u64,
+}
+
+impl TraceProfileSnapshot {
+    pub fn report(&self) -> String {
+        let mut rows = self.rows.clone();
+        rows.sort_unstable_by(|a, b| {
+            b.projected_dispatches()
+                .cmp(&a.projected_dispatches())
+                .then_with(|| b.backward_hits.cmp(&a.backward_hits))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+
+        let average = if self.native_calls == 0 {
+            0.0
+        } else {
+            self.jit_retired as f64 / self.native_calls as f64
+        };
+        let mut out = String::new();
+        let _ = writeln!(out, "m68k trace opportunity profile");
+        let _ = writeln!(
+            out,
+            "totals: backward_hits={} rejected_hits={} native_calls={} jit_retired={} avg_ops_per_native_call={average:.2}",
+            self.backward_hits, self.rejected_hits, self.native_calls, self.jit_retired
+        );
+        let _ = writeln!(
+            out,
+            "rank  start_pc  hits       rejected   attempts prefix projected   blocker_pc opcode  compiled calls      retired"
+        );
+        for (rank, row) in rows.iter().take(40).enumerate() {
+            let blocker_pc = row
+                .blocker_pc
+                .map_or_else(|| "--------".to_owned(), |pc| format!("{pc:08X}"));
+            let blocker_opcode = row
+                .blocker_opcode
+                .map_or_else(|| "----".to_owned(), |opcode| format!("{opcode:04X}"));
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:>10}  {:>10}  {:>8} {:>6} {:>10}   {}  {}  {:>8} {:>10} {:>12}",
+                rank + 1,
+                row.start_pc,
+                row.backward_hits,
+                row.rejected_hits,
+                row.recording_attempts,
+                row.prefix_ops,
+                row.projected_dispatches(),
+                blocker_pc,
+                blocker_opcode,
+                row.compiled_ops,
+                row.native_calls,
+                row.jit_retired
+            );
+        }
+
+        let mut compiled_rows: Vec<_> = self
+            .rows
+            .iter()
+            .filter(|row| row.native_calls != 0)
+            .collect();
+        compiled_rows.sort_unstable_by(|a, b| {
+            b.jit_retired
+                .cmp(&a.jit_retired)
+                .then_with(|| b.native_calls.cmp(&a.native_calls))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+        let _ = writeln!(out, "compiled traces by retired instructions");
+        let _ = writeln!(out, "rank  start_pc  ops      calls      retired avg_ops");
+        for (rank, row) in compiled_rows.iter().take(40).enumerate() {
+            let average = row.jit_retired as f64 / row.native_calls as f64;
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2}",
+                rank + 1,
+                row.start_pc,
+                row.compiled_ops,
+                row.native_calls,
+                row.jit_retired,
+                average
+            );
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct Row {
+    cpu_type: u32,
+    backward_hits: u64,
+    rejected_hits: u64,
+    recording_attempts: u64,
+    prefix_ops: u32,
+    blocker_pc: Option<u32>,
+    blocker_opcode: Option<u16>,
+    compiled_ops: u32,
+    native_calls: u64,
+    jit_retired: u64,
+}
+
+#[derive(Default)]
+struct Profile {
+    rows: BTreeMap<(u32, u32), Row>,
+}
+
+impl Profile {
+    fn row(&mut self, pc: u32, cpu_type: CpuType) -> &mut Row {
+        self.rows
+            .entry((pc, cpu_type as u32))
+            .or_insert_with(|| Row {
+                cpu_type: cpu_type as u32,
+                ..Row::default()
+            })
+    }
+
+    fn snapshot(&self) -> TraceProfileSnapshot {
+        let rows: Vec<_> = self
+            .rows
+            .iter()
+            .map(|(&(start_pc, _), row)| TraceProfileRow {
+                start_pc,
+                cpu_type: cpu_type_from_repr(row.cpu_type),
+                backward_hits: row.backward_hits,
+                rejected_hits: row.rejected_hits,
+                recording_attempts: row.recording_attempts,
+                prefix_ops: row.prefix_ops,
+                blocker_pc: row.blocker_pc,
+                blocker_opcode: row.blocker_opcode,
+                compiled_ops: row.compiled_ops,
+                native_calls: row.native_calls,
+                jit_retired: row.jit_retired,
+            })
+            .collect();
+        TraceProfileSnapshot {
+            backward_hits: rows.iter().map(|row| row.backward_hits).sum(),
+            rejected_hits: rows.iter().map(|row| row.rejected_hits).sum(),
+            native_calls: rows.iter().map(|row| row.native_calls).sum(),
+            jit_retired: rows.iter().map(|row| row.jit_retired).sum(),
+            rows,
+        }
+    }
+}
+
+struct ProfileState(Profile);
+
+impl Drop for ProfileState {
+    fn drop(&mut self) {
+        if std::env::var_os("M68K_TRACE_PROFILE").is_some() {
+            eprintln!("{}", self.0.snapshot().report());
+        }
+    }
+}
+
+thread_local! {
+    static PROFILE: RefCell<ProfileState> = RefCell::new(ProfileState(Profile::default()));
+}
+
+pub fn reset() {
+    PROFILE.with_borrow_mut(|profile| profile.0 = Profile::default());
+}
+
+pub fn snapshot() -> TraceProfileSnapshot {
+    PROFILE.with_borrow(|profile| profile.0.snapshot())
+}
+
+pub(crate) fn note_backward_edge(pc: u32, cpu_type: CpuType, rejected: bool) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.backward_hits = row.backward_hits.saturating_add(1);
+        if rejected {
+            row.rejected_hits = row.rejected_hits.saturating_add(1);
+        }
+    });
+}
+
+pub(crate) fn note_recording(pc: u32, cpu_type: CpuType) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.recording_attempts = row.recording_attempts.saturating_add(1);
+    });
+}
+
+pub(crate) fn note_blocker(
+    start_pc: u32,
+    cpu_type: CpuType,
+    prefix_ops: usize,
+    blocker_pc: u32,
+    blocker_opcode: u16,
+) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(start_pc, cpu_type);
+        // Keep the longest observed prefix for this trace head. It is the
+        // conservative amount of already-supported work stranded behind the
+        // blocker; path variation is visible through repeated recordings.
+        if prefix_ops as u32 >= row.prefix_ops {
+            row.prefix_ops = prefix_ops as u32;
+            row.blocker_pc = Some(blocker_pc);
+            row.blocker_opcode = Some(blocker_opcode);
+        }
+    });
+}
+
+pub(crate) fn note_compiled(pc: u32, cpu_type: CpuType, ops: usize) {
+    PROFILE.with_borrow_mut(|profile| {
+        profile.0.row(pc, cpu_type).compiled_ops = ops as u32;
+    });
+}
+
+pub(crate) fn note_native_call(pc: u32, cpu_type: CpuType, retired: u32) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.native_calls = row.native_calls.saturating_add(1);
+        row.jit_retired = row.jit_retired.saturating_add(u64::from(retired));
+    });
+}
+
+fn cpu_type_from_repr(value: u32) -> CpuType {
+    match value {
+        1 => CpuType::M68000,
+        2 => CpuType::M68010,
+        3 => CpuType::M68EC020,
+        4 => CpuType::M68020,
+        5 => CpuType::M68EC030,
+        6 => CpuType::M68030,
+        7 => CpuType::M68EC040,
+        8 => CpuType::M68LC040,
+        9 => CpuType::M68040,
+        10 => CpuType::SCC68070,
+        _ => CpuType::Invalid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AddressBus, CpuCore, LinearMemoryBus};
+
+    #[test]
+    fn report_ranks_stranded_dispatches_not_raw_hits() {
+        reset();
+        note_backward_edge(0x100, CpuType::M68040, true);
+        note_blocker(0x100, CpuType::M68040, 2, 0x104, 0x4ead);
+        for _ in 0..3 {
+            note_backward_edge(0x200, CpuType::M68040, true);
+        }
+        note_blocker(0x200, CpuType::M68040, 1, 0x202, 0x486d);
+
+        let report = snapshot().report();
+        assert!(report.find("00000200").unwrap() < report.find("00000100").unwrap());
+    }
+
+    #[test]
+    fn rejected_trace_keeps_counting_dynamic_backward_edges() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        bus.write_word(0, 0x5280); // ADDQ.L #1,D0: traceable prefix
+        bus.write_word(2, 0x0640); // ADDI.W #1,D0: untraceable blocker
+        bus.write_word(4, 0x0001);
+        bus.write_word(6, 0x60F8); // BRA.S $0000
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 120, &[]);
+        assert_eq!(result.instructions, 120);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("loop head was profiled");
+        assert_eq!(row.backward_hits, 40);
+        assert_eq!(row.rejected_hits, 39);
+        assert_eq!(row.recording_attempts, 1);
+        assert_eq!(row.prefix_ops, 1);
+        assert_eq!(row.blocker_pc, Some(2));
+        assert_eq!(row.blocker_opcode, Some(0x0640));
+        assert_eq!(row.projected_dispatches(), row.rejected_hits);
+    }
+}

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1246,3 +1246,39 @@ fn mem_trace_unaligned_matches_step_on_68020() {
         cpu.set_d(2, 0x0BAD_0001);
     });
 }
+
+/// The two memory-source CMP forms found at the hottest rejected Lemmings
+/// trace heads must compile without changing architectural behavior.
+#[test]
+fn mem_trace_cmp_sources_match_step() {
+    let indirect = &[
+        0xB210, // $1000: CMP.B (A0),D1
+        0x4E71, // $1002: NOP (three-op minimum with DBRA)
+        0x51C8, 0xFFFA, // $1004: DBRA D0,$1000
+        0xA000, // $1008: sentinel
+    ];
+    assert_fastmem_matches_step("mem-trace cmp indirect", indirect, CpuType::M68000, |cpu| {
+        cpu.set_a(0, 0x2000);
+        cpu.set_d(0, 127);
+        cpu.set_d(1, 0x1234_567F);
+        cpu.set_ccr(0x10);
+    });
+
+    let displacement = &[
+        0xBC6E, 0x0010, // $1000: CMP.W $0010(A6),D6
+        0x4E71, // $1004: NOP
+        0x51C8, 0xFFF8, // $1006: DBRA D0,$1000
+        0xA000, // $100A: sentinel
+    ];
+    assert_fastmem_matches_step(
+        "mem-trace cmp displacement",
+        displacement,
+        CpuType::M68000,
+        |cpu| {
+            cpu.set_a(6, 0x2100);
+            cpu.set_d(0, 127);
+            cpu.set_d(6, 0xCAFE_BEEF);
+            cpu.set_ccr(0x10);
+        },
+    );
+}

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1161,6 +1161,22 @@ fn mem_trace_memcpy_loop_matches_step() {
     });
 }
 
+/// A memory operation followed immediately by DBRA is a common 68k copy-loop
+/// shape. It must remain exact when admitted as the minimum two-op self-loop.
+#[test]
+fn mem_trace_two_op_memcpy_loop_matches_step() {
+    let words = &[
+        0x22D8, // $1000: MOVE.L (A0)+,(A1)+
+        0x51C8, 0xFFFC, // $1002: DBRA D0,$1000
+        0xA000, // $1006: sentinel
+    ];
+    assert_fastmem_matches_step("two-op mem-trace memcpy", words, CpuType::M68000, |cpu| {
+        cpu.set_a(0, 0x2000);
+        cpu.set_a(1, 0x3000);
+        cpu.set_d(0, 127);
+    });
+}
+
 /// Backward word copy with pre-decrement on both sides.
 #[test]
 fn mem_trace_predec_copy_matches_step() {


### PR DESCRIPTION
## Stack

This PR is stacked on #20 (`perf: JIT hot memory-source CMP loops`). Review the final commit in this branch for the two-op-loop change; once #20 merges, GitHub will automatically remove the parent commit from this PR's diff.

## Summary

Admit two-instruction traces when—and only when—the final control-flow operation closes directly back to the trace head. The existing three-operation minimum remains unchanged for non-self-loop regions, and one-instruction loops remain below the admission threshold.

This targets a canonical 68k pattern:

```text
loop:  MOVE.<size> <source>,<destination>
       DBRA        Dn,loop
```

The native and portable trace executors already implement these memory moves and `DBRA`; the previous global three-op minimum prevented the complete two-op region from reaching either executor.

The PR also extends the opt-in `trace-profile` feature to count decoded memory operations by opcode and `(PC, opcode)` site. These counters and their hot-path hook are fully compiled out of normal builds. A Lemmings-weighted microbenchmark and exact `run_batch`/step integration coverage make the workload reproducible.

## Why this shape

A normal-batching/JIT Lemmings run identified a small number of two-op loops dominating the remaining decoded-memory workload:

| Inner loop site | Body | Dynamic iterations |
|---|---|---:|
| `$0002AB5E` | `MOVE.B D1,(A0)+ / DBRA` | 3,702,308 |
| `$0002AD60` + `$0002ACE8` | `MOVE.B (A4)+,(A0)+ / DBRA` | 3,877,713 |
| `$0002A9FA` + `$0002AA9E` | `MOVE.L (A1)+,(A0)+ / DBRA` | 2,405,305 |
| `$0002318E` | `MOVE.B (A0)+,(A1)+ / DBRA` | 654,377 |

Together these represented roughly 21.3 million decoded operations in the captured interval. The existing three-op JIT minimum excluded all of them even though a self-loop amortizes validation across repeated iterations.

## Performance

### Reproducible weighted microbenchmark

Five alternating runs used fixed baseline and candidate binaries. The workload resets pointers and the DBRA counter in a small outer loop, keeping each measured inner loop inside fast memory indefinitely. Weights come from the real per-site profile above.

| Lemmings loop shape | Baseline median | Candidate median | Speedup |
|---|---:|---:|---:|
| `MOVE.B D1,(A0)+ / DBRA` | 54.5 MIPS | 149.9 MIPS | **2.75x** |
| `MOVE.B (A4)+,(A0)+ / DBRA` | 48.9 MIPS | 202.8 MIPS | **4.15x** |
| `MOVE.L (A1)+,(A0)+ / DBRA` | 49.2 MIPS | 205.6 MIPS | **4.18x** |
| Weighted total | 49.7 MIPS | 175.6 MIPS | **3.53x** |

Existing three-or-more-op self-loop rows remained noise-level neutral (paired weighted observations: baseline 351.6/358.4 MIPS; candidate 359.7/352.7 MIPS). Non-self-loop CMP and linear decoded-memory workloads do not enter the new admission case; their paired runs showed no consistent directional change.

### Matched Lemmings execution coverage

Baseline and candidate trace-profile runs covered nearly identical hot-site iteration counts (for example, `$23086` executed 7,012,739 vs. 6,988,354 times). That makes the structural comparison phase-matched:

| Metric | Baseline | Candidate | Change |
|---|---:|---:|---:|
| Decoded memory operations | 46,921,106 | 31,219,481 | **-15,701,625 (-33.5%)** |
| JIT-retired instructions | 18,205,771 | 33,972,058 | **+15,766,287 (+86.6%)** |

The newly admitted two-op traces retired:

| Trace head | Native-retired instructions |
|---|---:|
| `$0002AB5E` | 7,412,732 |
| `$0002A9FA` | 2,402,874 |
| `$0002AA9E` | 2,386,626 |
| `$0002ACE8` | 2,095,152 |
| `$0002318E` | 1,153,210 |
| `$0002AD24` | 192,724 |

A matched 30-second macOS `sample` also moved the decoded memory executor from 226 to 204 exclusive samples (**-9.7%**). Total runner-exclusive samples were noisy, and generated Cranelift functions appear as unresolved addresses, so the dynamic decoded/JIT counters above are the more reliable attribution.

One high-volume byte-copy path at `$0002AD60` remains decoded. It is reached through an interior-branch side exit from the existing `$0002AD5C` trace rather than by a backward edge whose target is `$0002AD60`; addressing it requires branch-path/chaining work and is intentionally outside this PR.

## Correctness and scope

- The minimum remains three ops for every non-self-loop trace.
- One-op loops remain rejected.
- Existing fast-memory bounds, alignment, self-modifying-code, instruction-budget, and watched-PC guards are unchanged.
- An integration test compares the two-op memory-copy trace with instruction stepping.
- A feature-gated profiler test asserts that a two-op self-loop actually compiles and retires native instructions.
- Decoded opcode/site counters have no code or storage in builds without `trace-profile`.

Validation completed:

- `cargo test --all-targets --features trace-profile`
- `cargo clippy --all-targets --features trace-profile -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo check --target wasm32-unknown-unknown` could not run locally because that Rust target is not installed; compilation did not reach project code. The portable trace executor is covered by the feature-enabled native test suite, and CI remains authoritative for the wasm target.
