### PR TITLE
perf: JIT profitable indirect JSR boundaries

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -295,6 +295,29 @@ fn blocked_self_loop(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
     words
 }
 
+/// Isolate the largest rejected trace from the Lemmings profile: a hot
+/// region executed 24 traceable operations before `ASR.W #1,D7`, then seven
+/// more before `LSL.L #3,D0`. The surrounding ADDQs are synthetic; this
+/// benchmark measures the cost of rejecting versus compiling that topology,
+/// while the application profile measures its end-to-end importance.
+fn bench_immediate_shift_trace() {
+    let mut words = vec![0x5280; 24];
+    words.push(0xE247);
+    words.extend(std::iter::repeat_n(0x5280, 7));
+    words.push(0xE788);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    bench_batch_loop_at(
+        "batch",
+        "shift blockers p24/32",
+        &words,
+        200_000_000,
+        0x7000,
+    );
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -605,6 +628,10 @@ fn main() {
     }
     if only.as_deref() == Some("trace-branch-bias") {
         bench_trace_branch_bias();
+        return;
+    }
+    if only.as_deref() == Some("immediate-shifts") {
+        bench_immediate_shift_trace();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -335,6 +335,134 @@ fn bench_memory_sub_trace() {
     bench_batch_loop_at("batch", "SUB.W d16(A5),D4 p10", &words, 200_000_000, 0x7A00);
 }
 
+#[derive(Clone, Copy)]
+enum IndirectJsrMix {
+    Register,
+    MemoryAlu,
+    MemoryHeavy,
+}
+
+impl IndirectJsrMix {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "register" => Some(Self::Register),
+            "memory-alu" => Some(Self::MemoryAlu),
+            "memory-heavy" => Some(Self::MemoryHeavy),
+            _ => None,
+        }
+    }
+
+    fn index(self) -> u32 {
+        match self {
+            Self::Register => 0,
+            Self::MemoryAlu => 1,
+            Self::MemoryHeavy => 2,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Register => "register",
+            Self::MemoryAlu => "memory-ALU",
+            Self::MemoryHeavy => "memory-heavy",
+        }
+    }
+
+    fn append_prefix_op(self, words: &mut Vec<u16>, index: usize) {
+        match self {
+            Self::Register => words.push(0x5280), // ADDQ.L #1,D0
+            Self::MemoryAlu if index == 0 => {
+                words.extend_from_slice(&[0x986D, 0x0100]); // SUB.W $0100(A5),D4
+            }
+            Self::MemoryAlu => words.push(0x5280), // ADDQ.L #1,D0
+            Self::MemoryHeavy => {
+                let op: &[u16] = match index % 4 {
+                    0 => &[0x986D, 0x0100], // SUB.W $0100(A5),D4
+                    1 => &[0x322D, 0x0100], // MOVE.W $0100(A5),D1
+                    2 => &[0x526D, 0x0100], // ADDQ.W #1,$0100(A5)
+                    _ => &[0x4A2D, 0x0100], // TST.B $0100(A5)
+                };
+                words.extend_from_slice(op);
+            }
+        }
+    }
+}
+
+/// Measure a non-self-loop region ending in `JSR (A0)`, followed by an RTS
+/// and a backward branch that re-enters the region. The three mixes separate
+/// fixed trace/call overhead from the savings available for register-only,
+/// Lemmings-like memory-ALU, and memory-heavy Classic Mac code.
+fn measure_indirect_jsr_region(
+    mix: IndirectJsrMix,
+    head_ops: usize,
+    instrs: u32,
+    code_base: u32,
+) -> f64 {
+    assert!((3..=24).contains(&head_ops));
+    let mut words = Vec::new();
+    for index in 0..head_ops - 1 {
+        mix.append_prefix_op(&mut words, index);
+    }
+    words.push(0x4E90); // JSR (A0)
+    let branch_word = words.len();
+    let bytes_after_branch = (branch_word + 1) * 2;
+    let back_disp = -(bytes_after_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | back_disp as u8 as u16); // return path: BRA.S head
+    let rts_word = words.len();
+    words.push(0x4E75); // subroutine: RTS
+
+    let mut bus = LinearMemoryBus::new(0x10000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(code_base + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = code_base;
+        cpu.set_a(0, code_base + rts_word as u32 * 2);
+        cpu.set_a(5, 0x1000);
+        cpu.set_a(7, 0xF000);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    let warm = warm_cpu.run_batch(&mut bus, 5_000_000, &[0]);
+    assert_eq!(warm.instructions, 5_000_000);
+
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    let result = cpu.run_batch(&mut bus, instrs, &[0]);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(result.instructions, instrs);
+    elapsed
+}
+
+fn bench_indirect_jsr_regions() {
+    const INSTRS: u32 = 50_000_000;
+    let mixes = [
+        IndirectJsrMix::Register,
+        IndirectJsrMix::MemoryAlu,
+        IndirectJsrMix::MemoryHeavy,
+    ];
+    for mix in mixes {
+        for head_ops in 3usize..=12 {
+            bench_indirect_jsr_case(mix, head_ops, INSTRS);
+        }
+    }
+}
+
+fn bench_indirect_jsr_case(mix: IndirectJsrMix, head_ops: usize, instrs: u32) {
+    let code_base = 0x4000 + mix.index() * 0x1000 + head_ops as u32 * 0x80;
+    let elapsed = measure_indirect_jsr_region(mix, head_ops, instrs, code_base);
+    println!(
+        "batch     JSR {:12} {head_ops:2} {:8.1} M instr/s",
+        mix.label(),
+        f64::from(instrs) / elapsed / 1_000_000.0
+    );
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -657,6 +785,25 @@ fn main() {
     }
     if only.as_deref() == Some("memory-sub") {
         bench_memory_sub_trace();
+        return;
+    }
+    if only.as_deref() == Some("indirect-jsr") {
+        match (std::env::args().nth(2), std::env::args().nth(3)) {
+            (Some(mix), Some(head_ops)) => {
+                let mix = IndirectJsrMix::parse(&mix)
+                    .expect("indirect-jsr mix must be register, memory-alu, or memory-heavy");
+                let head_ops = head_ops
+                    .parse()
+                    .expect("indirect-jsr op count must be an integer");
+                let instrs = std::env::args()
+                    .nth(4)
+                    .map(|value| value.parse().expect("instruction count must be an integer"))
+                    .unwrap_or(50_000_000);
+                bench_indirect_jsr_case(mix, head_ops, instrs);
+            }
+            (None, None) => bench_indirect_jsr_regions(),
+            _ => panic!("indirect-jsr requires both a mix and an operation count"),
+        }
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -318,6 +318,23 @@ fn bench_immediate_shift_trace() {
     );
 }
 
+/// Isolate the largest remaining rejected trace in the post-shift Lemmings
+/// profile: seven traceable operations followed by `ADD.W d16(A5),D7`.
+/// The ADDQ prefix is synthetic; the measured application profile establishes
+/// how often the real trace executes, while this benchmark measures the cost
+/// of admitting its memory-source ADD rather than rejecting the whole trace.
+fn bench_memory_add_trace() {
+    let words = blocked_self_loop(7, &[0xDE6D, 0x0100]);
+    bench_batch_loop_at("batch", "ADD.W d16(A5),D7 p7", &words, 200_000_000, 0x7800);
+}
+
+/// Isolate the largest rejected trace after memory-source ADD was admitted:
+/// ten traceable operations followed by `SUB.W d16(A5),D4`.
+fn bench_memory_sub_trace() {
+    let words = blocked_self_loop(10, &[0x986D, 0x0100]);
+    bench_batch_loop_at("batch", "SUB.W d16(A5),D4 p10", &words, 200_000_000, 0x7A00);
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -632,6 +649,14 @@ fn main() {
     }
     if only.as_deref() == Some("immediate-shifts") {
         bench_immediate_shift_trace();
+        return;
+    }
+    if only.as_deref() == Some("memory-add") {
+        bench_memory_add_trace();
+        return;
+    }
+    if only.as_deref() == Some("memory-sub") {
+        bench_memory_sub_trace();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -408,8 +408,22 @@ impl DecodedSimpleOp {
                 }
                 #[cfg(not(target_family = "wasm"))]
                 {
-                    let _ = (reg, size, count_or_reg, count_is_register, direction, op);
-                    None
+                    // Native traces lower the immediate-count shift forms
+                    // exercised by measured hot regions. Keep other variants
+                    // on the decoded interpreter until their flag handling is
+                    // lowered and measured independently.
+                    if !count_is_register && matches!((op, direction), (0, 0) | (1, 1)) {
+                        Some(JitTraceOp::ShiftReg {
+                            reg,
+                            size,
+                            count_or_reg,
+                            count_is_register,
+                            direction,
+                            op,
+                        })
+                    } else {
+                        None
+                    }
                 }
             }
             Self::BranchShort {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -239,8 +239,7 @@ pub(crate) enum JitTraceOp {
         dst: JitEa,
     },
     /// Read-only ALU operation from fast memory to a data register. The
-    /// initial decoder deliberately admits only CMP with `(An)`/`d16(An)`
-    /// sources; the generic shape leaves room for other read-only forms.
+    /// decoder admits measured CMP/ADD/SUB `(An)`/`d16(An)` sources.
     AluMemToReg {
         op: JitBinaryOp,
         size: Size,
@@ -1673,7 +1672,7 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
-/// CMP `<ea>,Dn` for the two addressing forms that dominate the rejected
+/// CMP/ADD/SUB `<ea>,Dn` for the two addressing forms that dominate rejected
 /// Lemmings traces. The access itself is emitted against the fastmem window;
 /// the extension word is captured for validation and displacement baking.
 fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
@@ -1683,14 +1682,15 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
     opcode: u16,
     cpu_type: CpuType,
 ) -> Option<TraceBuildOp> {
-    let DecodedMemOp::AluToReg {
-        op: BinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = DecodedMemOp::decode(cpu_type, opcode)?
+    let DecodedMemOp::AluToReg { op, size, src, dst } = DecodedMemOp::decode(cpu_type, opcode)?
     else {
         return None;
+    };
+    let op = match op {
+        BinaryOp::Cmp => JitBinaryOp::Cmp,
+        BinaryOp::Add => JitBinaryOp::Add,
+        BinaryOp::Sub => JitBinaryOp::Sub,
+        _ => return None,
     };
     let (src, extension) = match src {
         FastEa::AnInd(reg) => (JitEa::Ind(reg), None),
@@ -1705,12 +1705,7 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
         extension,
         extension2: None,
         pc,
-        op: JitTraceOp::AluMemToReg {
-            op: JitBinaryOp::Cmp,
-            size,
-            src,
-            dst,
-        },
+        op: JitTraceOp::AluMemToReg { op, size, src, dst },
     })
 }
 
@@ -1886,14 +1881,14 @@ fn execute_portable_an_disp(
 
 #[cfg(any(target_family = "wasm", test))]
 fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
-    let JitTraceOp::AluMemToReg {
-        op: JitBinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = trace.op
-    else {
+    let JitTraceOp::AluMemToReg { op, size, src, dst } = trace.op else {
         return None;
+    };
+    let op = match op {
+        JitBinaryOp::Cmp => BinaryOp::Cmp,
+        JitBinaryOp::Add => BinaryOp::Add,
+        JitBinaryOp::Sub => BinaryOp::Sub,
+        _ => return None,
     };
     let src = match src {
         JitEa::Ind(reg) => FastEa::AnInd(reg),
@@ -1902,15 +1897,7 @@ fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Op
     };
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
-    if super::mem_ops::execute_mem_op(
-        cpu,
-        DecodedMemOp::AluToReg {
-            op: BinaryOp::Cmp,
-            size,
-            src,
-            dst,
-        },
-    ) {
+    if super::mem_ops::execute_mem_op(cpu, DecodedMemOp::AluToReg { op, size, src, dst }) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -2934,14 +2921,8 @@ fn emit_alu_mem_to_reg(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::AluMemToReg {
-        op: JitBinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = trace.op
-    else {
-        unreachable!("only CMP memory-to-register traces are decoded")
+    let JitTraceOp::AluMemToReg { op, size, src, dst } = trace.op else {
+        unreachable!("expected memory-to-register ALU trace")
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -2952,7 +2933,7 @@ fn emit_alu_mem_to_reg(
 
     let base_reg = match src {
         JitEa::Ind(reg) | JitEa::Disp(reg, _) => reg,
-        _ => unreachable!("CMP trace decoder only admits (An) and d16(An)"),
+        _ => unreachable!("ALU trace decoder only admits (An) and d16(An)"),
     };
     let base = load_reg(builder, cpu, JitDirectReg::Addr(base_reg));
     let addr = match src {
@@ -2964,8 +2945,23 @@ fn emit_alu_mem_to_reg(
     let src_value = window_load(builder, env, off, size);
     let dst_value = load_reg(builder, cpu, JitDirectReg::Data(dst));
     let dst_value = mask_value(builder, dst_value, size);
-    let result = builder.ins().isub(dst_value, src_value);
-    set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+    match op {
+        JitBinaryOp::Cmp => {
+            let result = builder.ins().isub(dst_value, src_value);
+            set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        JitBinaryOp::Add => {
+            let result = builder.ins().iadd(dst_value, src_value);
+            write_data_reg_sized(builder, cpu, dst, size, result);
+            set_add_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        JitBinaryOp::Sub => {
+            let result = builder.ins().isub(dst_value, src_value);
+            write_data_reg_sized(builder, cpu, dst, size, result);
+            set_sub_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        _ => unreachable!("unsupported memory-to-register ALU operation"),
+    }
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -3985,7 +3981,7 @@ mod portable_tests {
     }
 
     #[test]
-    fn decodes_hot_cmp_memory_sources() {
+    fn decodes_hot_alu_memory_sources() {
         let cpu = cpu();
         let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
         mem.write_word(0x0100, 0xB210); // CMP.B (A0),D1
@@ -4012,6 +4008,34 @@ mod portable_tests {
                 size: Size::Word,
                 src: JitEa::Disp(6, 0x0010),
                 dst: 6,
+            }
+        ));
+
+        mem.write_word(0x0100, 0xDE6D); // ADD.W $0010(A5),D7
+        mem.write_word(0x0102, 0x0010);
+        let add = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(add.extension, Some(0x0010));
+        assert!(matches!(
+            add.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Add,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 7,
+            }
+        ));
+
+        mem.write_word(0x0100, 0x986D); // SUB.W $0010(A5),D4
+        mem.write_word(0x0102, 0x0010);
+        let sub = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(sub.extension, Some(0x0010));
+        assert!(matches!(
+            sub.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Sub,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 4,
             }
         ));
     }
@@ -4070,6 +4094,226 @@ mod portable_tests {
         assert_eq!(cpu.pc, 0x0444);
         assert_eq!(cpu.d(6), 0xCAFE_BEEF);
         assert_eq!(cpu.get_ccr(), 0x15);
+    }
+
+    #[test]
+    fn portable_add_displacement_updates_register_and_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+        mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0200);
+        cpu.set_d(7, 0xA5A5_7FFF);
+        cpu.set_ccr(0x1F);
+
+        let op = TraceBuildOp {
+            opcode: 0xDE6D,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Add,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 7,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104).is_some());
+        assert_eq!(cpu.d(7), 0xA5A5_8000);
+        assert_eq!(cpu.get_ccr(), 0x0A, "N/V set; X/Z/C clear");
+    }
+
+    #[test]
+    fn portable_sub_displacement_updates_register_and_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+        mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0200);
+        cpu.set_d(4, 0xA5A5_8000);
+        cpu.set_ccr(0x1F);
+
+        let op = TraceBuildOp {
+            opcode: 0x986D,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Sub,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 4,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104).is_some());
+        assert_eq!(cpu.d(4), 0xA5A5_7FFF);
+        assert_eq!(cpu.get_ccr(), 0x02, "V set; X/N/Z/C clear");
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_add_displacement_matches_interpreter_result() {
+        let cases = [
+            (Size::Byte, None, 0x81, 0xA5A5_557F),
+            (Size::Word, Some(0x0010), 1, 0xA5A5_7FFF),
+            (Size::Long, None, 0x8000_0000, 0x8000_0000),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, displacement, src_value, initial) in cases {
+                let dst = 7usize;
+                let addr_reg = 5usize;
+                let op_mode = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let ea_mode = if displacement.is_some() { 5 } else { 2 };
+                let opcode = 0xD000
+                    | ((dst as u16) << 9)
+                    | (op_mode << 6)
+                    | (ea_mode << 3)
+                    | addr_reg as u16;
+                let src = displacement
+                    .map(|disp| JitEa::Disp(addr_reg as u8, disp))
+                    .unwrap_or(JitEa::Ind(addr_reg as u8));
+                let branch_pc = if displacement.is_some() {
+                    0x0104
+                } else {
+                    0x0102
+                };
+                let branch_displacement = if displacement.is_some() { -6 } else { -4 };
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: displacement.map(|disp| disp as u16),
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::AluMemToReg {
+                            op: JitBinaryOp::Add,
+                            size,
+                            src,
+                            dst: dst as u8,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x6000 | branch_displacement as u8 as u16,
+                        extension: None,
+                        extension2: None,
+                        pc: branch_pc,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: branch_displacement,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(dst, initial);
+                expected.set_ccr(0x1F);
+                let mut unused_bus = super::super::memory::LinearMemoryBus::new(2);
+                let (result, _) =
+                    expected.exec_add(&mut unused_bus, size, src_value, initial & size.mask());
+                expected.set_d(dst, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                let mut mem = vec![0u8; 0x1000];
+                let address = 0x0200usize + displacement.unwrap_or(0) as usize;
+                match size {
+                    Size::Byte => mem[address] = src_value as u8,
+                    Size::Word => {
+                        mem[address..address + 2]
+                            .copy_from_slice(&(src_value as u16).to_be_bytes());
+                    }
+                    Size::Long => {
+                        mem[address..address + 4].copy_from_slice(&src_value.to_be_bytes());
+                    }
+                }
+                attach_window(&mut actual, &mut mem);
+                actual.set_cpu_type(cpu_type);
+                actual.set_a(addr_reg, 0x0200);
+                actual.set_d(dst, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native ADD loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?}");
+                assert_eq!(actual.d(dst), expected.d(dst), "{cpu_type:?} {size:?}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+            }
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_sub_displacement_matches_interpreter_result() {
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            let mut expected = cpu();
+            expected.set_cpu_type(cpu_type);
+            expected.set_d(4, 0xA5A5_8000);
+            expected.set_ccr(0x1F);
+            let mut unused_bus = super::super::memory::LinearMemoryBus::new(2);
+            let (result, _) = expected.exec_sub(&mut unused_bus, Size::Word, 1, 0x8000);
+            expected.set_d(4, 0xA5A5_0000 | result);
+
+            let mut actual = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+            attach_window(&mut actual, &mut mem);
+            actual.set_cpu_type(cpu_type);
+            actual.set_a(5, 0x0200);
+            actual.set_d(4, 0xA5A5_8000);
+            actual.set_ccr(0x1F);
+            let ops = vec![
+                TraceBuildOp {
+                    opcode: 0x986D,
+                    extension: Some(0x0010),
+                    extension2: None,
+                    pc: 0x0100,
+                    op: JitTraceOp::AluMemToReg {
+                        op: JitBinaryOp::Sub,
+                        size: Size::Word,
+                        src: JitEa::Disp(5, 0x0010),
+                        dst: 4,
+                    },
+                },
+                TraceBuildOp {
+                    opcode: 0x60FA,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0104,
+                    op: JitTraceOp::Branch {
+                        condition: 0,
+                        displacement: -6,
+                        length: 2,
+                        expected_taken: None,
+                    },
+                },
+            ];
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                .expect("native SUB loop should compile");
+            let packed = unsafe { (compiled.func)(&mut actual) };
+
+            assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?}");
+            assert_eq!(actual.d(4), expected.d(4), "{cpu_type:?}");
+            assert_eq!(actual.get_ccr(), expected.get_ccr(), "{cpu_type:?} flags");
+            assert_eq!(actual.pc, 0x0100);
+        }
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -2695,7 +2695,62 @@ fn emit_jit_op(
                 cycles_const(builder, 4)
             }
         }
-        JitTraceOp::ShiftReg { .. } => unreachable!("ShiftReg traces are wasm-only"),
+        JitTraceOp::ShiftReg {
+            reg,
+            size,
+            count_or_reg,
+            count_is_register,
+            direction,
+            op,
+        } => {
+            debug_assert!(!count_is_register && matches!((op, direction), (0, 0) | (1, 1)));
+            let shift = if count_or_reg == 0 {
+                8
+            } else {
+                u32::from(count_or_reg)
+            };
+            let value = load_reg_sized(builder, cpu, JitDirectReg::Data(reg), size);
+            let bits = size.bits() as u32;
+            let (result, shifted_out) = match (op, direction) {
+                (0, 0) => {
+                    let signed = match size {
+                        Size::Byte => sign_extend_byte(builder, value),
+                        Size::Word => sign_extend_word(builder, value),
+                        Size::Long => value,
+                    };
+                    let result = builder.ins().sshr_imm(signed, i64::from(shift));
+                    let shifted_out = if shift >= bits {
+                        let msb = iconst_u32(builder, size_msb(size));
+                        builder.ins().band(value, msb)
+                    } else {
+                        let bit = iconst_u32(builder, 1u32 << (shift - 1));
+                        builder.ins().band(value, bit)
+                    };
+                    (result, shifted_out)
+                }
+                (1, 1) => {
+                    let result = builder.ins().ishl_imm(value, i64::from(shift));
+                    let shifted_out = if shift > bits {
+                        iconst_u32(builder, 0)
+                    } else {
+                        let bit = iconst_u32(builder, 1u32 << (bits - shift));
+                        builder.ins().band(value, bit)
+                    };
+                    (result, shifted_out)
+                }
+                _ => unreachable!("unsupported native register shift"),
+            };
+            let result = mask_value(builder, result, size);
+            write_data_reg_sized(builder, cpu, reg, size, result);
+            let carry = flag_from_nonzero(builder, shifted_out, CFLAG_SET);
+            store_value_u32(builder, cpu, offset_of!(CpuCore, c_flag), carry);
+            store_value_u32(builder, cpu, offset_of!(CpuCore, x_flag), carry);
+            store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+            set_logic_flags_nv(builder, cpu, result, size);
+
+            let base = if pre020 && size == Size::Long { 8 } else { 6 };
+            cycles_const(builder, base + 2 * shift as i32)
+        }
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
         JitTraceOp::AluMemToReg { .. } => {
             unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
@@ -3286,14 +3341,19 @@ fn size_msb(size: Size) -> u32 {
 
 #[cfg(not(target_family = "wasm"))]
 fn set_logic_flags(builder: &mut FunctionBuilder<'_>, cpu: Value, value: Value, size: Size) {
+    set_logic_flags_nv(builder, cpu, value, size);
+    store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+    store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn set_logic_flags_nv(builder: &mut FunctionBuilder<'_>, cpu: Value, value: Value, size: Size) {
     let value = mask_value(builder, value, size);
     let msb = iconst_u32(builder, size_msb(size));
     let sign_bits = builder.ins().band(value, msb);
     let n = flag_from_nonzero(builder, sign_bits, NFLAG_SET);
     store_value_u32(builder, cpu, offset_of!(CpuCore, n_flag), n);
     store_value_u32(builder, cpu, offset_of!(CpuCore, not_z_flag), value);
-    store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
-    store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -4317,5 +4377,232 @@ mod portable_tests {
         assert_eq!(cpu.d(0), 0x0000_0100);
         assert_eq!(cpu.ppc, 0x0100);
         assert_eq!(cpu.ir, 0xE188);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_trace_accepts_only_supported_immediate_shift_forms() {
+        let asr = DecodedSimpleOp::decode(CpuType::M68040, 0xE247)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(matches!(
+            asr,
+            Some(JitTraceOp::ShiftReg {
+                reg: 7,
+                size: Size::Word,
+                count_or_reg: 1,
+                count_is_register: false,
+                direction: 0,
+                op: 0,
+            })
+        ));
+
+        let immediate_asl = DecodedSimpleOp::decode(CpuType::M68040, 0xE347)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(immediate_asl.is_none());
+
+        let immediate_lsl = DecodedSimpleOp::decode(CpuType::M68040, 0xE788)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(matches!(
+            immediate_lsl,
+            Some(JitTraceOp::ShiftReg {
+                reg: 0,
+                size: Size::Long,
+                count_or_reg: 3,
+                count_is_register: false,
+                direction: 1,
+                op: 1,
+            })
+        ));
+
+        let register_asr = DecodedSimpleOp::decode(CpuType::M68040, 0xE267)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(register_asr.is_none());
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_immediate_asr_matches_interpreter() {
+        let cases = [
+            (Size::Byte, 1u8, 0xA5A5_5581u32),
+            (Size::Byte, 7, 0xA5A5_557Fu32),
+            (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
+            (Size::Word, 1, 0xA5A5_8001u32), // Lemmings' E247 shape
+            (Size::Word, 4, 0xA5A5_7FF0u32),
+            (Size::Word, 0, 0xA5A5_8100u32),
+            (Size::Long, 1, 0x8000_0001u32),
+            (Size::Long, 5, 0x7FFF_FFE0u32),
+            (Size::Long, 0, 0x8100_0080u32),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, encoded_count, initial) in cases {
+                let shift = if encoded_count == 0 {
+                    8
+                } else {
+                    u32::from(encoded_count)
+                };
+                let size_code = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let opcode = 0xE000 | (u16::from(encoded_count) << 9) | (size_code << 6) | 7;
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::ShiftReg {
+                            reg: 7,
+                            size,
+                            count_or_reg: encoded_count,
+                            count_is_register: false,
+                            direction: 0,
+                            op: 0,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x60FC,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0102,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: -4,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(7, initial);
+                expected.set_ccr(0x1F);
+                let (result, shift_cycles) = expected.exec_asr(size, shift, initial & size.mask());
+                expected.set_d(7, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                actual.set_cpu_type(cpu_type);
+                actual.set_d(7, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native ASR loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    packed as u32 as i32,
+                    shift_cycles + 10,
+                    "{cpu_type:?} {size:?} #{shift} cycles"
+                );
+                assert_eq!(actual.d(7), expected.d(7), "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} #{shift} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+                assert_eq!(actual.ppc, 0x0102);
+                assert_eq!(actual.ir, 0x60FC);
+            }
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_immediate_lsl_matches_interpreter() {
+        let cases = [
+            (Size::Byte, 1u8, 0xA5A5_5581u32),
+            (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
+            (Size::Word, 4, 0xA5A5_1801u32),
+            (Size::Word, 0, 0xA5A5_8180u32),
+            (Size::Long, 3, 0x9000_0001u32), // Lemmings' E788 shape
+            (Size::Long, 0, 0x0180_0081u32),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, encoded_count, initial) in cases {
+                let shift = if encoded_count == 0 {
+                    8
+                } else {
+                    u32::from(encoded_count)
+                };
+                let size_code = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let opcode = 0xE108 | (u16::from(encoded_count) << 9) | (size_code << 6);
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::ShiftReg {
+                            reg: 0,
+                            size,
+                            count_or_reg: encoded_count,
+                            count_is_register: false,
+                            direction: 1,
+                            op: 1,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x60FC,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0102,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: -4,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(0, initial);
+                expected.set_ccr(0x1F);
+                let (result, shift_cycles) = expected.exec_lsl(size, shift, initial & size.mask());
+                expected.set_d(0, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                actual.set_cpu_type(cpu_type);
+                actual.set_d(0, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native LSL loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    packed as u32 as i32,
+                    shift_cycles + 10,
+                    "{cpu_type:?} {size:?} #{shift} cycles"
+                );
+                assert_eq!(actual.d(0), expected.d(0), "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} #{shift} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+                assert_eq!(actual.ppc, 0x0102);
+                assert_eq!(actual.ir, 0x60FC);
+            }
+        }
     }
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -34,6 +34,12 @@ const TRACE_CACHE_SIZE: usize = 4096;
 pub(crate) const TRACE_MAX_OPS: usize = 128;
 pub(crate) const TRACE_MIN_OPS: usize = 3;
 const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
+/// Indirect calls pay trace validation plus a native/Rust boundary on every
+/// visit. In same-binary paired 100-million-instruction runs, six-op register
+/// traces were only 0.6% faster at the median and regressed in one of five
+/// trials. Every seven-op trial won: at least 7.2% across register,
+/// memory-ALU, and memory-heavy mixes.
+const TRACE_MIN_INDIRECT_JSR_OPS: usize = 7;
 const TRACE_HOT_THRESHOLD: u8 = 2;
 const TRACE_ADAPT_WINDOW: u8 = 64;
 const TRACE_ADAPT_MISMATCHES: u8 = 48;
@@ -227,6 +233,12 @@ pub(crate) enum JitTraceOp {
         condition: u8,
         reg: u8,
         displacement: i16,
+    },
+    /// Terminal `JSR (An)`. The target is dynamic, and the return address
+    /// store is checked against the active fastmem window before any CPU
+    /// state is committed.
+    IndirectJsr {
+        reg: u8,
     },
     /// MOVE/MOVEA with at least one register-indirect operand, executed
     /// against the fastmem window (`dst == Addr` is MOVEA). Traces
@@ -833,6 +845,11 @@ impl TraceJit {
                 self.finish_recording(cpu, next_pc);
                 return;
             }
+            JitTraceOp::IndirectJsr { .. } => {
+                self.recording.as_mut().unwrap().ops.push(op);
+                self.finish_recording(cpu, next_pc);
+                return;
+            }
             _ if next_pc != executed_pc.wrapping_add(op_len as u32) => {
                 self.finish_recording(cpu, executed_pc);
                 return;
@@ -904,12 +921,19 @@ impl TraceJit {
             );
         }
 
-        // A checked memory CMP does not amortize trace validation and the
-        // native/Rust boundary in the short non-self-loop regions measured
-        // from Lemmings. Keep those on the already-fast decoded-memory path;
-        // native compilation is profitable only when one validation can be
-        // reused across repeated self-loop iterations.
+        let ends_in_indirect_jsr = ops
+            .last()
+            .is_some_and(|op| matches!(op.op, JitTraceOp::IndirectJsr { .. }));
+        if ends_in_indirect_jsr && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS {
+            return None;
+        }
+
+        // Short checked memory ALU regions do not amortize trace validation
+        // and the native/Rust boundary. Keep those on the decoded-memory path
+        // unless the measured indirect-call length threshold above provides
+        // enough independent work to cover the fixed cost.
         if !self_loop
+            && !ends_in_indirect_jsr
             && ops
                 .iter()
                 .any(|op| matches!(op.op, JitTraceOp::AluMemToReg { .. }))
@@ -925,6 +949,7 @@ impl TraceJit {
                     | JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
+                    | JitTraceOp::IndirectJsr { .. }
             )
         });
 
@@ -1063,6 +1088,10 @@ impl TraceJit {
                     JitTraceOp::AluMemToReg { .. } => {
                         let env = mem_env.as_ref().expect("AluMemToReg implies a window env");
                         emit_alu_mem_to_reg(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
+                    JitTraceOp::IndirectJsr { reg } => {
+                        let env = mem_env.as_ref().expect("IndirectJsr implies a window env");
+                        emit_indirect_jsr(&mut builder, cpu_ptr, *op, reg, env, &mut bails, bail_at)
                     }
                     JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
@@ -1396,6 +1425,7 @@ impl JitTraceOp {
                 4 + src_c + dst_c
             }
             Self::AluMemToReg { .. } => 24,
+            Self::IndirectJsr { .. } => 16,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::AnDispUnary { .. } | Self::AnDispAddqSubq { .. } | Self::AnDispBit { .. } => 24,
@@ -1403,7 +1433,10 @@ impl JitTraceOp {
     }
 
     fn ends_trace(self) -> bool {
-        matches!(self, Self::Branch { .. } | Self::Dbcc { .. })
+        matches!(
+            self,
+            Self::Branch { .. } | Self::Dbcc { .. } | Self::IndirectJsr { .. }
+        )
     }
 
     /// The PC a taken closing branch at `pc` jumps to, if this op is one.
@@ -1433,6 +1466,9 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_branch_word_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
+    if let Some(op) = decode_indirect_jsr_trace_op(pc, opcode) {
+        return Some(op);
+    }
     if let Some(op) = decode_an_disp_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
@@ -1451,6 +1487,21 @@ fn decode_trace_op<B: AddressBus>(
         extension2: None,
         pc,
         op,
+    })
+}
+
+fn decode_indirect_jsr_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
+    if (opcode & 0xFFF8) != 0x4E90 {
+        return None;
+    }
+    Some(TraceBuildOp {
+        opcode,
+        extension: None,
+        extension2: None,
+        pc,
+        op: JitTraceOp::IndirectJsr {
+            reg: (opcode & 7) as u8,
+        },
     })
 }
 
@@ -1785,7 +1836,27 @@ fn execute_portable_op(
     ) {
         return execute_portable_an_disp(cpu, op, code_start, code_end);
     }
+    if let JitTraceOp::IndirectJsr { reg } = op.op {
+        return execute_portable_indirect_jsr(cpu, op, reg);
+    }
     Some(execute_portable_reg_op(cpu, op))
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_indirect_jsr(cpu: &mut CpuCore, trace: TraceBuildOp, reg: u8) -> Option<i32> {
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::Jsr {
+            ea: FastEa::AnInd(reg),
+        },
+    ) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
 }
 
 #[cfg(any(target_family = "wasm", test))]
@@ -2352,6 +2423,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
                 12
             }
         }
+        JitTraceOp::IndirectJsr { .. } => {
+            unreachable!("IndirectJsr is handled by execute_portable_indirect_jsr")
+        }
         JitTraceOp::MoveMem { .. } => {
             unreachable!("MoveMem is handled by execute_portable_move_mem")
         }
@@ -2747,6 +2821,9 @@ fn emit_jit_op(
         | JitTraceOp::AnDispBit { .. } => {
             unreachable!("AnDisp ops are emitted by emit_an_disp_mem")
         }
+        JitTraceOp::IndirectJsr { .. } => {
+            unreachable!("IndirectJsr is emitted by emit_indirect_jsr")
+        }
         JitTraceOp::Branch {
             condition,
             displacement,
@@ -2962,6 +3039,40 @@ fn emit_alu_mem_to_reg(
         }
         _ => unreachable!("unsupported memory-to-register ALU operation"),
     }
+    cycles_const(builder, trace.op.max_cycles())
+}
+
+/// Emit terminal `JSR (An)`. The stack write is checked before the stack
+/// pointer, flow state, or PC changes, so a miss can re-execute the call via
+/// full dispatch. A successful call ends this non-self-loop trace; writing
+/// into its code is therefore safe because any later entry revalidates it.
+#[cfg(not(target_family = "wasm"))]
+fn emit_indirect_jsr(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    reg: u8,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let target = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+    let old_sp = load_reg(builder, cpu, JitDirectReg::Addr(7));
+    let new_sp = builder.ins().iadd_imm(old_sp, -4);
+    let (off, _) = checked_window_off(builder, env, bail, new_sp, Size::Long);
+    let return_pc = iconst_u32(builder, trace.pc.wrapping_add(2));
+    window_store(builder, env, off, Size::Long, return_pc);
+
+    store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
+    store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
+    store_value_u32(builder, cpu, offset_of!(CpuCore, pc), target);
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -4041,6 +4152,65 @@ mod portable_tests {
     }
 
     #[test]
+    fn decodes_indirect_jsr_trace_boundary() {
+        let cpu = cpu();
+        let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
+        mem.write_word(0x0100, 0x4E90); // JSR (A0)
+        let jsr = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jsr.extension, None);
+        assert_eq!(jsr.length(), 2);
+        assert!(matches!(jsr.op, JitTraceOp::IndirectJsr { reg: 0 }));
+        assert!(jsr.op.ends_trace());
+    }
+
+    #[test]
+    fn portable_indirect_jsr_pushes_return_and_changes_flow() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0340);
+        cpu.set_a(7, 0x0800);
+        cpu.change_of_flow = false;
+
+        let op = TraceBuildOp {
+            opcode: 0x4E90,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::IndirectJsr { reg: 0 },
+        };
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102), Some(16));
+        assert_eq!(cpu.a(7), 0x07FC);
+        assert_eq!(&mem[0x07FC..0x0800], &0x0102u32.to_be_bytes());
+        assert_eq!(cpu.pc, 0x0340);
+        assert!(cpu.change_of_flow);
+    }
+
+    #[test]
+    fn portable_indirect_jsr_bails_without_partial_state() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0340);
+        cpu.set_a(7, 2); // decremented SP wraps outside the window
+        cpu.pc = 0x0444;
+        cpu.change_of_flow = false;
+
+        let op = TraceBuildOp {
+            opcode: 0x4E90,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::IndirectJsr { reg: 0 },
+        };
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102), None);
+        assert_eq!(cpu.a(7), 2);
+        assert_eq!(cpu.pc, 0x0444);
+        assert!(!cpu.change_of_flow);
+        assert!(mem.iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
     fn portable_cmp_memory_sets_nzvc_and_preserves_x() {
         let mut cpu = cpu();
         let mut mem = vec![0u8; 0x1000];
@@ -4314,6 +4484,162 @@ mod portable_tests {
             assert_eq!(actual.get_ccr(), expected.get_ccr(), "{cpu_type:?} flags");
             assert_eq!(actual.pc, 0x0100);
         }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn indirect_jsr_profitability_threshold_is_enforced() {
+        let ops_for = |count: usize| {
+            let mut ops = Vec::new();
+            for index in 0..count - 1 {
+                let reg = (index & 7) as u8;
+                ops.push(TraceBuildOp {
+                    opcode: 0x7001 | (u16::from(reg) << 9),
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0100 + index as u32 * 2,
+                    op: JitTraceOp::Moveq { reg, data: 1 },
+                });
+            }
+            ops.push(TraceBuildOp {
+                opcode: 0x4E90,
+                extension: None,
+                extension2: None,
+                pc: 0x0100 + (count - 1) as u32 * 2,
+                op: JitTraceOp::IndirectJsr { reg: 0 },
+            });
+            ops
+        };
+
+        let compile_cpu = cpu();
+        let mut jit = TraceJit::new();
+        assert!(
+            jit.compile_decoded_ops(
+                &compile_cpu,
+                0x0100,
+                CpuType::M68000,
+                ops_for(TRACE_MIN_INDIRECT_JSR_OPS - 1),
+                Some(0x0340),
+            )
+            .is_none(),
+            "six-op indirect-call region should remain decoded"
+        );
+        assert!(
+            jit.compile_decoded_ops(
+                &compile_cpu,
+                0x0100,
+                CpuType::M68000,
+                ops_for(TRACE_MIN_INDIRECT_JSR_OPS),
+                Some(0x0340),
+            )
+            .is_some(),
+            "seven-op indirect-call region should compile"
+        );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_indirect_jsr_commits_only_after_stack_check() {
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x7201,
+                extension: None,
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::Moveq { reg: 1, data: 1 },
+            },
+            TraceBuildOp {
+                opcode: 0x7402,
+                extension: None,
+                extension2: None,
+                pc: 0x0102,
+                op: JitTraceOp::Moveq { reg: 2, data: 2 },
+            },
+            TraceBuildOp {
+                opcode: 0x7603,
+                extension: None,
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::Moveq { reg: 3, data: 3 },
+            },
+            TraceBuildOp {
+                opcode: 0x7804,
+                extension: None,
+                extension2: None,
+                pc: 0x0106,
+                op: JitTraceOp::Moveq { reg: 4, data: 4 },
+            },
+            TraceBuildOp {
+                opcode: 0x7A05,
+                extension: None,
+                extension2: None,
+                pc: 0x0108,
+                op: JitTraceOp::Moveq { reg: 5, data: 5 },
+            },
+            TraceBuildOp {
+                opcode: 0xDE6D,
+                extension: Some(0x0010),
+                extension2: None,
+                pc: 0x010A,
+                op: JitTraceOp::AluMemToReg {
+                    op: JitBinaryOp::Add,
+                    size: Size::Word,
+                    src: JitEa::Disp(5, 0x0010),
+                    dst: 7,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x4E90,
+                extension: None,
+                extension2: None,
+                pc: 0x010E,
+                op: JitTraceOp::IndirectJsr { reg: 0 },
+            },
+        ];
+        let mut compile_cpu = cpu();
+        compile_cpu.set_a(0, 0x0340);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&compile_cpu, 0x0100, CpuType::M68000, ops, Some(0x0340))
+            .expect("indirect JSR region should compile");
+
+        let prepare = |stack: u32| {
+            let mut cpu = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+            attach_window(&mut cpu, &mut mem);
+            cpu.set_a(0, 0x0340);
+            cpu.set_a(5, 0x0200);
+            cpu.set_a(7, stack);
+            cpu.set_d(7, 0xA5A5_7FFF);
+            cpu.set_ccr(0x1F);
+            cpu.change_of_flow = false;
+            (cpu, mem)
+        };
+
+        let (mut success, success_mem) = prepare(0x0800);
+        let packed = unsafe { (compiled.func)(&mut success) };
+        assert_eq!((packed >> 32) as u32, 7);
+        assert_eq!(packed as u32 as i32, 60);
+        assert_eq!(success.d(1), 1);
+        assert_eq!(success.d(7), 0xA5A5_8000);
+        assert_eq!(success.a(7), 0x07FC);
+        assert_eq!(&success_mem[0x07FC..0x0800], &0x0110u32.to_be_bytes());
+        assert_eq!(success.pc, 0x0340);
+        assert_eq!(success.ppc, 0x010E);
+        assert_eq!(success.ir, 0x4E90);
+        assert!(success.change_of_flow);
+
+        let (mut bail, bail_mem) = prepare(2);
+        let packed = unsafe { (compiled.func)(&mut bail) };
+        assert_eq!((packed >> 32) as u32, 6);
+        assert_eq!(packed as u32 as i32, 44);
+        assert_eq!(bail.d(1), 1, "prefix remains committed");
+        assert_eq!(bail.d(7), 0xA5A5_8000, "prefix remains committed");
+        assert_eq!(bail.a(7), 2, "call itself did not commit");
+        assert_eq!(bail.pc, 0x010E, "retry the unexecuted call");
+        assert!(!bail.change_of_flow);
+        assert!(bail_mem[0x07FC..0x0800].iter().all(|&byte| byte == 0));
     }
 
     #[test]


### PR DESCRIPTION
Depends on #26 (and therefore #25). Please review the final commit independently; the prerequisite commits will disappear from this diff as those PRs merge.

## Summary

- admit terminal `JSR (An)` into portable and native traces
- push the big-endian return PC and transfer control without returning to decoded dispatch before the call
- require at least seven operations in an indirect-call trace, based on paired profitability measurements
- preserve precise bail semantics: validate the new A7 longword location before changing A7, PC, flow state, or guest memory
- add five focused tests and a permanent `indirect-jsr` benchmark with register-only, memory-ALU, and memory-heavy mixes

## Why

After the preceding opcode changes, Lemmings' largest stranded region was a long straight-line trace ending in `JSR (A0)`. The earlier recorder stopped before the call and rejected the non-self-loop memory-containing prefix, sending the entire region through decoded execution.

This PR treats the indirect call as a terminal trace operation. It is intentionally a foundation rather than full call-region chaining: the generated trace performs the call at native speed, then returns to the Rust runner, which dispatches the target normally. A follow-up profile will investigate chaining that target directly, in the style of classic dynamic translators.

## Profitability threshold

An indirect-call trace pays validation and one native/Rust boundary per visit, so compiling every short prefix is counterproductive. Five paired 100-million-instruction trials compared enabled traces with the identical binary's threshold raised to disable them:

- 3 operations: slower for register and memory-ALU mixes
- 4 operations: register mix still about 8% slower
- 5 operations: register mix approximately break-even/slightly slower
- 6 operations: register median only +0.6%, with one of five trials slower
- **7 operations: every trial faster across all three mixes; register median +7.2%, memory-ALU about +13.5%, memory-heavy about +29%**

Seven is therefore the lowest measured threshold that was robust for the least favorable register-only case. Using nine or ten would discard profitable real traces without making the admitted traces faster.

I repeated the committed seven-op cases after rebasing. The medians from three paired threshold-disabled/enabled release runs were:

| Seven-op mix | Before | After | Change |
| --- | ---: | ---: | ---: |
| register-only | 92.6 M instr/s | 100.3 M instr/s | **+8.3%** |
| memory-ALU | 83.4 M instr/s | 94.0 M instr/s | **+12.7%** |
| memory-heavy | 62.5 M instr/s | 81.8 M instr/s | **+30.9%** |

The memory-heavy measurements showed host-frequency variance (one paired run slowed in both builds), which is why the table uses paired medians and the threshold decision used five trials.

## Lemmings profile

The previously rejected Lemmings region at guest `$28216` now compiles as a 21-operation trace ending in the indirect JSR. In the enabled application run it executed 65,592 times and retired 307,332 guest instructions.

Its average of only 4.69 retired instructions per call, plus 59,450 guard exits, is important follow-up evidence: the static trace is long enough to pass the threshold, but live control flow often leaves early. I am not presenting the large whole-runner sample difference as causal because adaptive traces selected different paths and the gameplay phases were not identical. The controlled microbenchmarks establish local profitability; the application profile establishes that Lemmings exercises the new operation and identifies native block/call chaining as the next target.

## Correctness and safety

- native code checks the complete new A7 longword against the active fast-memory window before committing any state
- the return PC is stored in 68k big-endian form, then A7, `change_of_flow`, and the dynamic target PC are committed
- a failed check restores/re-executes through normal dispatch with no partial stack write or register change
- ending the trace after JSR is safe for self-modifying code because a later entry revalidates the trace
- tests cover decoding, portable success, portable no-partial-state bail, the 6/7 profitability boundary, and native success/bail behavior
- `cargo test --all-features` passes on m68k 0.2.4: all unit, integration, Musashi, 127 single-step, and doc tests
