### PR TITLE
perf: adapt JIT traces to dominant branch paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ exclude = [
 
 [dependencies]
 
+[features]
+default = []
+# Opt-in trace-opportunity accounting for emulator profiling. Disabled builds
+# contain none of the counters or reporting code.
+trace-profile = []
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 cranelift-codegen = "0.132.0"
 cranelift-frontend = "0.132.0"

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -449,6 +449,63 @@ fn bench_lemmings_two_op_memory_loops() {
     );
 }
 
+/// Reproduce the path bias observed at Lemmings `$2AD5C`: the trace is first
+/// recorded through an uncommon conditional edge, then the workload settles
+/// into a copy loop reached through the opposite edge. A first-path-only
+/// recorder keeps side-exiting after the CMP/branch pair and interprets the
+/// MOVE/DBRA pair even though the four-op common path is a profitable loop.
+fn bench_trace_branch_bias() {
+    const CODE_BASE: u32 = 0x6000;
+    const INSTRS: u32 = 100_000_000;
+    let words = [
+        0xB210, // CMP.B (A0),D1
+        0x6606, // BNE.S outer
+        0x10DC, // common: MOVE.B (A4)+,(A0)+
+        0x51C8, 0xFFF8, // DBRA D0,head
+        0x2042, // outer: MOVEA.L D2,A0
+        0x2843, // MOVEA.L D3,A4
+        0x707F, // MOVEQ #127,D0
+        0x5884, // ADDQ.L #4,D4
+        0x60EC, // BRA.S head
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+
+    let prepare_cpu = |comparison: u32| {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(0, 0x4000);
+        cpu.set_a(4, 0x5000);
+        cpu.set_d(0, 127);
+        cpu.set_d(1, comparison);
+        cpu.set_d(2, 0x4000);
+        cpu.set_d(3, 0x5000);
+        cpu
+    };
+
+    // Two uncommon-path iterations are exactly enough to install and record
+    // the trace, without exercising it long enough to hide a later phase
+    // change from an adaptive policy.
+    let mut cpu = prepare_cpu(1);
+    let warm = cpu.run_batch(&mut bus, 14, &[0]);
+    assert_eq!(warm.instructions, 14);
+    assert_eq!(cpu.pc, CODE_BASE);
+
+    cpu.set_d(1, 0);
+    let start = Instant::now();
+    let result = cpu.run_batch(&mut bus, INSTRS, &[0]);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(result.instructions, INSTRS);
+    println!(
+        "batch     biased CMP/copy loop {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 /// Measure decoded generic memory operations without allowing a backward
 /// branch to turn the workload into a native JIT loop. Each pass walks the
 /// same straight-line code, retaining the decoded-op cache while resetting
@@ -544,6 +601,10 @@ fn main() {
     }
     if only.as_deref() == Some("lemmings-two-op-loops") {
         bench_lemmings_two_op_memory_loops();
+        return;
+    }
+    if only.as_deref() == Some("trace-branch-bias") {
+        bench_trace_branch_bias();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -152,6 +152,14 @@ fn bench_batch_loop(label: &str, name: &str, words: &[u16], instrs: u32) {
 }
 
 fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code_base: usize) {
+    let elapsed = measure_batch_loop_at(words, instrs, code_base);
+    println!(
+        "{label:9} {name:18} {:8.1} M instr/s",
+        instrs as f64 / elapsed / 1_000_000.0
+    );
+}
+
+fn measure_batch_loop_at(words: &[u16], instrs: u32, code_base: usize) -> f64 {
     let mut bus = LinearMemoryBus::new(0x10000);
     for (i, word) in words.iter().enumerate() {
         bus.write_word_at((code_base + i * 2) as u32, *word);
@@ -162,8 +170,11 @@ fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code
         cpu.set_cpu_type(CpuType::M68040);
         cpu.set_sr(0x2700);
         cpu.pc = code_base as u32;
+        cpu.set_a(0, 0x4000);
         cpu.set_a(5, 0x1000);
+        cpu.set_a(6, 0x5000);
         cpu.set_a(7, 0x8000);
+        cpu.set_d(7, 1);
         cpu
     };
 
@@ -179,10 +190,7 @@ fn bench_batch_loop_at(label: &str, name: &str, words: &[u16], instrs: u32, code
     let result = cpu.run_batch(&mut bus, instrs, &[0]);
     let elapsed = start.elapsed().as_secs_f64();
     assert_eq!(result.instructions, instrs);
-    println!(
-        "{label:9} {name:18} {:8.1} M instr/s",
-        instrs as f64 / elapsed / 1_000_000.0
-    );
+    elapsed
 }
 
 fn bench_one_shot_trace(head_ops: usize, instrs: u32) {
@@ -233,6 +241,149 @@ fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
         &words,
         instrs,
         0x800 + head_ops * 0x40,
+    );
+}
+
+/// Exercise the complete application-style trace round trip: validate and
+/// enter one non-self-looping native trace, return to the decoded Rust loop,
+/// execute a short tail, and take a backward branch to probe the trace again.
+fn bench_trace_roundtrip(head_ops: usize, instrs: u32) {
+    assert!((3..=16).contains(&head_ops));
+    let mut words = vec![0x5280; head_ops - 1]; // ADDQ.L #1,D0
+    words.extend_from_slice(&[
+        0x51CF, 0x0004, // DBF D7, reset (terminal non-self-loop trace op)
+        0x4E71, // padding, skipped by the taken DBF
+        0x7E01, // reset: MOVEQ #1,D7 (interpreted tail)
+    ]);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+
+    bench_batch_loop_at(
+        "batch",
+        &format!("roundtrip {head_ops}"),
+        &words,
+        instrs,
+        0x1000 + head_ops * 0x40,
+    );
+}
+
+fn blocked_roundtrip(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
+    let mut words = vec![0x5280; prefix_ops]; // traceable ADDQ.L #1,D0 prefix
+    words.extend_from_slice(blocker);
+    words.extend_from_slice(&[
+        0x51CF, 0x0004, // DBF D7, reset (terminal non-self-loop trace op)
+        0x4E71, // padding, skipped by the taken DBF
+        0x7E01, // reset: MOVEQ #1,D7 (interpreted tail)
+    ]);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    words
+}
+
+fn blocked_self_loop(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
+    let mut words = vec![0x5280; prefix_ops];
+    words.extend_from_slice(blocker);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    words
+}
+
+/// Replay the three dominant rejected-trace shapes observed during a
+/// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
+/// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
+/// dynamic backedges minus the initial visit that installs each trace
+/// candidate; consulting the actual trace slot avoids undercounting when the
+/// PC falls out of the CPU's four-entry skip filter. Each case's instruction
+/// budget also includes its full synthetic loop length, avoiding the prefix-
+/// length double-weighting that a projected-dispatch ratio causes.
+fn bench_lemmings_opportunities() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "CMP.B (A0),D1 p5",
+            blocked_roundtrip(5, &[0xB210]),
+            483_003u32,
+            9u32,
+        ),
+        (
+            "CMP.W d16(A6) p4",
+            blocked_roundtrip(4, &[0xBC6E, 0x0100]),
+            399_980u32,
+            8u32,
+        ),
+        (
+            "CMP.B (A0),D1 p2",
+            blocked_roundtrip(2, &[0xB210]),
+            407_271u32,
+            6u32,
+        ),
+    ];
+
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, rejected_hits, instrs_per_iteration)) in cases.iter().enumerate() {
+        let instrs = rejected_hits * instrs_per_iteration * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x2000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:18} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings weighted  {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
+    );
+}
+
+/// Optimistic counterpart to `lemmings-opportunities`: the same measured
+/// blocker mix when the instruction following the captured prefix eventually
+/// closes directly back to the trace head. This is the only topology for
+/// which memory CMP traces are admitted after the round-trip regression test.
+fn bench_lemmings_self_loops() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "CMP.B self p5",
+            blocked_self_loop(5, &[0xB210]),
+            483_003u32,
+            7u32,
+        ),
+        (
+            "CMP.W self p4",
+            blocked_self_loop(4, &[0xBC6E, 0x0100]),
+            399_980u32,
+            6u32,
+        ),
+        (
+            "CMP.B self p2",
+            blocked_self_loop(2, &[0xB210]),
+            407_271u32,
+            4u32,
+        ),
+    ];
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, rejected_hits, instrs_per_iteration)) in cases.iter().enumerate() {
+        let instrs = rejected_hits * instrs_per_iteration * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x3000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:18} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings self-loop {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
     );
 }
 
