### PR TITLE
perf: JIT memory-source ADD and SUB traces

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -295,6 +295,29 @@ fn blocked_self_loop(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
     words
 }
 
+/// Isolate the largest rejected trace from the Lemmings profile: a hot
+/// region executed 24 traceable operations before `ASR.W #1,D7`, then seven
+/// more before `LSL.L #3,D0`. The surrounding ADDQs are synthetic; this
+/// benchmark measures the cost of rejecting versus compiling that topology,
+/// while the application profile measures its end-to-end importance.
+fn bench_immediate_shift_trace() {
+    let mut words = vec![0x5280; 24];
+    words.push(0xE247);
+    words.extend(std::iter::repeat_n(0x5280, 7));
+    words.push(0xE788);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    bench_batch_loop_at(
+        "batch",
+        "shift blockers p24/32",
+        &words,
+        200_000_000,
+        0x7000,
+    );
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -605,6 +628,10 @@ fn main() {
     }
     if only.as_deref() == Some("trace-branch-bias") {
         bench_trace_branch_bias();
+        return;
+    }
+    if only.as_deref() == Some("immediate-shifts") {
+        bench_immediate_shift_trace();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -318,6 +318,23 @@ fn bench_immediate_shift_trace() {
     );
 }
 
+/// Isolate the largest remaining rejected trace in the post-shift Lemmings
+/// profile: seven traceable operations followed by `ADD.W d16(A5),D7`.
+/// The ADDQ prefix is synthetic; the measured application profile establishes
+/// how often the real trace executes, while this benchmark measures the cost
+/// of admitting its memory-source ADD rather than rejecting the whole trace.
+fn bench_memory_add_trace() {
+    let words = blocked_self_loop(7, &[0xDE6D, 0x0100]);
+    bench_batch_loop_at("batch", "ADD.W d16(A5),D7 p7", &words, 200_000_000, 0x7800);
+}
+
+/// Isolate the largest rejected trace after memory-source ADD was admitted:
+/// ten traceable operations followed by `SUB.W d16(A5),D4`.
+fn bench_memory_sub_trace() {
+    let words = blocked_self_loop(10, &[0x986D, 0x0100]);
+    bench_batch_loop_at("batch", "SUB.W d16(A5),D4 p10", &words, 200_000_000, 0x7A00);
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -632,6 +649,14 @@ fn main() {
     }
     if only.as_deref() == Some("immediate-shifts") {
         bench_immediate_shift_trace();
+        return;
+    }
+    if only.as_deref() == Some("memory-add") {
+        bench_memory_add_trace();
+        return;
+    }
+    if only.as_deref() == Some("memory-sub") {
+        bench_memory_sub_trace();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -408,8 +408,22 @@ impl DecodedSimpleOp {
                 }
                 #[cfg(not(target_family = "wasm"))]
                 {
-                    let _ = (reg, size, count_or_reg, count_is_register, direction, op);
-                    None
+                    // Native traces lower the immediate-count shift forms
+                    // exercised by measured hot regions. Keep other variants
+                    // on the decoded interpreter until their flag handling is
+                    // lowered and measured independently.
+                    if !count_is_register && matches!((op, direction), (0, 0) | (1, 1)) {
+                        Some(JitTraceOp::ShiftReg {
+                            reg,
+                            size,
+                            count_or_reg,
+                            count_is_register,
+                            direction,
+                            op,
+                        })
+                    } else {
+                        None
+                    }
                 }
             }
             Self::BranchShort {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -239,8 +239,7 @@ pub(crate) enum JitTraceOp {
         dst: JitEa,
     },
     /// Read-only ALU operation from fast memory to a data register. The
-    /// initial decoder deliberately admits only CMP with `(An)`/`d16(An)`
-    /// sources; the generic shape leaves room for other read-only forms.
+    /// decoder admits measured CMP/ADD/SUB `(An)`/`d16(An)` sources.
     AluMemToReg {
         op: JitBinaryOp,
         size: Size,
@@ -1673,7 +1672,7 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
-/// CMP `<ea>,Dn` for the two addressing forms that dominate the rejected
+/// CMP/ADD/SUB `<ea>,Dn` for the two addressing forms that dominate rejected
 /// Lemmings traces. The access itself is emitted against the fastmem window;
 /// the extension word is captured for validation and displacement baking.
 fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
@@ -1683,14 +1682,15 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
     opcode: u16,
     cpu_type: CpuType,
 ) -> Option<TraceBuildOp> {
-    let DecodedMemOp::AluToReg {
-        op: BinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = DecodedMemOp::decode(cpu_type, opcode)?
+    let DecodedMemOp::AluToReg { op, size, src, dst } = DecodedMemOp::decode(cpu_type, opcode)?
     else {
         return None;
+    };
+    let op = match op {
+        BinaryOp::Cmp => JitBinaryOp::Cmp,
+        BinaryOp::Add => JitBinaryOp::Add,
+        BinaryOp::Sub => JitBinaryOp::Sub,
+        _ => return None,
     };
     let (src, extension) = match src {
         FastEa::AnInd(reg) => (JitEa::Ind(reg), None),
@@ -1705,12 +1705,7 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
         extension,
         extension2: None,
         pc,
-        op: JitTraceOp::AluMemToReg {
-            op: JitBinaryOp::Cmp,
-            size,
-            src,
-            dst,
-        },
+        op: JitTraceOp::AluMemToReg { op, size, src, dst },
     })
 }
 
@@ -1886,14 +1881,14 @@ fn execute_portable_an_disp(
 
 #[cfg(any(target_family = "wasm", test))]
 fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
-    let JitTraceOp::AluMemToReg {
-        op: JitBinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = trace.op
-    else {
+    let JitTraceOp::AluMemToReg { op, size, src, dst } = trace.op else {
         return None;
+    };
+    let op = match op {
+        JitBinaryOp::Cmp => BinaryOp::Cmp,
+        JitBinaryOp::Add => BinaryOp::Add,
+        JitBinaryOp::Sub => BinaryOp::Sub,
+        _ => return None,
     };
     let src = match src {
         JitEa::Ind(reg) => FastEa::AnInd(reg),
@@ -1902,15 +1897,7 @@ fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Op
     };
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
-    if super::mem_ops::execute_mem_op(
-        cpu,
-        DecodedMemOp::AluToReg {
-            op: BinaryOp::Cmp,
-            size,
-            src,
-            dst,
-        },
-    ) {
+    if super::mem_ops::execute_mem_op(cpu, DecodedMemOp::AluToReg { op, size, src, dst }) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -2934,14 +2921,8 @@ fn emit_alu_mem_to_reg(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::AluMemToReg {
-        op: JitBinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = trace.op
-    else {
-        unreachable!("only CMP memory-to-register traces are decoded")
+    let JitTraceOp::AluMemToReg { op, size, src, dst } = trace.op else {
+        unreachable!("expected memory-to-register ALU trace")
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -2952,7 +2933,7 @@ fn emit_alu_mem_to_reg(
 
     let base_reg = match src {
         JitEa::Ind(reg) | JitEa::Disp(reg, _) => reg,
-        _ => unreachable!("CMP trace decoder only admits (An) and d16(An)"),
+        _ => unreachable!("ALU trace decoder only admits (An) and d16(An)"),
     };
     let base = load_reg(builder, cpu, JitDirectReg::Addr(base_reg));
     let addr = match src {
@@ -2964,8 +2945,23 @@ fn emit_alu_mem_to_reg(
     let src_value = window_load(builder, env, off, size);
     let dst_value = load_reg(builder, cpu, JitDirectReg::Data(dst));
     let dst_value = mask_value(builder, dst_value, size);
-    let result = builder.ins().isub(dst_value, src_value);
-    set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+    match op {
+        JitBinaryOp::Cmp => {
+            let result = builder.ins().isub(dst_value, src_value);
+            set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        JitBinaryOp::Add => {
+            let result = builder.ins().iadd(dst_value, src_value);
+            write_data_reg_sized(builder, cpu, dst, size, result);
+            set_add_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        JitBinaryOp::Sub => {
+            let result = builder.ins().isub(dst_value, src_value);
+            write_data_reg_sized(builder, cpu, dst, size, result);
+            set_sub_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        _ => unreachable!("unsupported memory-to-register ALU operation"),
+    }
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -3985,7 +3981,7 @@ mod portable_tests {
     }
 
     #[test]
-    fn decodes_hot_cmp_memory_sources() {
+    fn decodes_hot_alu_memory_sources() {
         let cpu = cpu();
         let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
         mem.write_word(0x0100, 0xB210); // CMP.B (A0),D1
@@ -4012,6 +4008,34 @@ mod portable_tests {
                 size: Size::Word,
                 src: JitEa::Disp(6, 0x0010),
                 dst: 6,
+            }
+        ));
+
+        mem.write_word(0x0100, 0xDE6D); // ADD.W $0010(A5),D7
+        mem.write_word(0x0102, 0x0010);
+        let add = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(add.extension, Some(0x0010));
+        assert!(matches!(
+            add.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Add,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 7,
+            }
+        ));
+
+        mem.write_word(0x0100, 0x986D); // SUB.W $0010(A5),D4
+        mem.write_word(0x0102, 0x0010);
+        let sub = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(sub.extension, Some(0x0010));
+        assert!(matches!(
+            sub.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Sub,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 4,
             }
         ));
     }
@@ -4070,6 +4094,226 @@ mod portable_tests {
         assert_eq!(cpu.pc, 0x0444);
         assert_eq!(cpu.d(6), 0xCAFE_BEEF);
         assert_eq!(cpu.get_ccr(), 0x15);
+    }
+
+    #[test]
+    fn portable_add_displacement_updates_register_and_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+        mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0200);
+        cpu.set_d(7, 0xA5A5_7FFF);
+        cpu.set_ccr(0x1F);
+
+        let op = TraceBuildOp {
+            opcode: 0xDE6D,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Add,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 7,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104).is_some());
+        assert_eq!(cpu.d(7), 0xA5A5_8000);
+        assert_eq!(cpu.get_ccr(), 0x0A, "N/V set; X/Z/C clear");
+    }
+
+    #[test]
+    fn portable_sub_displacement_updates_register_and_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+        mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0200);
+        cpu.set_d(4, 0xA5A5_8000);
+        cpu.set_ccr(0x1F);
+
+        let op = TraceBuildOp {
+            opcode: 0x986D,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Sub,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 4,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104).is_some());
+        assert_eq!(cpu.d(4), 0xA5A5_7FFF);
+        assert_eq!(cpu.get_ccr(), 0x02, "V set; X/N/Z/C clear");
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_add_displacement_matches_interpreter_result() {
+        let cases = [
+            (Size::Byte, None, 0x81, 0xA5A5_557F),
+            (Size::Word, Some(0x0010), 1, 0xA5A5_7FFF),
+            (Size::Long, None, 0x8000_0000, 0x8000_0000),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, displacement, src_value, initial) in cases {
+                let dst = 7usize;
+                let addr_reg = 5usize;
+                let op_mode = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let ea_mode = if displacement.is_some() { 5 } else { 2 };
+                let opcode = 0xD000
+                    | ((dst as u16) << 9)
+                    | (op_mode << 6)
+                    | (ea_mode << 3)
+                    | addr_reg as u16;
+                let src = displacement
+                    .map(|disp| JitEa::Disp(addr_reg as u8, disp))
+                    .unwrap_or(JitEa::Ind(addr_reg as u8));
+                let branch_pc = if displacement.is_some() {
+                    0x0104
+                } else {
+                    0x0102
+                };
+                let branch_displacement = if displacement.is_some() { -6 } else { -4 };
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: displacement.map(|disp| disp as u16),
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::AluMemToReg {
+                            op: JitBinaryOp::Add,
+                            size,
+                            src,
+                            dst: dst as u8,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x6000 | branch_displacement as u8 as u16,
+                        extension: None,
+                        extension2: None,
+                        pc: branch_pc,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: branch_displacement,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(dst, initial);
+                expected.set_ccr(0x1F);
+                let mut unused_bus = super::super::memory::LinearMemoryBus::new(2);
+                let (result, _) =
+                    expected.exec_add(&mut unused_bus, size, src_value, initial & size.mask());
+                expected.set_d(dst, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                let mut mem = vec![0u8; 0x1000];
+                let address = 0x0200usize + displacement.unwrap_or(0) as usize;
+                match size {
+                    Size::Byte => mem[address] = src_value as u8,
+                    Size::Word => {
+                        mem[address..address + 2]
+                            .copy_from_slice(&(src_value as u16).to_be_bytes());
+                    }
+                    Size::Long => {
+                        mem[address..address + 4].copy_from_slice(&src_value.to_be_bytes());
+                    }
+                }
+                attach_window(&mut actual, &mut mem);
+                actual.set_cpu_type(cpu_type);
+                actual.set_a(addr_reg, 0x0200);
+                actual.set_d(dst, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native ADD loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?}");
+                assert_eq!(actual.d(dst), expected.d(dst), "{cpu_type:?} {size:?}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+            }
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_sub_displacement_matches_interpreter_result() {
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            let mut expected = cpu();
+            expected.set_cpu_type(cpu_type);
+            expected.set_d(4, 0xA5A5_8000);
+            expected.set_ccr(0x1F);
+            let mut unused_bus = super::super::memory::LinearMemoryBus::new(2);
+            let (result, _) = expected.exec_sub(&mut unused_bus, Size::Word, 1, 0x8000);
+            expected.set_d(4, 0xA5A5_0000 | result);
+
+            let mut actual = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+            attach_window(&mut actual, &mut mem);
+            actual.set_cpu_type(cpu_type);
+            actual.set_a(5, 0x0200);
+            actual.set_d(4, 0xA5A5_8000);
+            actual.set_ccr(0x1F);
+            let ops = vec![
+                TraceBuildOp {
+                    opcode: 0x986D,
+                    extension: Some(0x0010),
+                    extension2: None,
+                    pc: 0x0100,
+                    op: JitTraceOp::AluMemToReg {
+                        op: JitBinaryOp::Sub,
+                        size: Size::Word,
+                        src: JitEa::Disp(5, 0x0010),
+                        dst: 4,
+                    },
+                },
+                TraceBuildOp {
+                    opcode: 0x60FA,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0104,
+                    op: JitTraceOp::Branch {
+                        condition: 0,
+                        displacement: -6,
+                        length: 2,
+                        expected_taken: None,
+                    },
+                },
+            ];
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                .expect("native SUB loop should compile");
+            let packed = unsafe { (compiled.func)(&mut actual) };
+
+            assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?}");
+            assert_eq!(actual.d(4), expected.d(4), "{cpu_type:?}");
+            assert_eq!(actual.get_ccr(), expected.get_ccr(), "{cpu_type:?} flags");
+            assert_eq!(actual.pc, 0x0100);
+        }
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -2695,7 +2695,62 @@ fn emit_jit_op(
                 cycles_const(builder, 4)
             }
         }
-        JitTraceOp::ShiftReg { .. } => unreachable!("ShiftReg traces are wasm-only"),
+        JitTraceOp::ShiftReg {
+            reg,
+            size,
+            count_or_reg,
+            count_is_register,
+            direction,
+            op,
+        } => {
+            debug_assert!(!count_is_register && matches!((op, direction), (0, 0) | (1, 1)));
+            let shift = if count_or_reg == 0 {
+                8
+            } else {
+                u32::from(count_or_reg)
+            };
+            let value = load_reg_sized(builder, cpu, JitDirectReg::Data(reg), size);
+            let bits = size.bits() as u32;
+            let (result, shifted_out) = match (op, direction) {
+                (0, 0) => {
+                    let signed = match size {
+                        Size::Byte => sign_extend_byte(builder, value),
+                        Size::Word => sign_extend_word(builder, value),
+                        Size::Long => value,
+                    };
+                    let result = builder.ins().sshr_imm(signed, i64::from(shift));
+                    let shifted_out = if shift >= bits {
+                        let msb = iconst_u32(builder, size_msb(size));
+                        builder.ins().band(value, msb)
+                    } else {
+                        let bit = iconst_u32(builder, 1u32 << (shift - 1));
+                        builder.ins().band(value, bit)
+                    };
+                    (result, shifted_out)
+                }
+                (1, 1) => {
+                    let result = builder.ins().ishl_imm(value, i64::from(shift));
+                    let shifted_out = if shift > bits {
+                        iconst_u32(builder, 0)
+                    } else {
+                        let bit = iconst_u32(builder, 1u32 << (bits - shift));
+                        builder.ins().band(value, bit)
+                    };
+                    (result, shifted_out)
+                }
+                _ => unreachable!("unsupported native register shift"),
+            };
+            let result = mask_value(builder, result, size);
+            write_data_reg_sized(builder, cpu, reg, size, result);
+            let carry = flag_from_nonzero(builder, shifted_out, CFLAG_SET);
+            store_value_u32(builder, cpu, offset_of!(CpuCore, c_flag), carry);
+            store_value_u32(builder, cpu, offset_of!(CpuCore, x_flag), carry);
+            store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+            set_logic_flags_nv(builder, cpu, result, size);
+
+            let base = if pre020 && size == Size::Long { 8 } else { 6 };
+            cycles_const(builder, base + 2 * shift as i32)
+        }
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
         JitTraceOp::AluMemToReg { .. } => {
             unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
@@ -3286,14 +3341,19 @@ fn size_msb(size: Size) -> u32 {
 
 #[cfg(not(target_family = "wasm"))]
 fn set_logic_flags(builder: &mut FunctionBuilder<'_>, cpu: Value, value: Value, size: Size) {
+    set_logic_flags_nv(builder, cpu, value, size);
+    store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+    store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn set_logic_flags_nv(builder: &mut FunctionBuilder<'_>, cpu: Value, value: Value, size: Size) {
     let value = mask_value(builder, value, size);
     let msb = iconst_u32(builder, size_msb(size));
     let sign_bits = builder.ins().band(value, msb);
     let n = flag_from_nonzero(builder, sign_bits, NFLAG_SET);
     store_value_u32(builder, cpu, offset_of!(CpuCore, n_flag), n);
     store_value_u32(builder, cpu, offset_of!(CpuCore, not_z_flag), value);
-    store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
-    store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -4317,5 +4377,232 @@ mod portable_tests {
         assert_eq!(cpu.d(0), 0x0000_0100);
         assert_eq!(cpu.ppc, 0x0100);
         assert_eq!(cpu.ir, 0xE188);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_trace_accepts_only_supported_immediate_shift_forms() {
+        let asr = DecodedSimpleOp::decode(CpuType::M68040, 0xE247)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(matches!(
+            asr,
+            Some(JitTraceOp::ShiftReg {
+                reg: 7,
+                size: Size::Word,
+                count_or_reg: 1,
+                count_is_register: false,
+                direction: 0,
+                op: 0,
+            })
+        ));
+
+        let immediate_asl = DecodedSimpleOp::decode(CpuType::M68040, 0xE347)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(immediate_asl.is_none());
+
+        let immediate_lsl = DecodedSimpleOp::decode(CpuType::M68040, 0xE788)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(matches!(
+            immediate_lsl,
+            Some(JitTraceOp::ShiftReg {
+                reg: 0,
+                size: Size::Long,
+                count_or_reg: 3,
+                count_is_register: false,
+                direction: 1,
+                op: 1,
+            })
+        ));
+
+        let register_asr = DecodedSimpleOp::decode(CpuType::M68040, 0xE267)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(register_asr.is_none());
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_immediate_asr_matches_interpreter() {
+        let cases = [
+            (Size::Byte, 1u8, 0xA5A5_5581u32),
+            (Size::Byte, 7, 0xA5A5_557Fu32),
+            (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
+            (Size::Word, 1, 0xA5A5_8001u32), // Lemmings' E247 shape
+            (Size::Word, 4, 0xA5A5_7FF0u32),
+            (Size::Word, 0, 0xA5A5_8100u32),
+            (Size::Long, 1, 0x8000_0001u32),
+            (Size::Long, 5, 0x7FFF_FFE0u32),
+            (Size::Long, 0, 0x8100_0080u32),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, encoded_count, initial) in cases {
+                let shift = if encoded_count == 0 {
+                    8
+                } else {
+                    u32::from(encoded_count)
+                };
+                let size_code = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let opcode = 0xE000 | (u16::from(encoded_count) << 9) | (size_code << 6) | 7;
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::ShiftReg {
+                            reg: 7,
+                            size,
+                            count_or_reg: encoded_count,
+                            count_is_register: false,
+                            direction: 0,
+                            op: 0,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x60FC,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0102,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: -4,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(7, initial);
+                expected.set_ccr(0x1F);
+                let (result, shift_cycles) = expected.exec_asr(size, shift, initial & size.mask());
+                expected.set_d(7, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                actual.set_cpu_type(cpu_type);
+                actual.set_d(7, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native ASR loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    packed as u32 as i32,
+                    shift_cycles + 10,
+                    "{cpu_type:?} {size:?} #{shift} cycles"
+                );
+                assert_eq!(actual.d(7), expected.d(7), "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} #{shift} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+                assert_eq!(actual.ppc, 0x0102);
+                assert_eq!(actual.ir, 0x60FC);
+            }
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_immediate_lsl_matches_interpreter() {
+        let cases = [
+            (Size::Byte, 1u8, 0xA5A5_5581u32),
+            (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
+            (Size::Word, 4, 0xA5A5_1801u32),
+            (Size::Word, 0, 0xA5A5_8180u32),
+            (Size::Long, 3, 0x9000_0001u32), // Lemmings' E788 shape
+            (Size::Long, 0, 0x0180_0081u32),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, encoded_count, initial) in cases {
+                let shift = if encoded_count == 0 {
+                    8
+                } else {
+                    u32::from(encoded_count)
+                };
+                let size_code = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let opcode = 0xE108 | (u16::from(encoded_count) << 9) | (size_code << 6);
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::ShiftReg {
+                            reg: 0,
+                            size,
+                            count_or_reg: encoded_count,
+                            count_is_register: false,
+                            direction: 1,
+                            op: 1,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x60FC,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0102,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: -4,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(0, initial);
+                expected.set_ccr(0x1F);
+                let (result, shift_cycles) = expected.exec_lsl(size, shift, initial & size.mask());
+                expected.set_d(0, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                actual.set_cpu_type(cpu_type);
+                actual.set_d(0, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native LSL loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    packed as u32 as i32,
+                    shift_cycles + 10,
+                    "{cpu_type:?} {size:?} #{shift} cycles"
+                );
+                assert_eq!(actual.d(0), expected.d(0), "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} #{shift} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+                assert_eq!(actual.ppc, 0x0102);
+                assert_eq!(actual.ir, 0x60FC);
+            }
+        }
     }
 }


### PR DESCRIPTION
Depends on #25. Please review the final commit independently; once #25 lands, GitHub will remove that prerequisite commit from this diff.

## Summary

- extend the existing native memory-to-register ALU trace operation from `CMP` to `ADD` and `SUB`
- support the measured `(An)` and `d16(An)` source forms at byte, word, and long widths
- write only the selected portion of the destination data register and reproduce 68k X/N/Z/V/C behavior
- retain checked fast-memory access and bail before changing architectural state when the source is outside the active window
- add portable and native differential tests plus permanent Lemmings-derived ADD and SUB microbenchmarks

## Why

After #25 admitted the immediate shifts, Lemmings' largest remaining rejected regions ended at:

- seven traceable operations followed by `ADD.W d16(A5),D7`
- ten traceable operations followed by `SUB.W d16(A5),D4`

The JIT already had the addressing, bounds checks, loads, and flag infrastructure for memory-source `CMP`; treating ADD/SUB as unrelated slow-path operations discarded the surrounding hot traces.

## Profiling

The committed benchmarks preserve those observed trace shapes. Before/after release results collected while developing this change were:

| Lemmings-derived case | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `ADD.W d16(A5),D7`, 7-op prefix | 55.7 M instr/s | 292.7 M instr/s | **5.25x** |
| `SUB.W d16(A5),D4`, 10-op prefix | 51.7 M instr/s | 283.0 M instr/s | **5.47x** |

The application profile confirmed both operations are real hot work rather than synthetic-only opportunities:

- the ADD-containing trace at guest `$286F6` compiled and retired 671,691 guest instructions in the final validation run
- the SUB-containing trace at `$22DD0` compiled as 15 operations, ran 105,211 times, and retired 1,515,221 guest instructions (14.40 per call on average)

A matched whole-runner sample dropped from 559 to 467 runner-closure samples (-16.5%). That end-to-end number is indicative rather than a causal microbenchmark because gameplay phase and adaptive trace choices introduce noise; the isolated rows above are the controlled before/after evidence.

## Correctness

- native results are checked against the interpreter for 68000 and 68040 CPU modes
- tests cover byte/word/long partial-register writes, `(An)` and displacement addressing, arithmetic edge cases, and all X/N/Z/V/C flags
- `cargo test --all-features` passes on the rebased stack, including Musashi and 127 single-step cases