@@ -306,12 +457,27 @@ fn main() {
     println!("m68k microbench");
     let only = std::env::args().nth(1);
     if only.as_deref() == Some("trace-calls") {
-        // Unlike a self-loop, each native trace here executes once before
-        // returning to Rust. This isolates the call-boundary break-even
-        // point seen in branch-heavy application code such as Lemmings.
+        // The trace function returns to the Rust self-loop driver after each
+        // iteration, isolating the native call-boundary break-even point.
+        // `trace-roundtrips` additionally includes validation, cache probing,
+        // and decoded-loop re-entry, as real non-self-loop traces do.
         for head_ops in 2..=9 {
             bench_one_shot_trace(head_ops, 50_000_000);
         }
+        return;
+    }
+    if only.as_deref() == Some("trace-roundtrips") {
+        for head_ops in 3..=9 {
+            bench_trace_roundtrip(head_ops, 50_000_000);
+        }
+        return;
+    }
+    if only.as_deref() == Some("lemmings-opportunities") {
+        bench_lemmings_opportunities();
+        return;
+    }
+    if only.as_deref() == Some("lemmings-self-loops") {
+        bench_lemmings_self_loops();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -174,6 +174,7 @@ fn measure_batch_loop_at(words: &[u16], instrs: u32, code_base: usize) -> f64 {
         cpu.set_a(5, 0x1000);
         cpu.set_a(6, 0x5000);
         cpu.set_a(7, 0x8000);
+        cpu.set_d(2, 0x8000);
         cpu.set_d(7, 1);
         cpu
     };
@@ -387,6 +388,67 @@ fn bench_lemmings_self_loops() {
     );
 }
 
+/// The dominant decoded-memory sites remaining after memory-source CMP
+/// traces are two-instruction copy/fill loops. Each synthetic outer loop
+/// resets its pointers and counter so the measured inner DBRA loop can run
+/// indefinitely without leaving the fastmem window.
+fn bench_lemmings_two_op_memory_loops() {
+    const SCALE: u32 = 10;
+    let cases = [
+        (
+            "MOVE.B D1,(A0)+",
+            vec![
+                0x2042, // MOVEA.L D2,A0
+                0x707F, // MOVEQ #127,D0
+                0x10C1, // inner: MOVE.B D1,(A0)+
+                0x51C8, 0xFFFC, // DBRA D0,inner
+                0x60F4, // BRA.S outer
+            ],
+            3_702_308u32,
+        ),
+        (
+            "MOVE.B (A4)+,(A0)+",
+            vec![
+                0x2042, // MOVEA.L D2,A0
+                0x2842, // MOVEA.L D2,A4
+                0x707F, // MOVEQ #127,D0
+                0x10DC, // inner: MOVE.B (A4)+,(A0)+
+                0x51C8, 0xFFFC, // DBRA D0,inner
+                0x60F2, // BRA.S outer
+            ],
+            4_532_090u32,
+        ),
+        (
+            "MOVE.L (A1)+,(A0)+",
+            vec![
+                0x2042, // MOVEA.L D2,A0
+                0x2242, // MOVEA.L D2,A1
+                0x707F, // MOVEQ #127,D0
+                0x20D9, // inner: MOVE.L (A1)+,(A0)+
+                0x51C8, 0xFFFC, // DBRA D0,inner
+                0x60F2, // BRA.S outer
+            ],
+            2_405_305u32,
+        ),
+    ];
+    let mut total_instrs = 0u64;
+    let mut total_elapsed = 0.0;
+    for (index, (name, words, loop_iterations)) in cases.iter().enumerate() {
+        let instrs = loop_iterations * 2 * SCALE;
+        let elapsed = measure_batch_loop_at(words, instrs, 0x4000 + index * 0x100);
+        total_instrs += u64::from(instrs);
+        total_elapsed += elapsed;
+        println!(
+            "batch     {name:23} {:8.1} M instr/s",
+            f64::from(instrs) / elapsed / 1_000_000.0
+        );
+    }
+    println!(
+        "batch     Lemmings two-op loops   {:8.1} M instr/s",
+        total_instrs as f64 / total_elapsed / 1_000_000.0
+    );
+}
+
 /// Measure decoded generic memory operations without allowing a backward
 /// branch to turn the workload into a native JIT loop. Each pass walks the
 /// same straight-line code, retaining the decoded-op cache while resetting
@@ -478,6 +540,10 @@ fn main() {
     }
     if only.as_deref() == Some("lemmings-self-loops") {
         bench_lemmings_self_loops();
+        return;
+    }
+    if only.as_deref() == Some("lemmings-two-op-loops") {
+        bench_lemmings_two_op_memory_loops();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,4 +17,6 @@ pub mod registers;
 pub mod status;
 pub mod timing;
 pub mod trace_jit;
+#[cfg(feature = "trace-profile")]
+pub mod trace_profile;
 pub mod types;

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -965,7 +965,10 @@ impl CpuCore {
             self.ir = opcode as u32;
 
             let Some(op) = self.decoded_simple_op(opcode, cpu_type) else {
+                #[cfg(not(feature = "trace-profile"))]
                 trace_jit::stop_recording(self);
+                #[cfg(feature = "trace-profile")]
+                trace_jit::stop_recording_at_blocker(self, self.ppc, opcode);
                 return CachedRunResult::Miss(opcode);
             };
             let branch_pc = if matches!(op, DecodedSimpleOp::BranchShort { .. }) {
@@ -1109,7 +1112,10 @@ impl CpuCore {
                     }
                 }
                 CachedOp::Complex => {
+                    #[cfg(not(feature = "trace-profile"))]
                     trace_jit::stop_recording(self);
+                    #[cfg(feature = "trace-profile")]
+                    trace_jit::stop_recording_at_blocker(self, self.ppc, opcode);
                     return BatchInnerExit::Miss(opcode);
                 }
             }

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1106,6 +1106,8 @@ impl CpuCore {
                         trace_jit::stop_recording(self);
                         return BatchInnerExit::Miss(opcode);
                     }
+                    #[cfg(feature = "trace-profile")]
+                    super::trace_profile::note_decoded_mem(self.ppc, opcode);
                     trace_jit::record_executed(self, bus, self.ppc, self.pc);
                     if self.pc <= self.ppc {
                         probe = trace_jit::note_backward_branch(self, cpu_type);

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -9,7 +9,7 @@ use super::cpu::{CpuCore, NFLAG_SET};
 use super::execute::RUN_MODE_BERR_AERR_RESET;
 use super::mem_ops::{BitSource, DecodedMemOp, FastEa};
 use super::memory::AddressBus;
-use super::op_cache::{BitOp, CachedRunResult, DecodedSimpleOp};
+use super::op_cache::{BinaryOp, BitOp, CachedRunResult, DecodedSimpleOp};
 use super::types::{CpuType, Size};
 #[cfg(not(target_family = "wasm"))]
 use cranelift_codegen::Context;
@@ -233,6 +233,15 @@ pub(crate) enum JitTraceOp {
         size: Size,
         src: JitEa,
         dst: JitEa,
+    },
+    /// Read-only ALU operation from fast memory to a data register. The
+    /// initial decoder deliberately admits only CMP with `(An)`/`d16(An)`
+    /// sources; the generic shape leaves room for other read-only forms.
+    AluMemToReg {
+        op: JitBinaryOp,
+        size: Size,
+        src: JitEa,
+        dst: u8,
     },
     /// Hot Classic Mac memory forms using the A5-relative global-data
     /// convention. These require extension words, so they are represented
@@ -540,6 +549,8 @@ impl TraceJit {
                     execute_portable_trace(cpu, &trace.ops, trace.code_start, trace.code_end);
                 cycles_total += (packed as u32) as i64;
                 let ops_done = (packed >> 32) as u32;
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_native_call(pc, cpu_type, ops_done);
                 retired += ops_done;
                 if ops_done < ops_len {
                     // A memory check bailed before its op, or a guarded
@@ -582,6 +593,8 @@ impl TraceJit {
                     cpu_type,
                     ops: Vec::with_capacity(TRACE_MAX_OPS),
                 });
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_recording(pc, cpu_type);
                 cpu.trace_recording = true;
                 None
             }
@@ -631,6 +644,17 @@ impl TraceJit {
         }
     }
 
+    #[cfg(feature = "trace-profile")]
+    fn is_rejected(&self, pc: u32, cpu_type: CpuType) -> bool {
+        matches!(
+            &self.slots[trace_cache_index(pc)],
+            TraceSlot::Rejected {
+                pc: rejected_pc,
+                cpu_type: rejected_type,
+            } if *rejected_pc == pc && *rejected_type == cpu_type
+        )
+    }
+
     fn reject_recording(&mut self, cpu: &mut CpuCore) {
         if let Some(recording) = self.recording.take() {
             let idx = trace_cache_index(recording.start_pc);
@@ -661,6 +685,8 @@ impl TraceJit {
         let idx = trace_cache_index(recording.start_pc);
         let start_pc = recording.start_pc;
         let cpu_type = recording.cpu_type;
+        #[cfg(feature = "trace-profile")]
+        let recorded_ops = recording.ops.len();
         self.slots[idx] =
             match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
                 Some(trace) => TraceSlot::Compiled(trace),
@@ -672,6 +698,10 @@ impl TraceJit {
                     }
                 }
             };
+        #[cfg(feature = "trace-profile")]
+        if matches!(self.slots[idx], TraceSlot::Compiled(_)) {
+            super::trace_profile::note_compiled(start_pc, cpu_type, recorded_ops);
+        }
     }
 
     fn record_executed<B: AddressBus>(
@@ -693,6 +723,14 @@ impl TraceJit {
         }
 
         let Some(mut op) = decode_trace_op(cpu, bus, executed_pc, cpu_type) else {
+            #[cfg(feature = "trace-profile")]
+            super::trace_profile::note_blocker(
+                start_pc,
+                cpu_type,
+                recording.ops.len(),
+                executed_pc,
+                cpu.ir as u16,
+            );
             self.finish_recording(cpu, executed_pc);
             return;
         };
@@ -776,10 +814,24 @@ impl TraceJit {
                 .last()
                 .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
 
+        // A checked memory CMP does not amortize trace validation and the
+        // native/Rust boundary in the short non-self-loop regions measured
+        // from Lemmings. Keep those on the already-fast decoded-memory path;
+        // native compilation is profitable only when one validation can be
+        // reused across repeated self-loop iterations.
+        if !self_loop
+            && ops
+                .iter()
+                .any(|op| matches!(op.op, JitTraceOp::AluMemToReg { .. }))
+        {
+            return None;
+        }
+
         let needs_window = ops.iter().any(|op| {
             matches!(
                 op.op,
                 JitTraceOp::MoveMem { .. }
+                    | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
@@ -917,6 +969,10 @@ impl TraceJit {
                             &mut bails,
                             bail_at,
                         )
+                    }
+                    JitTraceOp::AluMemToReg { .. } => {
+                        let env = mem_env.as_ref().expect("AluMemToReg implies a window env");
+                        emit_alu_mem_to_reg(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
                     JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
@@ -1065,6 +1121,27 @@ pub(crate) fn stop_recording(cpu: &mut CpuCore) {
     }
 }
 
+/// End a recording because the decoded fast loop reached an opcode that it
+/// cannot execute. Profiling builds retain the stranded prefix and blocker;
+/// ordinary builds are identical to `stop_recording`.
+#[cfg(feature = "trace-profile")]
+pub(crate) fn stop_recording_at_blocker(cpu: &mut CpuCore, pc: u32, opcode: u16) {
+    if cpu.trace_recording {
+        TRACE_JIT.with_borrow_mut(|jit| {
+            if let Some(recording) = jit.recording.as_ref() {
+                super::trace_profile::note_blocker(
+                    recording.start_pc,
+                    recording.cpu_type,
+                    recording.ops.len(),
+                    pc,
+                    opcode,
+                );
+            }
+            jit.finish_recording(cpu, pc);
+        });
+    }
+}
+
 /// Note that execution just took a backward branch to `cpu.pc` (a potential
 /// trace head) and return whether the caller should probe the trace cache.
 ///
@@ -1076,6 +1153,14 @@ pub(crate) fn stop_recording(cpu: &mut CpuCore) {
 #[inline]
 pub(crate) fn note_backward_branch(cpu: &mut CpuCore, cpu_type: CpuType) -> bool {
     let pc = cpu.pc;
+    #[cfg(feature = "trace-profile")]
+    {
+        // Consult the actual direct-mapped slot instead of relying only on
+        // the CPU's four-entry skip cache: a busy workload can evict a PC
+        // from that tiny filter even though its trace remains rejected.
+        let rejected = TRACE_JIT.with_borrow(|jit| jit.is_rejected(pc, cpu_type));
+        super::trace_profile::note_backward_edge(pc, cpu_type, rejected);
+    }
     if cpu.trace_probe_skip.contains(&pc) {
         // Known-uncompilable target: recording is a no-op and probing
         // cannot succeed.
@@ -1196,6 +1281,7 @@ impl JitTraceOp {
                 };
                 4 + src_c + dst_c
             }
+            Self::AluMemToReg { .. } => 24,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::AnDispUnary { .. } | Self::AnDispAddqSubq { .. } | Self::AnDispBit { .. } => 24,
@@ -1234,6 +1320,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_an_disp_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_alu_mem_to_reg_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
@@ -1469,6 +1558,47 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
+/// CMP `<ea>,Dn` for the two addressing forms that dominate the rejected
+/// Lemmings traces. The access itself is emitted against the fastmem window;
+/// the extension word is captured for validation and displacement baking.
+fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let DecodedMemOp::AluToReg {
+        op: BinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = DecodedMemOp::decode(cpu_type, opcode)?
+    else {
+        return None;
+    };
+    let (src, extension) = match src {
+        FastEa::AnInd(reg) => (JitEa::Ind(reg), None),
+        FastEa::AnDisp(reg) => {
+            let displacement = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (JitEa::Disp(reg, displacement as i16), Some(displacement))
+        }
+        _ => return None,
+    };
+    Some(TraceBuildOp {
+        opcode,
+        extension,
+        extension2: None,
+        pc,
+        op: JitTraceOp::AluMemToReg {
+            op: JitBinaryOp::Cmp,
+            size,
+            src,
+            dst,
+        },
+    })
+}
+
 fn decode_jit_ea(mode: u16, reg: u16, displacement: i16) -> Option<JitEa> {
     Some(match mode & 7 {
         0 => JitEa::Data(reg as u8),
@@ -1533,6 +1663,9 @@ fn execute_portable_op(
 ) -> Option<i32> {
     if let JitTraceOp::MoveMem { size, src, dst } = op.op {
         return execute_portable_move_mem(cpu, size, src, dst, code_start, code_end);
+    }
+    if matches!(op.op, JitTraceOp::AluMemToReg { .. }) {
+        return execute_portable_alu_mem_to_reg(cpu, op);
     }
     if matches!(
         op.op,
@@ -1629,6 +1762,40 @@ fn execute_portable_an_disp(
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
     if super::mem_ops::execute_mem_op(cpu, op) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
+    let JitTraceOp::AluMemToReg {
+        op: JitBinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = trace.op
+    else {
+        return None;
+    };
+    let src = match src {
+        JitEa::Ind(reg) => FastEa::AnInd(reg),
+        JitEa::Disp(reg, _) => FastEa::AnDisp(reg),
+        _ => return None,
+    };
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::AluToReg {
+            op: BinaryOp::Cmp,
+            size,
+            src,
+            dst,
+        },
+    ) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -2086,6 +2253,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::MoveMem { .. } => {
             unreachable!("MoveMem is handled by execute_portable_move_mem")
         }
+        JitTraceOp::AluMemToReg { .. } => {
+            unreachable!("AluMemToReg is handled by execute_portable_alu_mem_to_reg")
+        }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
         | JitTraceOp::AnDispBit { .. } => {
@@ -2412,6 +2582,9 @@ fn emit_jit_op(
         }
         JitTraceOp::ShiftReg { .. } => unreachable!("ShiftReg traces are wasm-only"),
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
+        JitTraceOp::AluMemToReg { .. } => {
+            unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
+        }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
         | JitTraceOp::AnDispBit { .. } => {
@@ -2577,6 +2750,53 @@ fn guard_store_not_code(
         .icmp_imm(IntCC::UnsignedGreaterThan, past, env.code_start as i64);
     let bad = builder.ins().band(lt_end, gt_start);
     branch_guard(builder, bail, bad);
+}
+
+/// Emit a read-only memory-to-register ALU operation. All address checks run
+/// before flags are committed, so a miss can re-execute the instruction via
+/// full dispatch without rolling back architectural state.
+#[cfg(not(target_family = "wasm"))]
+fn emit_alu_mem_to_reg(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::AluMemToReg {
+        op: JitBinaryOp::Cmp,
+        size,
+        src,
+        dst,
+    } = trace.op
+    else {
+        unreachable!("only CMP memory-to-register traces are decoded")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let base_reg = match src {
+        JitEa::Ind(reg) | JitEa::Disp(reg, _) => reg,
+        _ => unreachable!("CMP trace decoder only admits (An) and d16(An)"),
+    };
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(base_reg));
+    let addr = match src {
+        JitEa::Ind(_) => base,
+        JitEa::Disp(_, displacement) => builder.ins().iadd_imm(base, displacement as i64),
+        _ => unreachable!(),
+    };
+    let (off, _) = checked_window_off(builder, env, bail, addr, size);
+    let src_value = window_load(builder, env, off, size);
+    let dst_value = load_reg(builder, cpu, JitDirectReg::Data(dst));
+    let dst_value = mask_value(builder, dst_value, size);
+    let result = builder.ins().isub(dst_value, src_value);
+    set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+    cycles_const(builder, trace.op.max_cycles())
 }
 
 /// Emit the displacement-memory operations that dominate Classic Mac code.
@@ -3587,6 +3807,94 @@ mod portable_tests {
         assert!(cycles.is_some());
         assert_eq!(&mem[0x202..0x204], &0xBEEFu16.to_be_bytes());
         assert_eq!(cpu.a(0), 0x204);
+    }
+
+    #[test]
+    fn decodes_hot_cmp_memory_sources() {
+        let cpu = cpu();
+        let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
+        mem.write_word(0x0100, 0xB210); // CMP.B (A0),D1
+        let indirect = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(indirect.extension, None);
+        assert!(matches!(
+            indirect.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Byte,
+                src: JitEa::Ind(0),
+                dst: 1,
+            }
+        ));
+
+        mem.write_word(0x0100, 0xBC6E); // CMP.W $0010(A6),D6
+        mem.write_word(0x0102, 0x0010);
+        let displacement = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(displacement.extension, Some(0x0010));
+        assert!(matches!(
+            displacement.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Disp(6, 0x0010),
+                dst: 6,
+            }
+        ));
+    }
+
+    #[test]
+    fn portable_cmp_memory_sets_nzvc_and_preserves_x() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0200);
+        cpu.set_d(1, 0x1234_567F);
+        cpu.set_ccr(0x10); // X set; CMP must preserve it.
+        mem[0x0200] = 0x80;
+
+        let op = TraceBuildOp {
+            opcode: 0xB210,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Byte,
+                src: JitEa::Ind(0),
+                dst: 1,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102).is_some());
+        assert_eq!(cpu.d(1), 0x1234_567F, "CMP does not write its destination");
+        assert_eq!(cpu.get_ccr(), 0x1B, "X/N/V/C set and Z clear");
+    }
+
+    #[test]
+    fn portable_cmp_displacement_bails_without_changing_state() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(6, 0x00FF_F000); // displacement remains outside the window
+        cpu.set_d(6, 0xCAFE_BEEF);
+        cpu.set_ccr(0x15);
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+
+        let op = TraceBuildOp {
+            opcode: 0xBC6E,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Disp(6, 0x0010),
+                dst: 6,
+            },
+        };
+        cpu.pc = 0x0444;
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104), None);
+        assert_eq!(cpu.pc, 0x0444);
+        assert_eq!(cpu.d(6), 0xCAFE_BEEF);
+        assert_eq!(cpu.get_ccr(), 0x15);
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -24,7 +24,7 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_jit::{JITBuilder, JITModule};
 #[cfg(not(target_family = "wasm"))]
 use cranelift_module::{Linkage, Module, default_libcall_names};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::fmt;
 #[cfg(not(target_family = "wasm"))]
 use std::mem::{offset_of, size_of, transmute};
@@ -35,6 +35,9 @@ pub(crate) const TRACE_MAX_OPS: usize = 128;
 pub(crate) const TRACE_MIN_OPS: usize = 3;
 const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
 const TRACE_HOT_THRESHOLD: u8 = 2;
+const TRACE_ADAPT_WINDOW: u8 = 64;
+const TRACE_ADAPT_MISMATCHES: u8 = 48;
+const TRACE_MAX_ADAPTIVE_RERECORDS: u8 = 1;
 
 /// Sentinel for `CpuCore::trace_record_skip` / `trace_probe_skip`: no PC.
 pub(crate) const TRACE_PC_NONE: u32 = u32::MAX;
@@ -310,14 +313,39 @@ struct CompiledTrace {
     code_start: u32,
     #[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
     code_end: u32,
+    /// A recorded interior branch is a path prediction. Sample its guarded
+    /// exits in bounded windows so an initially rare path cannot permanently
+    /// strand a later dominant path in the interpreter.
+    has_guarded_branch: bool,
+    adaptive_calls: Cell<u32>,
+    adaptive_guard_exits: Cell<u32>,
+    adaptive_rerecords: u8,
     #[cfg(not(target_family = "wasm"))]
     func: TraceFn,
+}
+
+impl CompiledTrace {
+    fn is_guarded_branch_exit(&self, cpu: &CpuCore, ops_done: u32) -> bool {
+        let Some(index) = ops_done.checked_sub(1).map(|index| index as usize) else {
+            return false;
+        };
+        self.ops.get(index).is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::Branch {
+                    expected_taken: Some(_),
+                    ..
+                }
+            ) && cpu.ppc == op.pc
+        })
+    }
 }
 
 struct TraceRecording {
     start_pc: u32,
     cpu_type: CpuType,
     ops: Vec<TraceBuildOp>,
+    adaptive_rerecords: u8,
 }
 
 enum TraceSlot {
@@ -326,6 +354,7 @@ enum TraceSlot {
         pc: u32,
         cpu_type: CpuType,
         hits: u8,
+        adaptive_rerecords: u8,
     },
     Rejected {
         pc: u32,
@@ -538,11 +567,10 @@ impl TraceJit {
                 let by_cycles = (cpu.cycles_remaining / trace.max_cycles).max(1) as u32;
                 by_instrs.min(by_cycles)
             };
-
             let mut cycles_total = 0i64;
             let mut retired = 0u32;
             let mut full_iters = 0u32;
-            loop {
+            let guarded_branch_exit = loop {
                 #[cfg(not(target_family = "wasm"))]
                 let packed = unsafe { (trace.func)(cpu as *mut CpuCore) };
                 #[cfg(target_family = "wasm")]
@@ -550,14 +578,21 @@ impl TraceJit {
                     execute_portable_trace(cpu, &trace.ops, trace.code_start, trace.code_end);
                 cycles_total += (packed as u32) as i64;
                 let ops_done = (packed >> 32) as u32;
+                let partial_call = ops_done < ops_len;
+                let guarded_branch_exit =
+                    partial_call && trace.is_guarded_branch_exit(cpu, ops_done);
                 #[cfg(feature = "trace-profile")]
                 super::trace_profile::note_native_call(pc, cpu_type, ops_done);
+                #[cfg(feature = "trace-profile")]
+                if guarded_branch_exit {
+                    super::trace_profile::note_guarded_branch_exit(pc, cpu_type);
+                }
                 retired += ops_done;
-                if ops_done < ops_len {
+                if partial_call {
                     // A memory check bailed before its op, or a guarded
                     // interior branch took a different path. PC identifies
                     // the correct interpreter/next-trace continuation.
-                    break;
+                    break guarded_branch_exit;
                 }
                 full_iters += 1;
                 // Re-entering the (already validated) loop head is the only
@@ -566,7 +601,32 @@ impl TraceJit {
                 // committing, so nothing needs re-checking between
                 // iterations.
                 if full_iters >= max_iters || cpu.pc != pc {
-                    break;
+                    break false;
+                }
+            };
+            let mut rerecord_dominant_path = false;
+            if guarded_branch_exit
+                && trace.has_guarded_branch
+                && trace.adaptive_rerecords < TRACE_MAX_ADAPTIVE_RERECORDS
+            {
+                // A guarded exit ends this Rust entry, so `full_iters + 1`
+                // is the exact number of native calls since entry. Updating
+                // only here keeps correctly predicted traces off the
+                // adaptation hot path while still distinguishing dominant
+                // side exits from genuinely alternating branches.
+                let calls = trace
+                    .adaptive_calls
+                    .get()
+                    .saturating_add(full_iters.saturating_add(1));
+                let exits = trace.adaptive_guard_exits.get().saturating_add(1);
+                trace.adaptive_calls.set(calls);
+                trace.adaptive_guard_exits.set(exits);
+                if calls >= u32::from(TRACE_ADAPT_WINDOW) {
+                    rerecord_dominant_path = exits >= u32::from(TRACE_ADAPT_MISMATCHES)
+                        && u64::from(exits) * u64::from(TRACE_ADAPT_WINDOW)
+                            >= u64::from(calls) * u64::from(TRACE_ADAPT_MISMATCHES);
+                    trace.adaptive_calls.set(0);
+                    trace.adaptive_guard_exits.set(0);
                 }
             }
             cpu.cycles_remaining -= i32::try_from(cycles_total).unwrap_or(i32::MAX);
@@ -576,6 +636,19 @@ impl TraceJit {
                 // progress through full dispatch.
                 return None;
             }
+            if rerecord_dominant_path {
+                let adaptive_rerecords = trace.adaptive_rerecords.saturating_add(1);
+                self.slots[idx] = TraceSlot::Counting {
+                    pc,
+                    cpu_type,
+                    hits: 0,
+                    adaptive_rerecords,
+                };
+                cpu.trace_record_skip = [TRACE_PC_NONE; 4];
+                cpu.trace_probe_skip = [TRACE_PC_NONE; 4];
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_adaptive_rerecord(pc, cpu_type);
+            }
             return Some((CachedRunResult::Ran, retired));
         }
 
@@ -584,6 +657,7 @@ impl TraceJit {
                 pc: counted_pc,
                 cpu_type: counted_type,
                 hits,
+                adaptive_rerecords,
             } if *counted_pc == pc && *counted_type == cpu_type => {
                 *hits = hits.saturating_add(1);
                 if *hits < TRACE_HOT_THRESHOLD {
@@ -593,6 +667,7 @@ impl TraceJit {
                     start_pc: pc,
                     cpu_type,
                     ops: Vec::with_capacity(TRACE_MAX_OPS),
+                    adaptive_rerecords: *adaptive_rerecords,
                 });
                 #[cfg(feature = "trace-profile")]
                 super::trace_profile::note_recording(pc, cpu_type);
@@ -639,6 +714,7 @@ impl TraceJit {
                     pc,
                     cpu_type,
                     hits: 1,
+                    adaptive_rerecords: 0,
                 };
                 TRACE_JIT_HAS_CANDIDATES.store(true, Ordering::Relaxed);
             }
@@ -686,11 +762,15 @@ impl TraceJit {
         let idx = trace_cache_index(recording.start_pc);
         let start_pc = recording.start_pc;
         let cpu_type = recording.cpu_type;
+        let adaptive_rerecords = recording.adaptive_rerecords;
         #[cfg(feature = "trace-profile")]
         let recorded_ops = recording.ops.len();
         self.slots[idx] =
             match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
-                Some(trace) => TraceSlot::Compiled(trace),
+                Some(mut trace) => {
+                    trace.adaptive_rerecords = adaptive_rerecords;
+                    TraceSlot::Compiled(trace)
+                }
                 None => {
                     push_probe_skip(cpu, start_pc);
                     TraceSlot::Rejected {
@@ -1044,6 +1124,18 @@ impl TraceJit {
             needs_window,
             code_start,
             code_end,
+            has_guarded_branch: ops.iter().any(|op| {
+                matches!(
+                    op.op,
+                    JitTraceOp::Branch {
+                        expected_taken: Some(_),
+                        ..
+                    }
+                )
+            }),
+            adaptive_calls: Cell::new(0),
+            adaptive_guard_exits: Cell::new(0),
+            adaptive_rerecords: 0,
             func,
         })
     }
@@ -1061,6 +1153,18 @@ impl TraceJit {
             needs_window: params.needs_window,
             code_start: params.code_start,
             code_end: params.code_end,
+            has_guarded_branch: params.ops.iter().any(|op| {
+                matches!(
+                    op.op,
+                    JitTraceOp::Branch {
+                        expected_taken: Some(_),
+                        ..
+                    }
+                )
+            }),
+            adaptive_calls: Cell::new(0),
+            adaptive_guard_exits: Cell::new(0),
+            adaptive_rerecords: 0,
         })
     }
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -313,10 +313,10 @@ struct CompiledTrace {
     code_start: u32,
     #[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
     code_end: u32,
-    /// A recorded interior branch is a path prediction. Sample its guarded
-    /// exits in bounded windows so an initially rare path cannot permanently
-    /// strand a later dominant path in the interpreter.
-    has_guarded_branch: bool,
+    /// A recorded interior branch is a path prediction eligible for adaptive
+    /// rerecording. Cleared after the one allowed rerecord so completed traces
+    /// stay off the accounting path.
+    adaptive_branch: bool,
     adaptive_calls: Cell<u32>,
     adaptive_guard_exits: Cell<u32>,
     adaptive_rerecords: u8,
@@ -570,7 +570,7 @@ impl TraceJit {
             let mut cycles_total = 0i64;
             let mut retired = 0u32;
             let mut full_iters = 0u32;
-            let guarded_branch_exit = loop {
+            let (guarded_branch_exit, partial_call_this_entry) = loop {
                 #[cfg(not(target_family = "wasm"))]
                 let packed = unsafe { (trace.func)(cpu as *mut CpuCore) };
                 #[cfg(target_family = "wasm")]
@@ -592,7 +592,7 @@ impl TraceJit {
                     // A memory check bailed before its op, or a guarded
                     // interior branch took a different path. PC identifies
                     // the correct interpreter/next-trace continuation.
-                    break guarded_branch_exit;
+                    break (guarded_branch_exit, true);
                 }
                 full_iters += 1;
                 // Re-entering the (already validated) loop head is the only
@@ -601,24 +601,23 @@ impl TraceJit {
                 // committing, so nothing needs re-checking between
                 // iterations.
                 if full_iters >= max_iters || cpu.pc != pc {
-                    break false;
+                    break (false, false);
                 }
             };
             let mut rerecord_dominant_path = false;
-            if guarded_branch_exit
-                && trace.has_guarded_branch
-                && trace.adaptive_rerecords < TRACE_MAX_ADAPTIVE_RERECORDS
-            {
-                // A guarded exit ends this Rust entry, so `full_iters + 1`
-                // is the exact number of native calls since entry. Updating
-                // only here keeps correctly predicted traces off the
-                // adaptation hot path while still distinguishing dominant
-                // side exits from genuinely alternating branches.
+            if trace.adaptive_branch {
+                // Account once per Rust entry, not once per guest operation.
+                // Non-self-loop traces normally make one native call per
+                // entry, while self-loops may make many; both successful
+                // predictions and guarded exits belong in the denominator.
                 let calls = trace
                     .adaptive_calls
                     .get()
-                    .saturating_add(full_iters.saturating_add(1));
-                let exits = trace.adaptive_guard_exits.get().saturating_add(1);
+                    .saturating_add(full_iters.saturating_add(u32::from(partial_call_this_entry)));
+                let exits = trace
+                    .adaptive_guard_exits
+                    .get()
+                    .saturating_add(u32::from(guarded_branch_exit));
                 trace.adaptive_calls.set(calls);
                 trace.adaptive_guard_exits.set(exits);
                 if calls >= u32::from(TRACE_ADAPT_WINDOW) {
@@ -769,6 +768,9 @@ impl TraceJit {
             match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
                 Some(mut trace) => {
                     trace.adaptive_rerecords = adaptive_rerecords;
+                    if adaptive_rerecords >= TRACE_MAX_ADAPTIVE_RERECORDS {
+                        trace.adaptive_branch = false;
+                    }
                     TraceSlot::Compiled(trace)
                 }
                 None => {
@@ -1124,7 +1126,7 @@ impl TraceJit {
             needs_window,
             code_start,
             code_end,
-            has_guarded_branch: ops.iter().any(|op| {
+            adaptive_branch: ops.iter().any(|op| {
                 matches!(
                     op.op,
                     JitTraceOp::Branch {
@@ -1153,7 +1155,7 @@ impl TraceJit {
             needs_window: params.needs_window,
             code_start: params.code_start,
             code_end: params.code_end,
-            has_guarded_branch: params.ops.iter().any(|op| {
+            adaptive_branch: params.ops.iter().any(|op| {
                 matches!(
                     op.op,
                     JitTraceOp::Branch {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -33,6 +33,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const TRACE_CACHE_SIZE: usize = 4096;
 pub(crate) const TRACE_MAX_OPS: usize = 128;
 pub(crate) const TRACE_MIN_OPS: usize = 3;
+const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
 const TRACE_HOT_THRESHOLD: u8 = 2;
 
 /// Sentinel for `CpuCore::trace_record_skip` / `trace_probe_skip`: no PC.
@@ -779,7 +780,20 @@ impl TraceJit {
         ops: Vec<TraceBuildOp>,
         recorded_exit_pc: Option<u32>,
     ) -> Option<CompiledTrace> {
-        if ops.len() < TRACE_MIN_OPS || !ops.last().is_some_and(|op| op.op.ends_trace()) {
+        if !ops.last().is_some_and(|op| op.op.ends_trace()) {
+            return None;
+        }
+
+        let self_loop = recorded_exit_pc == Some(start_pc)
+            || ops
+                .last()
+                .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
+        let min_ops = if self_loop {
+            TRACE_MIN_SELF_LOOP_OPS
+        } else {
+            TRACE_MIN_OPS
+        };
+        if ops.len() < min_ops {
             return None;
         }
 
@@ -808,11 +822,6 @@ impl TraceJit {
                     .wrapping_sub(start_pc)
             );
         }
-
-        let self_loop = recorded_exit_pc == Some(start_pc)
-            || ops
-                .last()
-                .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
 
         // A checked memory CMP does not amortize trace validation and the
         // native/Rust boundary in the short non-self-loop regions measured

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -6,8 +6,9 @@
 
 use super::types::CpuType;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write;
+use std::hash::{BuildHasherDefault, Hasher};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraceProfileRow {
@@ -24,6 +25,19 @@ pub struct TraceProfileRow {
     pub jit_retired: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedMemProfileRow {
+    pub opcode: u16,
+    pub executions: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedMemSiteProfileRow {
+    pub pc: u32,
+    pub opcode: u16,
+    pub executions: u64,
+}
+
 impl TraceProfileRow {
     /// Approximate interpreter dispatches made eligible by supporting the
     /// blocker. This deliberately excludes the blocker itself: some control-
@@ -37,6 +51,8 @@ impl TraceProfileRow {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TraceProfileSnapshot {
     pub rows: Vec<TraceProfileRow>,
+    pub decoded_mem_ops: Vec<DecodedMemProfileRow>,
+    pub decoded_mem_sites: Vec<DecodedMemSiteProfileRow>,
     pub backward_hits: u64,
     pub rejected_hits: u64,
     pub native_calls: u64,
@@ -120,6 +136,55 @@ impl TraceProfileSnapshot {
                 average
             );
         }
+
+        let mut decoded_mem_ops = self.decoded_mem_ops.clone();
+        decoded_mem_ops.sort_unstable_by(|a, b| {
+            b.executions
+                .cmp(&a.executions)
+                .then_with(|| a.opcode.cmp(&b.opcode))
+        });
+        let decoded_mem_total: u64 = decoded_mem_ops.iter().map(|row| row.executions).sum();
+        let _ = writeln!(
+            out,
+            "decoded memory operations: total={decoded_mem_total} distinct_opcodes={}",
+            decoded_mem_ops.len()
+        );
+        let _ = writeln!(out, "rank  opcode  executions percent");
+        for (rank, row) in decoded_mem_ops.iter().take(40).enumerate() {
+            let percent = if decoded_mem_total == 0 {
+                0.0
+            } else {
+                row.executions as f64 * 100.0 / decoded_mem_total as f64
+            };
+            let _ = writeln!(
+                out,
+                "{:>4}  {:04X} {:>11} {:>6.2}%",
+                rank + 1,
+                row.opcode,
+                row.executions,
+                percent
+            );
+        }
+
+        let mut decoded_mem_sites = self.decoded_mem_sites.clone();
+        decoded_mem_sites.sort_unstable_by(|a, b| {
+            b.executions
+                .cmp(&a.executions)
+                .then_with(|| a.pc.cmp(&b.pc))
+                .then_with(|| a.opcode.cmp(&b.opcode))
+        });
+        let _ = writeln!(out, "decoded memory sites by execution count");
+        let _ = writeln!(out, "rank  pc        opcode  executions");
+        for (rank, row) in decoded_mem_sites.iter().take(60).enumerate() {
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:04X} {:>11}",
+                rank + 1,
+                row.pc,
+                row.opcode,
+                row.executions
+            );
+        }
         out
     }
 }
@@ -138,9 +203,46 @@ struct Row {
     jit_retired: u64,
 }
 
+/// The site key is already a uniformly useful `(pc << 16) | opcode` integer,
+/// so hashing it again only adds overhead to this hot, feature-only profiler.
 #[derive(Default)]
+struct IdentityHasher(u64);
+
+impl Hasher for IdentityHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for &byte in bytes {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        self.0 = hash;
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.0 = value;
+    }
+}
+
+type SiteCounts = HashMap<u64, u64, BuildHasherDefault<IdentityHasher>>;
+
 struct Profile {
     rows: BTreeMap<(u32, u32), Row>,
+    decoded_mem_counts: Box<[u64]>,
+    decoded_mem_site_counts: SiteCounts,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Self {
+            rows: BTreeMap::new(),
+            decoded_mem_counts: vec![0; super::op_cache::DECODE_TABLE_SIZE].into_boxed_slice(),
+            decoded_mem_site_counts: SiteCounts::default(),
+        }
+    }
 }
 
 impl Profile {
@@ -171,12 +273,34 @@ impl Profile {
                 jit_retired: row.jit_retired,
             })
             .collect();
+        let decoded_mem_ops = self
+            .decoded_mem_counts
+            .iter()
+            .enumerate()
+            .filter_map(|(opcode, &executions)| {
+                (executions != 0).then_some(DecodedMemProfileRow {
+                    opcode: opcode as u16,
+                    executions,
+                })
+            })
+            .collect();
+        let decoded_mem_sites = self
+            .decoded_mem_site_counts
+            .iter()
+            .map(|(&key, &executions)| DecodedMemSiteProfileRow {
+                pc: (key >> 16) as u32,
+                opcode: key as u16,
+                executions,
+            })
+            .collect();
         TraceProfileSnapshot {
             backward_hits: rows.iter().map(|row| row.backward_hits).sum(),
             rejected_hits: rows.iter().map(|row| row.rejected_hits).sum(),
             native_calls: rows.iter().map(|row| row.native_calls).sum(),
             jit_retired: rows.iter().map(|row| row.jit_retired).sum(),
             rows,
+            decoded_mem_ops,
+            decoded_mem_sites,
         }
     }
 }
@@ -201,6 +325,20 @@ pub fn reset() {
 
 pub fn snapshot() -> TraceProfileSnapshot {
     PROFILE.with_borrow(|profile| profile.0.snapshot())
+}
+
+pub(crate) fn note_decoded_mem(pc: u32, opcode: u16) {
+    PROFILE.with_borrow_mut(|profile| {
+        let count = &mut profile.0.decoded_mem_counts[usize::from(opcode)];
+        *count = count.saturating_add(1);
+        let site_key = (u64::from(pc) << 16) | u64::from(opcode);
+        let site_count = profile
+            .0
+            .decoded_mem_site_counts
+            .entry(site_key)
+            .or_default();
+        *site_count = site_count.saturating_add(1);
+    });
 }
 
 pub(crate) fn note_backward_edge(pc: u32, cpu_type: CpuType, rejected: bool) {
@@ -317,5 +455,48 @@ mod tests {
         assert_eq!(row.blocker_pc, Some(2));
         assert_eq!(row.blocker_opcode, Some(0x0640));
         assert_eq!(row.projected_dispatches(), row.rejected_hits);
+    }
+
+    #[test]
+    fn two_op_self_loop_is_compiled_and_runs_natively() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x4000);
+        bus.write_word(0, 0x22D8); // MOVE.L (A0)+,(A1)+
+        bus.write_word(2, 0x51C8); // DBRA D0,$0000
+        bus.write_word(4, 0xFFFC);
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(0, 0x1000);
+        cpu.set_a(1, 0x2000);
+        cpu.set_d(0, 1000);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 120, &[]);
+        assert_eq!(result.instructions, 120);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("two-op loop head was profiled");
+        assert_eq!(row.compiled_ops, 2);
+        assert!(row.native_calls > 0);
+        assert!(row.jit_retired > 0);
+    }
+
+    #[test]
+    fn report_ranks_decoded_memory_opcodes_by_execution_count() {
+        reset();
+        note_decoded_mem(0x1000, 0x20d9);
+        note_decoded_mem(0x1002, 0x10dc);
+        note_decoded_mem(0x1000, 0x20d9);
+
+        let snapshot = snapshot();
+        assert_eq!(snapshot.decoded_mem_ops.len(), 2);
+        let report = snapshot.report();
+        assert!(report.contains("decoded memory operations: total=3 distinct_opcodes=2"));
+        assert!(report.find("20D9").unwrap() < report.find("10DC").unwrap());
+        assert!(report.contains("00001000  20D9           2"));
     }
 }

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -595,6 +595,46 @@ mod tests {
     }
 
     #[test]
+    fn rare_non_self_loop_guard_exit_is_not_rerecorded() {
+        reset();
+        const HEAD: u32 = 0x8000;
+        let mut bus = LinearMemoryBus::new(0x1_0000);
+        let words = [
+            0x5340, // SUBQ.W #1,D0
+            0x6602, // BNE.S common (taken about 99% of entries)
+            0x7063, // rare: MOVEQ #99,D0
+            0x5281, // common: ADDQ.L #1,D1
+            0x51CF, 0x0004, // DBF D7,outer
+            0x4E71, // unreachable padding
+            0x4E71, // unreachable padding
+            0x7E01, // outer: MOVEQ #1,D7
+            0x60EC, // BRA.S head
+        ];
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word(HEAD + index as u32 * 2, *word);
+        }
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = HEAD;
+        cpu.set_d(0, 100);
+        cpu.set_d(7, 1);
+        assert_eq!(cpu.run_batch(&mut bus, 50_000, &[0]).instructions, 50_000);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == HEAD)
+            .expect("rare-exit loop head was profiled");
+        assert_eq!(row.recording_attempts, 1);
+        assert_eq!(row.adaptive_rerecords, 0);
+        assert_eq!(row.compiled_ops, 4);
+        assert!(row.guarded_branch_exits > 64);
+    }
+
+    #[test]
     fn report_ranks_decoded_memory_opcodes_by_execution_count() {
         reset();
         note_decoded_mem(0x1000, 0x20d9);

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -1,0 +1,321 @@
+//! Opt-in trace-JIT opportunity profiling.
+//!
+//! Enable the `trace-profile` Cargo feature and set `M68K_TRACE_PROFILE=1`
+//! to print a report when the CPU thread exits. The normal build contains
+//! none of this module or its hot-path hooks.
+
+use super::types::CpuType;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceProfileRow {
+    pub start_pc: u32,
+    pub cpu_type: CpuType,
+    pub backward_hits: u64,
+    pub rejected_hits: u64,
+    pub recording_attempts: u64,
+    pub prefix_ops: u32,
+    pub blocker_pc: Option<u32>,
+    pub blocker_opcode: Option<u16>,
+    pub compiled_ops: u32,
+    pub native_calls: u64,
+    pub jit_retired: u64,
+}
+
+impl TraceProfileRow {
+    /// Approximate interpreter dispatches made eligible by supporting the
+    /// blocker. This deliberately excludes the blocker itself: some control-
+    /// flow instructions should terminate a trace rather than execute in it.
+    pub fn projected_dispatches(&self) -> u64 {
+        self.rejected_hits
+            .saturating_mul(u64::from(self.prefix_ops))
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TraceProfileSnapshot {
+    pub rows: Vec<TraceProfileRow>,
+    pub backward_hits: u64,
+    pub rejected_hits: u64,
+    pub native_calls: u64,
+    pub jit_retired: u64,
+}
+
+impl TraceProfileSnapshot {
+    pub fn report(&self) -> String {
+        let mut rows = self.rows.clone();
+        rows.sort_unstable_by(|a, b| {
+            b.projected_dispatches()
+                .cmp(&a.projected_dispatches())
+                .then_with(|| b.backward_hits.cmp(&a.backward_hits))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+
+        let average = if self.native_calls == 0 {
+            0.0
+        } else {
+            self.jit_retired as f64 / self.native_calls as f64
+        };
+        let mut out = String::new();
+        let _ = writeln!(out, "m68k trace opportunity profile");
+        let _ = writeln!(
+            out,
+            "totals: backward_hits={} rejected_hits={} native_calls={} jit_retired={} avg_ops_per_native_call={average:.2}",
+            self.backward_hits, self.rejected_hits, self.native_calls, self.jit_retired
+        );
+        let _ = writeln!(
+            out,
+            "rank  start_pc  hits       rejected   attempts prefix projected   blocker_pc opcode  compiled calls      retired"
+        );
+        for (rank, row) in rows.iter().take(40).enumerate() {
+            let blocker_pc = row
+                .blocker_pc
+                .map_or_else(|| "--------".to_owned(), |pc| format!("{pc:08X}"));
+            let blocker_opcode = row
+                .blocker_opcode
+                .map_or_else(|| "----".to_owned(), |opcode| format!("{opcode:04X}"));
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:>10}  {:>10}  {:>8} {:>6} {:>10}   {}  {}  {:>8} {:>10} {:>12}",
+                rank + 1,
+                row.start_pc,
+                row.backward_hits,
+                row.rejected_hits,
+                row.recording_attempts,
+                row.prefix_ops,
+                row.projected_dispatches(),
+                blocker_pc,
+                blocker_opcode,
+                row.compiled_ops,
+                row.native_calls,
+                row.jit_retired
+            );
+        }
+
+        let mut compiled_rows: Vec<_> = self
+            .rows
+            .iter()
+            .filter(|row| row.native_calls != 0)
+            .collect();
+        compiled_rows.sort_unstable_by(|a, b| {
+            b.jit_retired
+                .cmp(&a.jit_retired)
+                .then_with(|| b.native_calls.cmp(&a.native_calls))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+        let _ = writeln!(out, "compiled traces by retired instructions");
+        let _ = writeln!(out, "rank  start_pc  ops      calls      retired avg_ops");
+        for (rank, row) in compiled_rows.iter().take(40).enumerate() {
+            let average = row.jit_retired as f64 / row.native_calls as f64;
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2}",
+                rank + 1,
+                row.start_pc,
+                row.compiled_ops,
+                row.native_calls,
+                row.jit_retired,
+                average
+            );
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct Row {
+    cpu_type: u32,
+    backward_hits: u64,
+    rejected_hits: u64,
+    recording_attempts: u64,
+    prefix_ops: u32,
+    blocker_pc: Option<u32>,
+    blocker_opcode: Option<u16>,
+    compiled_ops: u32,
+    native_calls: u64,
+    jit_retired: u64,
+}
+
+#[derive(Default)]
+struct Profile {
+    rows: BTreeMap<(u32, u32), Row>,
+}
+
+impl Profile {
+    fn row(&mut self, pc: u32, cpu_type: CpuType) -> &mut Row {
+        self.rows
+            .entry((pc, cpu_type as u32))
+            .or_insert_with(|| Row {
+                cpu_type: cpu_type as u32,
+                ..Row::default()
+            })
+    }
+
+    fn snapshot(&self) -> TraceProfileSnapshot {
+        let rows: Vec<_> = self
+            .rows
+            .iter()
+            .map(|(&(start_pc, _), row)| TraceProfileRow {
+                start_pc,
+                cpu_type: cpu_type_from_repr(row.cpu_type),
+                backward_hits: row.backward_hits,
+                rejected_hits: row.rejected_hits,
+                recording_attempts: row.recording_attempts,
+                prefix_ops: row.prefix_ops,
+                blocker_pc: row.blocker_pc,
+                blocker_opcode: row.blocker_opcode,
+                compiled_ops: row.compiled_ops,
+                native_calls: row.native_calls,
+                jit_retired: row.jit_retired,
+            })
+            .collect();
+        TraceProfileSnapshot {
+            backward_hits: rows.iter().map(|row| row.backward_hits).sum(),
+            rejected_hits: rows.iter().map(|row| row.rejected_hits).sum(),
+            native_calls: rows.iter().map(|row| row.native_calls).sum(),
+            jit_retired: rows.iter().map(|row| row.jit_retired).sum(),
+            rows,
+        }
+    }
+}
+
+struct ProfileState(Profile);
+
+impl Drop for ProfileState {
+    fn drop(&mut self) {
+        if std::env::var_os("M68K_TRACE_PROFILE").is_some() {
+            eprintln!("{}", self.0.snapshot().report());
+        }
+    }
+}
+
+thread_local! {
+    static PROFILE: RefCell<ProfileState> = RefCell::new(ProfileState(Profile::default()));
+}
+
+pub fn reset() {
+    PROFILE.with_borrow_mut(|profile| profile.0 = Profile::default());
+}
+
+pub fn snapshot() -> TraceProfileSnapshot {
+    PROFILE.with_borrow(|profile| profile.0.snapshot())
+}
+
+pub(crate) fn note_backward_edge(pc: u32, cpu_type: CpuType, rejected: bool) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.backward_hits = row.backward_hits.saturating_add(1);
+        if rejected {
+            row.rejected_hits = row.rejected_hits.saturating_add(1);
+        }
+    });
+}
+
+pub(crate) fn note_recording(pc: u32, cpu_type: CpuType) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.recording_attempts = row.recording_attempts.saturating_add(1);
+    });
+}
+
+pub(crate) fn note_blocker(
+    start_pc: u32,
+    cpu_type: CpuType,
+    prefix_ops: usize,
+    blocker_pc: u32,
+    blocker_opcode: u16,
+) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(start_pc, cpu_type);
+        // Keep the longest observed prefix for this trace head. It is the
+        // conservative amount of already-supported work stranded behind the
+        // blocker; path variation is visible through repeated recordings.
+        if prefix_ops as u32 >= row.prefix_ops {
+            row.prefix_ops = prefix_ops as u32;
+            row.blocker_pc = Some(blocker_pc);
+            row.blocker_opcode = Some(blocker_opcode);
+        }
+    });
+}
+
+pub(crate) fn note_compiled(pc: u32, cpu_type: CpuType, ops: usize) {
+    PROFILE.with_borrow_mut(|profile| {
+        profile.0.row(pc, cpu_type).compiled_ops = ops as u32;
+    });
+}
+
+pub(crate) fn note_native_call(pc: u32, cpu_type: CpuType, retired: u32) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.native_calls = row.native_calls.saturating_add(1);
+        row.jit_retired = row.jit_retired.saturating_add(u64::from(retired));
+    });
+}
+
+fn cpu_type_from_repr(value: u32) -> CpuType {
+    match value {
+        1 => CpuType::M68000,
+        2 => CpuType::M68010,
+        3 => CpuType::M68EC020,
+        4 => CpuType::M68020,
+        5 => CpuType::M68EC030,
+        6 => CpuType::M68030,
+        7 => CpuType::M68EC040,
+        8 => CpuType::M68LC040,
+        9 => CpuType::M68040,
+        10 => CpuType::SCC68070,
+        _ => CpuType::Invalid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AddressBus, CpuCore, LinearMemoryBus};
+
+    #[test]
+    fn report_ranks_stranded_dispatches_not_raw_hits() {
+        reset();
+        note_backward_edge(0x100, CpuType::M68040, true);
+        note_blocker(0x100, CpuType::M68040, 2, 0x104, 0x4ead);
+        for _ in 0..3 {
+            note_backward_edge(0x200, CpuType::M68040, true);
+        }
+        note_blocker(0x200, CpuType::M68040, 1, 0x202, 0x486d);
+
+        let report = snapshot().report();
+        assert!(report.find("00000200").unwrap() < report.find("00000100").unwrap());
+    }
+
+    #[test]
+    fn rejected_trace_keeps_counting_dynamic_backward_edges() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        bus.write_word(0, 0x5280); // ADDQ.L #1,D0: traceable prefix
+        bus.write_word(2, 0x0640); // ADDI.W #1,D0: untraceable blocker
+        bus.write_word(4, 0x0001);
+        bus.write_word(6, 0x60F8); // BRA.S $0000
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 120, &[]);
+        assert_eq!(result.instructions, 120);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("loop head was profiled");
+        assert_eq!(row.backward_hits, 40);
+        assert_eq!(row.rejected_hits, 39);
+        assert_eq!(row.recording_attempts, 1);
+        assert_eq!(row.prefix_ops, 1);
+        assert_eq!(row.blocker_pc, Some(2));
+        assert_eq!(row.blocker_opcode, Some(0x0640));
+        assert_eq!(row.projected_dispatches(), row.rejected_hits);
+    }
+}

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -23,6 +23,8 @@ pub struct TraceProfileRow {
     pub compiled_ops: u32,
     pub native_calls: u64,
     pub jit_retired: u64,
+    pub guarded_branch_exits: u64,
+    pub adaptive_rerecords: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -122,18 +124,23 @@ impl TraceProfileSnapshot {
                 .then_with(|| a.start_pc.cmp(&b.start_pc))
         });
         let _ = writeln!(out, "compiled traces by retired instructions");
-        let _ = writeln!(out, "rank  start_pc  ops      calls      retired avg_ops");
+        let _ = writeln!(
+            out,
+            "rank  start_pc  ops      calls      retired avg_ops guard_exits rerecords"
+        );
         for (rank, row) in compiled_rows.iter().take(40).enumerate() {
             let average = row.jit_retired as f64 / row.native_calls as f64;
             let _ = writeln!(
                 out,
-                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2}",
+                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2} {:>11} {:>9}",
                 rank + 1,
                 row.start_pc,
                 row.compiled_ops,
                 row.native_calls,
                 row.jit_retired,
-                average
+                average,
+                row.guarded_branch_exits,
+                row.adaptive_rerecords
             );
         }
 
@@ -201,6 +208,8 @@ struct Row {
     compiled_ops: u32,
     native_calls: u64,
     jit_retired: u64,
+    guarded_branch_exits: u64,
+    adaptive_rerecords: u64,
 }
 
 /// The site key is already a uniformly useful `(pc << 16) | opcode` integer,
@@ -271,6 +280,8 @@ impl Profile {
                 compiled_ops: row.compiled_ops,
                 native_calls: row.native_calls,
                 jit_retired: row.jit_retired,
+                guarded_branch_exits: row.guarded_branch_exits,
+                adaptive_rerecords: row.adaptive_rerecords,
             })
             .collect();
         let decoded_mem_ops = self
@@ -392,6 +403,20 @@ pub(crate) fn note_native_call(pc: u32, cpu_type: CpuType, retired: u32) {
     });
 }
 
+pub(crate) fn note_guarded_branch_exit(pc: u32, cpu_type: CpuType) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.guarded_branch_exits = row.guarded_branch_exits.saturating_add(1);
+    });
+}
+
+pub(crate) fn note_adaptive_rerecord(pc: u32, cpu_type: CpuType) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.adaptive_rerecords = row.adaptive_rerecords.saturating_add(1);
+    });
+}
+
 fn cpu_type_from_repr(value: u32) -> CpuType {
     match value {
         1 => CpuType::M68000,
@@ -483,6 +508,90 @@ mod tests {
         assert_eq!(row.compiled_ops, 2);
         assert!(row.native_calls > 0);
         assert!(row.jit_retired > 0);
+    }
+
+    #[test]
+    fn dominant_guard_side_exit_is_rerecorded() {
+        reset();
+        const HEAD: u32 = 0x6000;
+        let words = [
+            0xB210, // CMP.B (A0),D1
+            0x6606, // BNE.S outer
+            0x10DC, // common: MOVE.B (A4)+,(A0)+
+            0x51C8, 0xFFF8, // DBRA D0,head
+            0x2042, // outer: MOVEA.L D2,A0
+            0x2843, // MOVEA.L D3,A4
+            0x707F, // MOVEQ #127,D0
+            0x5884, // ADDQ.L #4,D4
+            0x60EC, // BRA.S head
+        ];
+        let mut bus = LinearMemoryBus::new(0x1_0000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word(HEAD + index as u32 * 2, *word);
+        }
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = HEAD;
+        cpu.set_a(0, 0x4000);
+        cpu.set_a(4, 0x5000);
+        cpu.set_d(0, 127);
+        cpu.set_d(1, 1);
+        cpu.set_d(2, 0x4000);
+        cpu.set_d(3, 0x5000);
+
+        // Record the uncommon seven-op BNE path, then make the four-op
+        // fallthrough loop dominant long enough to trigger adaptation.
+        assert_eq!(cpu.run_batch(&mut bus, 14, &[0]).instructions, 14);
+        cpu.set_d(1, 0);
+        assert_eq!(cpu.run_batch(&mut bus, 100_000, &[0]).instructions, 100_000);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == HEAD)
+            .expect("biased loop head was profiled");
+        assert_eq!(row.recording_attempts, 2);
+        assert_eq!(row.adaptive_rerecords, 1);
+        assert_eq!(row.guarded_branch_exits, 64);
+        assert_eq!(row.compiled_ops, 4);
+        assert!(row.jit_retired > 90_000);
+    }
+
+    #[test]
+    fn alternating_guard_paths_are_not_rerecorded() {
+        reset();
+        const HEAD: u32 = 0x7000;
+        let mut bus = LinearMemoryBus::new(0x1_0000);
+        let words = [
+            0x4600, // NOT.B D0: alternates Z every iteration
+            0x6602, // BNE.S skip
+            0x4E71, // opposite-path NOP
+            0x5281, // skip: ADDQ.L #1,D1
+            0x60F6, // BRA.S head
+        ];
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word(HEAD + index as u32 * 2, *word);
+        }
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = HEAD;
+        assert_eq!(cpu.run_batch(&mut bus, 100_000, &[0]).instructions, 100_000);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == HEAD)
+            .expect("alternating loop head was profiled");
+        assert_eq!(row.recording_attempts, 1);
+        assert_eq!(row.adaptive_rerecords, 0);
+        assert_eq!(row.compiled_ops, 5);
+        assert!(row.guarded_branch_exits > 1_000);
     }
 
     #[test]

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1246,3 +1246,39 @@ fn mem_trace_unaligned_matches_step_on_68020() {
         cpu.set_d(2, 0x0BAD_0001);
     });
 }
+
+/// The two memory-source CMP forms found at the hottest rejected Lemmings
+/// trace heads must compile without changing architectural behavior.
+#[test]
+fn mem_trace_cmp_sources_match_step() {
+    let indirect = &[
+        0xB210, // $1000: CMP.B (A0),D1
+        0x4E71, // $1002: NOP (three-op minimum with DBRA)
+        0x51C8, 0xFFFA, // $1004: DBRA D0,$1000
+        0xA000, // $1008: sentinel
+    ];
+    assert_fastmem_matches_step("mem-trace cmp indirect", indirect, CpuType::M68000, |cpu| {
+        cpu.set_a(0, 0x2000);
+        cpu.set_d(0, 127);
+        cpu.set_d(1, 0x1234_567F);
+        cpu.set_ccr(0x10);
+    });
+
+    let displacement = &[
+        0xBC6E, 0x0010, // $1000: CMP.W $0010(A6),D6
+        0x4E71, // $1004: NOP
+        0x51C8, 0xFFF8, // $1006: DBRA D0,$1000
+        0xA000, // $100A: sentinel
+    ];
+    assert_fastmem_matches_step(
+        "mem-trace cmp displacement",
+        displacement,
+        CpuType::M68000,
+        |cpu| {
+            cpu.set_a(6, 0x2100);
+            cpu.set_d(0, 127);
+            cpu.set_d(6, 0xCAFE_BEEF);
+            cpu.set_ccr(0x10);
+        },
+    );
+}

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -162,6 +162,68 @@ fn multi_block_trace_guard_side_exit_matches_step() {
 }
 
 #[test]
+fn multi_block_trace_path_change_matches_step() {
+    // First record the BNE path, then switch to the opposite, dominant path.
+    // The common path is the same CMP/branch/copy/DBRA topology observed in
+    // Lemmings; the outer path resets its pointers and counter.
+    let words = [
+        (0x1000, 0xB210), // CMP.B (A0),D1
+        (0x1002, 0x6606), // BNE.S outer
+        (0x1004, 0x10DC), // MOVE.B (A4)+,(A0)+
+        (0x1006, 0x51C8), // DBRA D0,head
+        (0x1008, 0xFFF8),
+        (0x100A, 0x2042), // outer: MOVEA.L D2,A0
+        (0x100C, 0x2843), // MOVEA.L D3,A4
+        (0x100E, 0x707F), // MOVEQ #127,D0
+        (0x1010, 0x5884), // ADDQ.L #4,D4
+        (0x1012, 0x60EC), // BRA.S head
+    ];
+    let prepare = || {
+        let mut cpu = cpu_at(0x1000);
+        cpu.set_a(0, 0x2000);
+        cpu.set_a(4, 0x3000);
+        cpu.set_d(0, 127);
+        cpu.set_d(1, 1);
+        cpu.set_d(2, 0x2000);
+        cpu.set_d(3, 0x3000);
+        cpu
+    };
+
+    let mut batch_bus = bus_with(&words);
+    let mut batch_cpu = prepare();
+    assert_eq!(
+        batch_cpu.run_batch(&mut batch_bus, 14, &[0]).instructions,
+        14
+    );
+    batch_cpu.set_d(1, 0);
+    let result = batch_cpu.run_batch(&mut batch_bus, 100_000, &[0]);
+    assert_eq!(result.instructions, 100_000);
+
+    let mut step_bus = bus_with(&words);
+    let mut step_cpu = prepare();
+    for _ in 0..14 {
+        assert!(matches!(
+            step_cpu.step(&mut step_bus),
+            m68k::StepResult::Ok { .. }
+        ));
+    }
+    step_cpu.set_d(1, 0);
+    for _ in 0..100_000 {
+        assert!(matches!(
+            step_cpu.step(&mut step_bus),
+            m68k::StepResult::Ok { .. }
+        ));
+    }
+
+    assert_eq!(batch_cpu.pc, step_cpu.pc);
+    assert_eq!(batch_cpu.get_sr(), step_cpu.get_sr());
+    for reg in 0..8 {
+        assert_eq!(batch_cpu.d(reg), step_cpu.d(reg), "D{reg}");
+        assert_eq!(batch_cpu.a(reg), step_cpu.a(reg), "A{reg}");
+    }
+}
+
+#[test]
 fn aline_trap_exits_without_counting_the_trap() {
     // NOP ; NOP ; A-line ; NOP
     let mut bus = bus_with(&[

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1161,6 +1161,22 @@ fn mem_trace_memcpy_loop_matches_step() {
     });
 }
 
+/// A memory operation followed immediately by DBRA is a common 68k copy-loop
+/// shape. It must remain exact when admitted as the minimum two-op self-loop.
+#[test]
+fn mem_trace_two_op_memcpy_loop_matches_step() {
+    let words = &[
+        0x22D8, // $1000: MOVE.L (A0)+,(A1)+
+        0x51C8, 0xFFFC, // $1002: DBRA D0,$1000
+        0xA000, // $1006: sentinel
+    ];
+    assert_fastmem_matches_step("two-op mem-trace memcpy", words, CpuType::M68000, |cpu| {
+        cpu.set_a(0, 0x2000);
+        cpu.set_a(1, 0x3000);
+        cpu.set_d(0, 127);
+    });
+}
+
 /// Backward word copy with pre-decrement on both sides.
 #[test]
 fn mem_trace_predec_copy_matches_step() {


### PR DESCRIPTION
## Summary

Trace regions follow the first path observed through an interior conditional branch and guard that decision at runtime. That works well while the original path remains representative, but a phase change can make the opposite path dominant. The compiled trace then side-exits on nearly every call and permanently strands the rest of the loop in decoded execution.

This change makes that path prediction adapt once:

- identify partial returns caused specifically by an interior guarded branch, rather than memory-access bailouts;
- accumulate the exact number of native calls ending at each guarded exit (`full_iters + 1`);
- after at least 64 calls, re-record when at least 48 calls (75%) used the opposite path;
- carry a one-re-record budget into the replacement trace to prevent oscillation;
- reset the per-CPU record/probe filters when retiring the stale trace;
- perform adaptation bookkeeping only on guarded exits, leaving correctly predicted traces off this path;
- expose guarded-exit and adaptive-re-record counts in the opt-in trace profiler.

The policy is shared by native Cranelift traces and the portable WebAssembly trace executor.

## Why this matters for Lemmings

The hot trace at `$0002AD5C` was recorded through an uncommon branch path. Its common path side-exited after:

```text
$0002AD5C  CMP.B  (A0),D1
            Bcc    guarded opposite path
```

and left this copy loop interpreted:

```text
$0002AD60  MOVE.B (A4)+,(A0)+
$0002AD62  DBRA   D0,$0002AD5C
```

After one adaptive re-record, `$0002AD5C` becomes the four-instruction common-path loop and executes the copy/DBRA pair inside the trace.

## Performance

### Reproducible phase-biased microbenchmark

`microbench trace-branch-bias` deliberately records a seven-op uncommon path, then changes state so a four-op CMP/branch/copy/DBRA loop becomes dominant. Five alternating fixed-binary runs produced:

| Build | Median throughput |
|---|---:|
| Parent (`cdc342a`, adaptation disabled) | 22.2 MIPS |
| Candidate | 165.6 MIPS |
| Change | **7.46x** |

The benchmark is permanent so future trace-policy changes keep covering this topology.

### Lemmings trace counters

The before/after runs retired comparable instruction totals (94,732,669 and 97,401,472 respectively):

| Metric | Before | After | Change |
|---|---:|---:|---:|
| `$2AD5C` compiled ops | 5 | 4 | dominant path captured |
| `$2AD5C` native calls | 3,179,114 | 3,081,598 | -3.1% |
| `$2AD5C` JIT-retired ops | 7,758,682 | 11,411,935 | **+47.1%** |
| `$2AD5C` average ops/call | 2.44 | 3.70 | **+51.6%** |
| `$2AD60 MOVE.B` decoded | 2,803,636 | 87,628 | **-96.9%** |
| `$2AD62 DBRA` decoded | 2,803,636 | 87,628 | **-96.9%** |
| All JIT-retired ops | 33,972,058 | 41,385,932 | **+21.8%** |
| All decoded memory ops | 31,219,481 | 26,455,087 | **-15.3%** |

The profiler recorded 459,380 guarded exits at `$2AD5C` over the full run and exactly one adaptive re-record. The large lifetime exit count includes later path variation; the replacement is intentionally not allowed to oscillate.

### 30-second macOS level-1 samples

Matched non-instrumented Systemless samples corroborate the trace counters:

| Top-of-stack symbol | Before | After | Change |
|---|---:|---:|---:|
| `FixtureRunner::run_steps_internal` | 444 | 184 | **-58.6%** |
| `m68k::core::mem_ops::execute_mem_op` | 204 | 80 | **-60.8%** |
| `MacMemoryBus::read_word` | 50 | 5 | **-90.0%** |
| host `memmove` | 148 | 80 | **-45.9%** |

These live-game samples are workload-sensitive, so the deterministic microbenchmark and guest instruction counters are the primary evidence; the host samples show that the improvement survives in the application.

The final policy refinement removed bookkeeping from correctly predicted entries and uses exact native calls rather than Rust entries as the dominance denominator. The committed benchmark and behavior tests exercise that final policy.

## Correctness and stability

- A 100,000-instruction differential test compares the phase-changing batch/JIT path against `step()`, including PC, SR, all address registers, and all data registers.
- A profiler test proves the biased seven-op trace is recorded twice, adaptively replaced once, and ends as the four-op loop.
- A deliberately alternating interior branch proves a 50/50 path does **not** re-record.
- A one-re-record budget prevents repeated path flipping even if a program later changes phase again.
- Memory-check partial exits are excluded from branch adaptation.

Validation completed:

```text
cargo test --all-targets --features trace-profile
cargo clippy --all-targets --features trace-profile -- -D warnings
git diff --check
```

All passed.

## Stack

This PR depends on #21 (`perf: JIT two-instruction self-loops`), which in turn depends on #20. Because the upstream base is `master`, GitHub temporarily displays the parent commits too. The new commit for this PR is:

```text
c9026c3 perf: adapt JIT traces to dominant branch paths
```

Review only the new layer with:

```text
git diff cdc342a...c9026c3
```

Once the parent PRs merge, this PR's visible diff will collapse to the adaptive-path commit.
