### PR TITLE
perf: JIT brief-indexed MOVE and postincrement ADD loops

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -295,6 +295,29 @@ fn blocked_self_loop(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
     words
 }
 
+/// Isolate the largest rejected trace from the Lemmings profile: a hot
+/// region executed 24 traceable operations before `ASR.W #1,D7`, then seven
+/// more before `LSL.L #3,D0`. The surrounding ADDQs are synthetic; this
+/// benchmark measures the cost of rejecting versus compiling that topology,
+/// while the application profile measures its end-to-end importance.
+fn bench_immediate_shift_trace() {
+    let mut words = vec![0x5280; 24];
+    words.push(0xE247);
+    words.extend(std::iter::repeat_n(0x5280, 7));
+    words.push(0xE788);
+    let bytes_after_back_branch = (words.len() + 1) * 2;
+    let back_disp = -(bytes_after_back_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | (back_disp as u8 as u16));
+    bench_batch_loop_at(
+        "batch",
+        "shift blockers p24/32",
+        &words,
+        200_000_000,
+        0x7000,
+    );
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -605,6 +628,10 @@ fn main() {
     }
     if only.as_deref() == Some("trace-branch-bias") {
         bench_trace_branch_bias();
+        return;
+    }
+    if only.as_deref() == Some("immediate-shifts") {
+        bench_immediate_shift_trace();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -617,6 +617,32 @@ fn bench_lemmings_two_op_memory_loops() {
     );
 }
 
+/// Reproduce the hottest wholly interpreted loop in the post-batching
+/// Lemmings profile.  The real loop has five indexed byte loads, two long
+/// and one word register-to-memory ADDs, twelve register-only instructions,
+/// and a closing DBRA.  Keeping the same 21-instruction shape makes this a
+/// useful end-to-end measure of whether tracing the missing memory forms
+/// amortizes validation, guards, and native entry.
+fn bench_lemmings_indexed_memory_loop() {
+    const INSTRS: u32 = 210_000_000;
+    let words = [
+        0x2042, // outer: MOVEA.L D2,A0
+        0x2442, // MOVEA.L D2,A2
+        0x707F, // MOVEQ #127,D0
+        0x1832, 0x1000, // inner: MOVE.B 0(A2,D1.W),D4
+        0x4E71, 0x4E71, 0x4E71, 0x1832, 0x1001, // MOVE.B 1(A2,D1.W),D4
+        0x4E71, 0x4E71, 0xD998, // ADD.L D4,(A0)+
+        0x1832, 0x1002, // MOVE.B 2(A2,D1.W),D4
+        0x4E71, 0x4E71, 0x4E71, 0x1832, 0x1003, // MOVE.B 3(A2,D1.W),D4
+        0x4E71, 0x4E71, 0xD998, // ADD.L D4,(A0)+
+        0x1832, 0x1004, // MOVE.B 4(A2,D1.W),D4
+        0x4E71, 0x4E71, 0xD958, // ADD.W D4,(A0)+
+        0x51C8, 0xFFCC, // DBRA D0,inner
+        0x60C2, // BRA.S outer
+    ];
+    bench_batch_loop_at("batch", "Lemmings indexed loop", &words, INSTRS, 0x7000);
+}
+
 /// Reproduce the path bias observed at Lemmings `$2AD5C`: the trace is first
 /// recorded through an uncommon conditional edge, then the workload settles
 /// into a copy loop reached through the opposite edge. A first-path-only
@@ -769,6 +795,10 @@ fn main() {
     }
     if only.as_deref() == Some("lemmings-two-op-loops") {
         bench_lemmings_two_op_memory_loops();
+        return;
+    }
+    if only.as_deref() == Some("lemmings-indexed-loop") {
+        bench_lemmings_indexed_memory_loop();
         return;
     }
     if only.as_deref() == Some("trace-branch-bias") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -335,6 +335,134 @@ fn bench_memory_sub_trace() {
     bench_batch_loop_at("batch", "SUB.W d16(A5),D4 p10", &words, 200_000_000, 0x7A00);
 }
 
+#[derive(Clone, Copy)]
+enum IndirectJsrMix {
+    Register,
+    MemoryAlu,
+    MemoryHeavy,
+}
+
+impl IndirectJsrMix {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "register" => Some(Self::Register),
+            "memory-alu" => Some(Self::MemoryAlu),
+            "memory-heavy" => Some(Self::MemoryHeavy),
+            _ => None,
+        }
+    }
+
+    fn index(self) -> u32 {
+        match self {
+            Self::Register => 0,
+            Self::MemoryAlu => 1,
+            Self::MemoryHeavy => 2,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Register => "register",
+            Self::MemoryAlu => "memory-ALU",
+            Self::MemoryHeavy => "memory-heavy",
+        }
+    }
+
+    fn append_prefix_op(self, words: &mut Vec<u16>, index: usize) {
+        match self {
+            Self::Register => words.push(0x5280), // ADDQ.L #1,D0
+            Self::MemoryAlu if index == 0 => {
+                words.extend_from_slice(&[0x986D, 0x0100]); // SUB.W $0100(A5),D4
+            }
+            Self::MemoryAlu => words.push(0x5280), // ADDQ.L #1,D0
+            Self::MemoryHeavy => {
+                let op: &[u16] = match index % 4 {
+                    0 => &[0x986D, 0x0100], // SUB.W $0100(A5),D4
+                    1 => &[0x322D, 0x0100], // MOVE.W $0100(A5),D1
+                    2 => &[0x526D, 0x0100], // ADDQ.W #1,$0100(A5)
+                    _ => &[0x4A2D, 0x0100], // TST.B $0100(A5)
+                };
+                words.extend_from_slice(op);
+            }
+        }
+    }
+}
+
+/// Measure a non-self-loop region ending in `JSR (A0)`, followed by an RTS
+/// and a backward branch that re-enters the region. The three mixes separate
+/// fixed trace/call overhead from the savings available for register-only,
+/// Lemmings-like memory-ALU, and memory-heavy Classic Mac code.
+fn measure_indirect_jsr_region(
+    mix: IndirectJsrMix,
+    head_ops: usize,
+    instrs: u32,
+    code_base: u32,
+) -> f64 {
+    assert!((3..=24).contains(&head_ops));
+    let mut words = Vec::new();
+    for index in 0..head_ops - 1 {
+        mix.append_prefix_op(&mut words, index);
+    }
+    words.push(0x4E90); // JSR (A0)
+    let branch_word = words.len();
+    let bytes_after_branch = (branch_word + 1) * 2;
+    let back_disp = -(bytes_after_branch as i16);
+    assert!((-128..=-1).contains(&back_disp));
+    words.push(0x6000 | back_disp as u8 as u16); // return path: BRA.S head
+    let rts_word = words.len();
+    words.push(0x4E75); // subroutine: RTS
+
+    let mut bus = LinearMemoryBus::new(0x10000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(code_base + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = code_base;
+        cpu.set_a(0, code_base + rts_word as u32 * 2);
+        cpu.set_a(5, 0x1000);
+        cpu.set_a(7, 0xF000);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    let warm = warm_cpu.run_batch(&mut bus, 5_000_000, &[0]);
+    assert_eq!(warm.instructions, 5_000_000);
+
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    let result = cpu.run_batch(&mut bus, instrs, &[0]);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(result.instructions, instrs);
+    elapsed
+}
+
+fn bench_indirect_jsr_regions() {
+    const INSTRS: u32 = 50_000_000;
+    let mixes = [
+        IndirectJsrMix::Register,
+        IndirectJsrMix::MemoryAlu,
+        IndirectJsrMix::MemoryHeavy,
+    ];
+    for mix in mixes {
+        for head_ops in 3usize..=12 {
+            bench_indirect_jsr_case(mix, head_ops, INSTRS);
+        }
+    }
+}
+
+fn bench_indirect_jsr_case(mix: IndirectJsrMix, head_ops: usize, instrs: u32) {
+    let code_base = 0x4000 + mix.index() * 0x1000 + head_ops as u32 * 0x80;
+    let elapsed = measure_indirect_jsr_region(mix, head_ops, instrs, code_base);
+    println!(
+        "batch     JSR {:12} {head_ops:2} {:8.1} M instr/s",
+        mix.label(),
+        f64::from(instrs) / elapsed / 1_000_000.0
+    );
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -657,6 +785,25 @@ fn main() {
     }
     if only.as_deref() == Some("memory-sub") {
         bench_memory_sub_trace();
+        return;
+    }
+    if only.as_deref() == Some("indirect-jsr") {
+        match (std::env::args().nth(2), std::env::args().nth(3)) {
+            (Some(mix), Some(head_ops)) => {
+                let mix = IndirectJsrMix::parse(&mix)
+                    .expect("indirect-jsr mix must be register, memory-alu, or memory-heavy");
+                let head_ops = head_ops
+                    .parse()
+                    .expect("indirect-jsr op count must be an integer");
+                let instrs = std::env::args()
+                    .nth(4)
+                    .map(|value| value.parse().expect("instruction count must be an integer"))
+                    .unwrap_or(50_000_000);
+                bench_indirect_jsr_case(mix, head_ops, instrs);
+            }
+            (None, None) => bench_indirect_jsr_regions(),
+            _ => panic!("indirect-jsr requires both a mix and an operation count"),
+        }
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -318,6 +318,23 @@ fn bench_immediate_shift_trace() {
     );
 }
 
+/// Isolate the largest remaining rejected trace in the post-shift Lemmings
+/// profile: seven traceable operations followed by `ADD.W d16(A5),D7`.
+/// The ADDQ prefix is synthetic; the measured application profile establishes
+/// how often the real trace executes, while this benchmark measures the cost
+/// of admitting its memory-source ADD rather than rejecting the whole trace.
+fn bench_memory_add_trace() {
+    let words = blocked_self_loop(7, &[0xDE6D, 0x0100]);
+    bench_batch_loop_at("batch", "ADD.W d16(A5),D7 p7", &words, 200_000_000, 0x7800);
+}
+
+/// Isolate the largest rejected trace after memory-source ADD was admitted:
+/// ten traceable operations followed by `SUB.W d16(A5),D4`.
+fn bench_memory_sub_trace() {
+    let words = blocked_self_loop(10, &[0x986D, 0x0100]);
+    bench_batch_loop_at("batch", "SUB.W d16(A5),D4 p10", &words, 200_000_000, 0x7A00);
+}
+
 /// Replay the three dominant rejected-trace shapes observed during a
 /// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
 /// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
@@ -632,6 +649,14 @@ fn main() {
     }
     if only.as_deref() == Some("immediate-shifts") {
         bench_immediate_shift_trace();
+        return;
+    }
+    if only.as_deref() == Some("memory-add") {
+        bench_memory_add_trace();
+        return;
+    }
+    if only.as_deref() == Some("memory-sub") {
+        bench_memory_sub_trace();
         return;
     }
     if only.as_deref() == Some("a5-trace-calls") {

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -408,8 +408,22 @@ impl DecodedSimpleOp {
                 }
                 #[cfg(not(target_family = "wasm"))]
                 {
-                    let _ = (reg, size, count_or_reg, count_is_register, direction, op);
-                    None
+                    // Native traces lower the immediate-count shift forms
+                    // exercised by measured hot regions. Keep other variants
+                    // on the decoded interpreter until their flag handling is
+                    // lowered and measured independently.
+                    if !count_is_register && matches!((op, direction), (0, 0) | (1, 1)) {
+                        Some(JitTraceOp::ShiftReg {
+                            reg,
+                            size,
+                            count_or_reg,
+                            count_is_register,
+                            direction,
+                            op,
+                        })
+                    } else {
+                        None
+                    }
                 }
             }
             Self::BranchShort {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -239,8 +239,7 @@ pub(crate) enum JitTraceOp {
         dst: JitEa,
     },
     /// Read-only ALU operation from fast memory to a data register. The
-    /// initial decoder deliberately admits only CMP with `(An)`/`d16(An)`
-    /// sources; the generic shape leaves room for other read-only forms.
+    /// decoder admits measured CMP/ADD/SUB `(An)`/`d16(An)` sources.
     AluMemToReg {
         op: JitBinaryOp,
         size: Size,
@@ -1673,7 +1672,7 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
-/// CMP `<ea>,Dn` for the two addressing forms that dominate the rejected
+/// CMP/ADD/SUB `<ea>,Dn` for the two addressing forms that dominate rejected
 /// Lemmings traces. The access itself is emitted against the fastmem window;
 /// the extension word is captured for validation and displacement baking.
 fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
@@ -1683,14 +1682,15 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
     opcode: u16,
     cpu_type: CpuType,
 ) -> Option<TraceBuildOp> {
-    let DecodedMemOp::AluToReg {
-        op: BinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = DecodedMemOp::decode(cpu_type, opcode)?
+    let DecodedMemOp::AluToReg { op, size, src, dst } = DecodedMemOp::decode(cpu_type, opcode)?
     else {
         return None;
+    };
+    let op = match op {
+        BinaryOp::Cmp => JitBinaryOp::Cmp,
+        BinaryOp::Add => JitBinaryOp::Add,
+        BinaryOp::Sub => JitBinaryOp::Sub,
+        _ => return None,
     };
     let (src, extension) = match src {
         FastEa::AnInd(reg) => (JitEa::Ind(reg), None),
@@ -1705,12 +1705,7 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
         extension,
         extension2: None,
         pc,
-        op: JitTraceOp::AluMemToReg {
-            op: JitBinaryOp::Cmp,
-            size,
-            src,
-            dst,
-        },
+        op: JitTraceOp::AluMemToReg { op, size, src, dst },
     })
 }
 
@@ -1886,14 +1881,14 @@ fn execute_portable_an_disp(
 
 #[cfg(any(target_family = "wasm", test))]
 fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
-    let JitTraceOp::AluMemToReg {
-        op: JitBinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = trace.op
-    else {
+    let JitTraceOp::AluMemToReg { op, size, src, dst } = trace.op else {
         return None;
+    };
+    let op = match op {
+        JitBinaryOp::Cmp => BinaryOp::Cmp,
+        JitBinaryOp::Add => BinaryOp::Add,
+        JitBinaryOp::Sub => BinaryOp::Sub,
+        _ => return None,
     };
     let src = match src {
         JitEa::Ind(reg) => FastEa::AnInd(reg),
@@ -1902,15 +1897,7 @@ fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Op
     };
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
-    if super::mem_ops::execute_mem_op(
-        cpu,
-        DecodedMemOp::AluToReg {
-            op: BinaryOp::Cmp,
-            size,
-            src,
-            dst,
-        },
-    ) {
+    if super::mem_ops::execute_mem_op(cpu, DecodedMemOp::AluToReg { op, size, src, dst }) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -2934,14 +2921,8 @@ fn emit_alu_mem_to_reg(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::AluMemToReg {
-        op: JitBinaryOp::Cmp,
-        size,
-        src,
-        dst,
-    } = trace.op
-    else {
-        unreachable!("only CMP memory-to-register traces are decoded")
+    let JitTraceOp::AluMemToReg { op, size, src, dst } = trace.op else {
+        unreachable!("expected memory-to-register ALU trace")
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -2952,7 +2933,7 @@ fn emit_alu_mem_to_reg(
 
     let base_reg = match src {
         JitEa::Ind(reg) | JitEa::Disp(reg, _) => reg,
-        _ => unreachable!("CMP trace decoder only admits (An) and d16(An)"),
+        _ => unreachable!("ALU trace decoder only admits (An) and d16(An)"),
     };
     let base = load_reg(builder, cpu, JitDirectReg::Addr(base_reg));
     let addr = match src {
@@ -2964,8 +2945,23 @@ fn emit_alu_mem_to_reg(
     let src_value = window_load(builder, env, off, size);
     let dst_value = load_reg(builder, cpu, JitDirectReg::Data(dst));
     let dst_value = mask_value(builder, dst_value, size);
-    let result = builder.ins().isub(dst_value, src_value);
-    set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+    match op {
+        JitBinaryOp::Cmp => {
+            let result = builder.ins().isub(dst_value, src_value);
+            set_cmp_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        JitBinaryOp::Add => {
+            let result = builder.ins().iadd(dst_value, src_value);
+            write_data_reg_sized(builder, cpu, dst, size, result);
+            set_add_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        JitBinaryOp::Sub => {
+            let result = builder.ins().isub(dst_value, src_value);
+            write_data_reg_sized(builder, cpu, dst, size, result);
+            set_sub_flags(builder, cpu, src_value, dst_value, result, size);
+        }
+        _ => unreachable!("unsupported memory-to-register ALU operation"),
+    }
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -3985,7 +3981,7 @@ mod portable_tests {
     }
 
     #[test]
-    fn decodes_hot_cmp_memory_sources() {
+    fn decodes_hot_alu_memory_sources() {
         let cpu = cpu();
         let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
         mem.write_word(0x0100, 0xB210); // CMP.B (A0),D1
@@ -4012,6 +4008,34 @@ mod portable_tests {
                 size: Size::Word,
                 src: JitEa::Disp(6, 0x0010),
                 dst: 6,
+            }
+        ));
+
+        mem.write_word(0x0100, 0xDE6D); // ADD.W $0010(A5),D7
+        mem.write_word(0x0102, 0x0010);
+        let add = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(add.extension, Some(0x0010));
+        assert!(matches!(
+            add.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Add,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 7,
+            }
+        ));
+
+        mem.write_word(0x0100, 0x986D); // SUB.W $0010(A5),D4
+        mem.write_word(0x0102, 0x0010);
+        let sub = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(sub.extension, Some(0x0010));
+        assert!(matches!(
+            sub.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Sub,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 4,
             }
         ));
     }
@@ -4070,6 +4094,226 @@ mod portable_tests {
         assert_eq!(cpu.pc, 0x0444);
         assert_eq!(cpu.d(6), 0xCAFE_BEEF);
         assert_eq!(cpu.get_ccr(), 0x15);
+    }
+
+    #[test]
+    fn portable_add_displacement_updates_register_and_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+        mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0200);
+        cpu.set_d(7, 0xA5A5_7FFF);
+        cpu.set_ccr(0x1F);
+
+        let op = TraceBuildOp {
+            opcode: 0xDE6D,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Add,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 7,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104).is_some());
+        assert_eq!(cpu.d(7), 0xA5A5_8000);
+        assert_eq!(cpu.get_ccr(), 0x0A, "N/V set; X/Z/C clear");
+    }
+
+    #[test]
+    fn portable_sub_displacement_updates_register_and_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0x0010u16.to_be_bytes());
+        mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0200);
+        cpu.set_d(4, 0xA5A5_8000);
+        cpu.set_ccr(0x1F);
+
+        let op = TraceBuildOp {
+            opcode: 0x986D,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Sub,
+                size: Size::Word,
+                src: JitEa::Disp(5, 0x0010),
+                dst: 4,
+            },
+        };
+        assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104).is_some());
+        assert_eq!(cpu.d(4), 0xA5A5_7FFF);
+        assert_eq!(cpu.get_ccr(), 0x02, "V set; X/N/Z/C clear");
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_add_displacement_matches_interpreter_result() {
+        let cases = [
+            (Size::Byte, None, 0x81, 0xA5A5_557F),
+            (Size::Word, Some(0x0010), 1, 0xA5A5_7FFF),
+            (Size::Long, None, 0x8000_0000, 0x8000_0000),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, displacement, src_value, initial) in cases {
+                let dst = 7usize;
+                let addr_reg = 5usize;
+                let op_mode = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let ea_mode = if displacement.is_some() { 5 } else { 2 };
+                let opcode = 0xD000
+                    | ((dst as u16) << 9)
+                    | (op_mode << 6)
+                    | (ea_mode << 3)
+                    | addr_reg as u16;
+                let src = displacement
+                    .map(|disp| JitEa::Disp(addr_reg as u8, disp))
+                    .unwrap_or(JitEa::Ind(addr_reg as u8));
+                let branch_pc = if displacement.is_some() {
+                    0x0104
+                } else {
+                    0x0102
+                };
+                let branch_displacement = if displacement.is_some() { -6 } else { -4 };
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: displacement.map(|disp| disp as u16),
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::AluMemToReg {
+                            op: JitBinaryOp::Add,
+                            size,
+                            src,
+                            dst: dst as u8,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x6000 | branch_displacement as u8 as u16,
+                        extension: None,
+                        extension2: None,
+                        pc: branch_pc,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: branch_displacement,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(dst, initial);
+                expected.set_ccr(0x1F);
+                let mut unused_bus = super::super::memory::LinearMemoryBus::new(2);
+                let (result, _) =
+                    expected.exec_add(&mut unused_bus, size, src_value, initial & size.mask());
+                expected.set_d(dst, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                let mut mem = vec![0u8; 0x1000];
+                let address = 0x0200usize + displacement.unwrap_or(0) as usize;
+                match size {
+                    Size::Byte => mem[address] = src_value as u8,
+                    Size::Word => {
+                        mem[address..address + 2]
+                            .copy_from_slice(&(src_value as u16).to_be_bytes());
+                    }
+                    Size::Long => {
+                        mem[address..address + 4].copy_from_slice(&src_value.to_be_bytes());
+                    }
+                }
+                attach_window(&mut actual, &mut mem);
+                actual.set_cpu_type(cpu_type);
+                actual.set_a(addr_reg, 0x0200);
+                actual.set_d(dst, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native ADD loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?}");
+                assert_eq!(actual.d(dst), expected.d(dst), "{cpu_type:?} {size:?}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+            }
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_sub_displacement_matches_interpreter_result() {
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            let mut expected = cpu();
+            expected.set_cpu_type(cpu_type);
+            expected.set_d(4, 0xA5A5_8000);
+            expected.set_ccr(0x1F);
+            let mut unused_bus = super::super::memory::LinearMemoryBus::new(2);
+            let (result, _) = expected.exec_sub(&mut unused_bus, Size::Word, 1, 0x8000);
+            expected.set_d(4, 0xA5A5_0000 | result);
+
+            let mut actual = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+            attach_window(&mut actual, &mut mem);
+            actual.set_cpu_type(cpu_type);
+            actual.set_a(5, 0x0200);
+            actual.set_d(4, 0xA5A5_8000);
+            actual.set_ccr(0x1F);
+            let ops = vec![
+                TraceBuildOp {
+                    opcode: 0x986D,
+                    extension: Some(0x0010),
+                    extension2: None,
+                    pc: 0x0100,
+                    op: JitTraceOp::AluMemToReg {
+                        op: JitBinaryOp::Sub,
+                        size: Size::Word,
+                        src: JitEa::Disp(5, 0x0010),
+                        dst: 4,
+                    },
+                },
+                TraceBuildOp {
+                    opcode: 0x60FA,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0104,
+                    op: JitTraceOp::Branch {
+                        condition: 0,
+                        displacement: -6,
+                        length: 2,
+                        expected_taken: None,
+                    },
+                },
+            ];
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                .expect("native SUB loop should compile");
+            let packed = unsafe { (compiled.func)(&mut actual) };
+
+            assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?}");
+            assert_eq!(actual.d(4), expected.d(4), "{cpu_type:?}");
+            assert_eq!(actual.get_ccr(), expected.get_ccr(), "{cpu_type:?} flags");
+            assert_eq!(actual.pc, 0x0100);
+        }
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -15,8 +15,8 @@ use super::types::{CpuType, Size};
 use cranelift_codegen::Context;
 #[cfg(not(target_family = "wasm"))]
 use cranelift_codegen::ir::{
-    AbiParam, Block, Function, InstBuilder, MemFlags, Type, UserFuncName, Value, condcodes::IntCC,
-    types,
+    AbiParam, Block, BlockArg, Function, InstBuilder, MemFlags, Type, UserFuncName, Value,
+    condcodes::IntCC, types,
 };
 #[cfg(not(target_family = "wasm"))]
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
@@ -49,10 +49,20 @@ const TRACE_MAX_ADAPTIVE_RERECORDS: u8 = 1;
 pub(crate) const TRACE_PC_NONE: u32 = u32::MAX;
 
 #[cfg(not(target_family = "wasm"))]
-/// Compiled trace entry point. Returns `(ops_retired << 32) | cycles`:
-/// a full pass retires every op; a mem-op bail retires a prefix and sets
-/// `cpu.pc` to the first un-executed instruction.
-type TraceFn = unsafe extern "C" fn(*mut CpuCore) -> u64;
+/// Original one-pass compiled trace entry point.
+type TraceOnceFn = unsafe extern "C" fn(*mut CpuCore) -> u64;
+
+#[cfg(not(target_family = "wasm"))]
+/// Counted self-loop entry point. Keeping repeated guest iterations inside
+/// generated code avoids an ABI round trip for every tiny loop.
+type TraceLoopFn = unsafe extern "C" fn(*mut CpuCore, u32) -> u64;
+
+#[cfg(not(target_family = "wasm"))]
+#[derive(Clone, Copy)]
+enum NativeTraceFn {
+    Once(TraceOnceFn),
+    Loop(TraceLoopFn),
+}
 
 static TRACE_JIT_HAS_CANDIDATES: AtomicBool = AtomicBool::new(false);
 
@@ -312,7 +322,13 @@ struct CompiledTrace {
     /// without re-validating: trace stores that would touch code bail out
     /// before committing, and nothing observable happens between
     /// iterations.
+    #[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
     self_loop: bool,
+    /// The native body was generated as a counted loop. Short read/write
+    /// MoveMem loops deliberately retain the original one-pass body: the
+    /// extra loop-carried state costs more than the saved call boundary.
+    #[cfg(not(target_family = "wasm"))]
+    native_loop: bool,
     /// Contains `MoveMem` ops: only executable while a fastmem window is
     /// active (i.e. inside `run_batch`).
     needs_window: bool,
@@ -332,10 +348,18 @@ struct CompiledTrace {
     adaptive_guard_exits: Cell<u32>,
     adaptive_rerecords: u8,
     #[cfg(not(target_family = "wasm"))]
-    func: TraceFn,
+    func: NativeTraceFn,
 }
 
 impl CompiledTrace {
+    #[cfg(all(not(target_family = "wasm"), test))]
+    unsafe fn call_native(&self, cpu: *mut CpuCore, max_iters: u32) -> u64 {
+        match self.func {
+            NativeTraceFn::Once(func) => unsafe { func(cpu) },
+            NativeTraceFn::Loop(func) => unsafe { func(cpu, max_iters) },
+        }
+    }
+
     fn is_guarded_branch_exit(&self, cpu: &CpuCore, ops_done: u32) -> bool {
         let Some(index) = ops_done.checked_sub(1).map(|index| index as usize) else {
             return false;
@@ -568,6 +592,14 @@ impl TraceJit {
             if instr_budget < ops_len {
                 return None;
             }
+            // A generated loop clearly amortizes the ABI boundary for the
+            // mixed 3+-op and read-only loops measured from Lemmings. A
+            // two-op read/write MoveMem loop is already dominated by its two
+            // checked guest accesses; carrying native loop state made that
+            // case 3.5% slower at the median, so retain the old one-pass
+            // function and repeat it in this already-validated Rust entry.
+            #[cfg(not(target_family = "wasm"))]
+            let batch_self_loop = trace.native_loop;
             // How many whole iterations fit in both budgets. The guards
             // above ensure at least one; the instruction budget is the
             // caller's (u32::MAX on the cycle-budgeted paths).
@@ -581,10 +613,77 @@ impl TraceJit {
             let mut cycles_total = 0i64;
             let mut retired = 0u32;
             let mut full_iters = 0u32;
+            #[cfg(not(target_family = "wasm"))]
+            let (guarded_branch_exit, partial_call_this_entry) = if batch_self_loop {
+                let NativeTraceFn::Loop(func) = trace.func else {
+                    unreachable!("a batched trace must have a counted entry point")
+                };
+                loop {
+                    let call_max_iters = max_iters - full_iters;
+                    let packed = unsafe { func(cpu as *mut CpuCore, call_max_iters) };
+                    cycles_total += (packed as u32) as i64;
+                    let ops_done = (packed >> 32) as u32;
+                    let completed = ops_done / ops_len;
+                    let remainder = ops_done % ops_len;
+                    let partial_call = completed < call_max_iters;
+                    // A side exit at the last op has a zero remainder after
+                    // one or more complete numeric trace lengths. PC/ppc
+                    // distinguish it from an op-zero memory bail.
+                    let exit_ops = if partial_call && remainder == 0 && ops_done != 0 {
+                        ops_len
+                    } else {
+                        remainder
+                    };
+                    let guarded_branch_exit =
+                        partial_call && trace.is_guarded_branch_exit(cpu, exit_ops);
+                    #[cfg(feature = "trace-profile")]
+                    super::trace_profile::note_native_call(pc, cpu_type, ops_done);
+                    #[cfg(feature = "trace-profile")]
+                    if guarded_branch_exit {
+                        super::trace_profile::note_guarded_branch_exit(pc, cpu_type);
+                    }
+                    retired += ops_done;
+                    full_iters += completed;
+                    if partial_call {
+                        break (guarded_branch_exit, true);
+                    }
+                    if full_iters >= max_iters || cpu.pc != pc {
+                        break (false, false);
+                    }
+                }
+            } else {
+                // This is intentionally the original direct-call driver.
+                // Tiny memory loops can execute this path once per two guest
+                // instructions, so even generalized result accounting is
+                // measurable here.
+                let NativeTraceFn::Once(func) = trace.func else {
+                    unreachable!("a one-pass trace must have a linear entry point")
+                };
+                loop {
+                    let packed = unsafe { func(cpu as *mut CpuCore) };
+                    cycles_total += (packed as u32) as i64;
+                    let ops_done = (packed >> 32) as u32;
+                    let partial_call = ops_done < ops_len;
+                    let guarded_branch_exit =
+                        partial_call && trace.is_guarded_branch_exit(cpu, ops_done);
+                    #[cfg(feature = "trace-profile")]
+                    super::trace_profile::note_native_call(pc, cpu_type, ops_done);
+                    #[cfg(feature = "trace-profile")]
+                    if guarded_branch_exit {
+                        super::trace_profile::note_guarded_branch_exit(pc, cpu_type);
+                    }
+                    retired += ops_done;
+                    if partial_call {
+                        break (guarded_branch_exit, true);
+                    }
+                    full_iters += 1;
+                    if full_iters >= max_iters || cpu.pc != pc {
+                        break (false, false);
+                    }
+                }
+            };
+            #[cfg(target_family = "wasm")]
             let (guarded_branch_exit, partial_call_this_entry) = loop {
-                #[cfg(not(target_family = "wasm"))]
-                let packed = unsafe { (trace.func)(cpu as *mut CpuCore) };
-                #[cfg(target_family = "wasm")]
                 let packed =
                     execute_portable_trace(cpu, &trace.ops, trace.code_start, trace.code_end);
                 cycles_total += (packed as u32) as i64;
@@ -600,17 +699,9 @@ impl TraceJit {
                 }
                 retired += ops_done;
                 if partial_call {
-                    // A memory check bailed before its op, or a guarded
-                    // interior branch took a different path. PC identifies
-                    // the correct interpreter/next-trace continuation.
                     break (guarded_branch_exit, true);
                 }
                 full_iters += 1;
-                // Re-entering the (already validated) loop head is the only
-                // continue condition; trace ops cannot fault or take
-                // exceptions, and stores that would touch code bail before
-                // committing, so nothing needs re-checking between
-                // iterations.
                 if full_iters >= max_iters || cpu.pc != pc {
                     break (false, false);
                 }
@@ -1000,10 +1091,23 @@ impl TraceJit {
             aligned_only,
             address_mask,
         } = params;
+        // Matched Lemmings and microbenchmark profiles show a clear win for
+        // mixed 3+-op and read-only self-loops. A two-op read/write MoveMem
+        // loop regresses when it carries counters around the generated loop,
+        // so compile that shape with the original linear body instead of
+        // trying to disable batching only at call time.
+        let native_loop = self_loop
+            && (ops.len() >= 3
+                || !ops
+                    .iter()
+                    .any(|op| matches!(op.op, JitTraceOp::MoveMem { .. })));
         let module = self.module.as_mut()?;
         let ptr_ty = module.target_config().pointer_type();
         let mut sig = module.make_signature();
         sig.params.push(AbiParam::new(ptr_ty));
+        if native_loop {
+            sig.params.push(AbiParam::new(types::I32));
+        }
         sig.returns.push(AbiParam::new(types::I64));
 
         let name = format!("m68k_trace_{}", self.next_func);
@@ -1045,11 +1149,43 @@ impl TraceJit {
                 None
             };
 
+            let zero = builder.ins().iconst(types::I32, 0);
+            let max_iters = if native_loop {
+                builder.block_params(block)[1]
+            } else {
+                builder.ins().iconst(types::I32, 1)
+            };
+            let trace_body = if native_loop {
+                let trace_body = builder.create_block();
+                builder.append_block_param(trace_body, types::I32); // accumulated cycles
+                builder.append_block_param(trace_body, types::I32); // retired instructions
+                builder.append_block_param(trace_body, types::I32); // iterations remaining
+                let initial_args: [BlockArg; 3] = [zero.into(), zero.into(), max_iters.into()];
+                builder.ins().jump(trace_body, &initial_args);
+                builder.switch_to_block(trace_body);
+                Some(trace_body)
+            } else {
+                None
+            };
+            let (cycles_before_iter, retired_before_iter, iterations_left) =
+                if let Some(trace_body) = trace_body {
+                    let params = builder.block_params(trace_body);
+                    (params[0], params[1], params[2])
+                } else {
+                    (zero, zero, max_iters)
+                };
+
             let mut bails: Vec<BailReq> = Vec::new();
-            let mut cycles_value = builder.ins().iconst(types::I32, 0);
+            let mut cycles_value = cycles_before_iter;
             for (index, op) in ops.iter().enumerate() {
                 let bail_at = BailAt {
-                    ops_before: index as u32,
+                    ops_before: if native_loop {
+                        RetiredBefore::Dynamic(
+                            builder.ins().iadd_imm(retired_before_iter, index as i64),
+                        )
+                    } else {
+                        RetiredBefore::Constant(index as u32)
+                    },
                     cycles_before: cycles_value,
                 };
                 let op_cycles = match op.op {
@@ -1067,6 +1203,11 @@ impl TraceJit {
                         length,
                         expected_taken,
                         cycles_value,
+                        if native_loop {
+                            RetiredBefore::Dynamic(retired_before_iter)
+                        } else {
+                            RetiredBefore::Constant(0)
+                        },
                         (index + 1) as u32,
                     ),
                     JitTraceOp::MoveMem { size, src, dst } => {
@@ -1114,21 +1255,54 @@ impl TraceJit {
                 );
             }
 
-            // Success: all ops retired. Pack (ops_retired << 32) | cycles.
+            let retired_value = builder
+                .ins()
+                .iadd_imm(retired_before_iter, ops.len() as i64);
+            if let Some(trace_body) = trace_body {
+                let iterations_left = builder.ins().iadd_imm(iterations_left, -1);
+                let more_iterations = builder.ins().icmp_imm(IntCC::NotEqual, iterations_left, 0);
+                let live_pc = load_u32(&mut builder, cpu_ptr, offset_of!(CpuCore, pc));
+                let at_head = builder
+                    .ins()
+                    .icmp_imm(IntCC::Equal, live_pc, i64::from(start_pc));
+                let repeat = builder.ins().band(more_iterations, at_head);
+                let done = builder.create_block();
+                let repeat_args: [BlockArg; 3] = [
+                    cycles_value.into(),
+                    retired_value.into(),
+                    iterations_left.into(),
+                ];
+                builder
+                    .ins()
+                    .brif(repeat, trace_body, &repeat_args, done, &[]);
+                builder.switch_to_block(done);
+            }
+
             let cycles64 = builder.ins().uextend(types::I64, cycles_value);
-            let ops_len = builder.ins().iconst(types::I64, (ops.len() as i64) << 32);
-            let packed = builder.ins().bor(cycles64, ops_len);
+            let retired64 = if native_loop {
+                let retired64 = builder.ins().uextend(types::I64, retired_value);
+                builder.ins().ishl_imm(retired64, 32)
+            } else {
+                builder.ins().iconst(types::I64, (ops.len() as i64) << 32)
+            };
+            let packed = builder.ins().bor(cycles64, retired64);
             builder.ins().return_(&[packed]);
 
             // Bail exits: set PC to the un-executed op, return the ops and
-            // (constant) cycles retired before it.
+            // accumulated cycles/instructions retired before it.
             for bail in bails {
                 builder.switch_to_block(bail.block);
                 store_u32(&mut builder, cpu_ptr, offset_of!(CpuCore, pc), bail.pc);
                 let cycles64 = builder.ins().uextend(types::I64, bail.at.cycles_before);
-                let retired = builder
-                    .ins()
-                    .iconst(types::I64, (bail.at.ops_before as i64) << 32);
+                let retired = match bail.at.ops_before {
+                    RetiredBefore::Constant(ops) => {
+                        builder.ins().iconst(types::I64, i64::from(ops) << 32)
+                    }
+                    RetiredBefore::Dynamic(ops) => {
+                        let retired = builder.ins().uextend(types::I64, ops);
+                        builder.ins().ishl_imm(retired, 32)
+                    }
+                };
                 let packed = builder.ins().bor(cycles64, retired);
                 builder.ins().return_(&[packed]);
             }
@@ -1141,7 +1315,11 @@ impl TraceJit {
         module.clear_context(&mut ctx);
         module.finalize_definitions().ok()?;
         let ptr = module.get_finalized_function(func_id);
-        let func = unsafe { transmute::<*const u8, TraceFn>(ptr) };
+        let func = if native_loop {
+            NativeTraceFn::Loop(unsafe { transmute::<*const u8, TraceLoopFn>(ptr) })
+        } else {
+            NativeTraceFn::Once(unsafe { transmute::<*const u8, TraceOnceFn>(ptr) })
+        };
 
         Some(CompiledTrace {
             pc: start_pc,
@@ -1151,6 +1329,7 @@ impl TraceJit {
             contiguous_code,
             max_cycles,
             self_loop,
+            native_loop,
             needs_window,
             code_start,
             code_end,
@@ -1773,7 +1952,7 @@ fn decode_jit_ea(mode: u16, reg: u16, displacement: i16) -> Option<JitEa> {
 }
 
 /// Interpreted trace execution (wasm and unit tests). Same contract as a
-/// compiled [`TraceFn`]: returns `(ops_retired << 32) | cycles`, and a
+/// compiled native trace: returns `(ops_retired << 32) | cycles`, and a
 /// mem-op bail sets `pc` to the un-executed op.
 #[cfg(any(target_family = "wasm", test))]
 fn execute_portable_trace(
@@ -2854,8 +3033,15 @@ struct MemEnv {
 #[cfg(not(target_family = "wasm"))]
 #[derive(Clone, Copy)]
 struct BailAt {
-    ops_before: u32,
+    ops_before: RetiredBefore,
     cycles_before: Value,
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[derive(Clone, Copy)]
+enum RetiredBefore {
+    Constant(u32),
+    Dynamic(Value),
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -3774,6 +3960,7 @@ fn emit_guarded_branch(
     length: u8,
     expected_taken: bool,
     cycles_before: Value,
+    retired_before_iter: RetiredBefore,
     ops_done: u32,
 ) -> Value {
     let target_pc = (trace_pc.wrapping_add(2) as i32).wrapping_add(displacement) as u32;
@@ -3808,7 +3995,16 @@ fn emit_guarded_branch(
     store_u32(builder, cpu, offset_of!(CpuCore, ppc), trace_pc);
     let total_cycles = builder.ins().iadd(cycles_before, op_cycles);
     let cycles64 = builder.ins().uextend(types::I64, total_cycles);
-    let retired = builder.ins().iconst(types::I64, (ops_done as i64) << 32);
+    let retired = match retired_before_iter {
+        RetiredBefore::Constant(retired) => builder
+            .ins()
+            .iconst(types::I64, i64::from(retired + ops_done) << 32),
+        RetiredBefore::Dynamic(retired) => {
+            let retired = builder.ins().iadd_imm(retired, i64::from(ops_done));
+            let retired = builder.ins().uextend(types::I64, retired);
+            builder.ins().ishl_imm(retired, 32)
+        }
+    };
     let packed = builder.ins().bor(cycles64, retired);
     builder.ins().return_(&[packed]);
 
@@ -4413,7 +4609,7 @@ mod portable_tests {
                 let compiled = jit
                     .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
                     .expect("native ADD loop should compile");
-                let packed = unsafe { (compiled.func)(&mut actual) };
+                let packed = unsafe { compiled.call_native(&mut actual, 1) };
 
                 assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?}");
                 assert_eq!(actual.d(dst), expected.d(dst), "{cpu_type:?} {size:?}");
@@ -4477,7 +4673,7 @@ mod portable_tests {
             let compiled = jit
                 .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
                 .expect("native SUB loop should compile");
-            let packed = unsafe { (compiled.func)(&mut actual) };
+            let packed = unsafe { compiled.call_native(&mut actual, 1) };
 
             assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?}");
             assert_eq!(actual.d(4), expected.d(4), "{cpu_type:?}");
@@ -4618,7 +4814,7 @@ mod portable_tests {
         };
 
         let (mut success, success_mem) = prepare(0x0800);
-        let packed = unsafe { (compiled.func)(&mut success) };
+        let packed = unsafe { compiled.call_native(&mut success, 1) };
         assert_eq!((packed >> 32) as u32, 7);
         assert_eq!(packed as u32 as i32, 60);
         assert_eq!(success.d(1), 1);
@@ -4631,7 +4827,7 @@ mod portable_tests {
         assert!(success.change_of_flow);
 
         let (mut bail, bail_mem) = prepare(2);
-        let packed = unsafe { (compiled.func)(&mut bail) };
+        let packed = unsafe { compiled.call_native(&mut bail, 1) };
         assert_eq!((packed >> 32) as u32, 6);
         assert_eq!(packed as u32 as i32, 44);
         assert_eq!(bail.d(1), 1, "prefix remains committed");
@@ -4821,6 +5017,49 @@ mod portable_tests {
         assert_eq!(cpu.pc, 0x0100);
         assert_eq!(cpu.ppc, 0x0102);
         assert_eq!(cpu.ir, 0x60FC);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_self_loop_batches_iterations_and_accumulates_progress() {
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x5280,
+                extension: None,
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 0,
+                    data: 1,
+                    size: Size::Long,
+                    is_sub: false,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x60FC,
+                extension: None,
+                extension2: None,
+                pc: 0x0102,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -4,
+                    length: 2,
+                    expected_taken: None,
+                },
+            },
+        ];
+        let mut actual = cpu();
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&actual, 0x0100, CpuType::M68000, ops, Some(0x0100))
+            .expect("native self-loop should compile");
+
+        let packed = unsafe { compiled.call_native(&mut actual, 5) };
+
+        assert_eq!((packed >> 32) as u32, 10);
+        assert_eq!(packed as u32, 90);
+        assert_eq!(actual.d(0), 5);
+        assert_eq!(actual.pc, 0x0100);
     }
 
     #[test]
@@ -5065,7 +5304,7 @@ mod portable_tests {
                 let compiled = jit
                     .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
                     .expect("native ASR loop should compile");
-                let packed = unsafe { (compiled.func)(&mut actual) };
+                let packed = unsafe { compiled.call_native(&mut actual, 1) };
 
                 assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
                 assert_eq!(
@@ -5155,7 +5394,7 @@ mod portable_tests {
                 let compiled = jit
                     .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
                     .expect("native LSL loop should compile");
-                let packed = unsafe { (compiled.func)(&mut actual) };
+                let packed = unsafe { compiled.call_native(&mut actual, 1) };
 
                 assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
                 assert_eq!(

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -2695,7 +2695,62 @@ fn emit_jit_op(
                 cycles_const(builder, 4)
             }
         }
-        JitTraceOp::ShiftReg { .. } => unreachable!("ShiftReg traces are wasm-only"),
+        JitTraceOp::ShiftReg {
+            reg,
+            size,
+            count_or_reg,
+            count_is_register,
+            direction,
+            op,
+        } => {
+            debug_assert!(!count_is_register && matches!((op, direction), (0, 0) | (1, 1)));
+            let shift = if count_or_reg == 0 {
+                8
+            } else {
+                u32::from(count_or_reg)
+            };
+            let value = load_reg_sized(builder, cpu, JitDirectReg::Data(reg), size);
+            let bits = size.bits() as u32;
+            let (result, shifted_out) = match (op, direction) {
+                (0, 0) => {
+                    let signed = match size {
+                        Size::Byte => sign_extend_byte(builder, value),
+                        Size::Word => sign_extend_word(builder, value),
+                        Size::Long => value,
+                    };
+                    let result = builder.ins().sshr_imm(signed, i64::from(shift));
+                    let shifted_out = if shift >= bits {
+                        let msb = iconst_u32(builder, size_msb(size));
+                        builder.ins().band(value, msb)
+                    } else {
+                        let bit = iconst_u32(builder, 1u32 << (shift - 1));
+                        builder.ins().band(value, bit)
+                    };
+                    (result, shifted_out)
+                }
+                (1, 1) => {
+                    let result = builder.ins().ishl_imm(value, i64::from(shift));
+                    let shifted_out = if shift > bits {
+                        iconst_u32(builder, 0)
+                    } else {
+                        let bit = iconst_u32(builder, 1u32 << (bits - shift));
+                        builder.ins().band(value, bit)
+                    };
+                    (result, shifted_out)
+                }
+                _ => unreachable!("unsupported native register shift"),
+            };
+            let result = mask_value(builder, result, size);
+            write_data_reg_sized(builder, cpu, reg, size, result);
+            let carry = flag_from_nonzero(builder, shifted_out, CFLAG_SET);
+            store_value_u32(builder, cpu, offset_of!(CpuCore, c_flag), carry);
+            store_value_u32(builder, cpu, offset_of!(CpuCore, x_flag), carry);
+            store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+            set_logic_flags_nv(builder, cpu, result, size);
+
+            let base = if pre020 && size == Size::Long { 8 } else { 6 };
+            cycles_const(builder, base + 2 * shift as i32)
+        }
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
         JitTraceOp::AluMemToReg { .. } => {
             unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
@@ -3286,14 +3341,19 @@ fn size_msb(size: Size) -> u32 {
 
 #[cfg(not(target_family = "wasm"))]
 fn set_logic_flags(builder: &mut FunctionBuilder<'_>, cpu: Value, value: Value, size: Size) {
+    set_logic_flags_nv(builder, cpu, value, size);
+    store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+    store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn set_logic_flags_nv(builder: &mut FunctionBuilder<'_>, cpu: Value, value: Value, size: Size) {
     let value = mask_value(builder, value, size);
     let msb = iconst_u32(builder, size_msb(size));
     let sign_bits = builder.ins().band(value, msb);
     let n = flag_from_nonzero(builder, sign_bits, NFLAG_SET);
     store_value_u32(builder, cpu, offset_of!(CpuCore, n_flag), n);
     store_value_u32(builder, cpu, offset_of!(CpuCore, not_z_flag), value);
-    store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
-    store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -4317,5 +4377,232 @@ mod portable_tests {
         assert_eq!(cpu.d(0), 0x0000_0100);
         assert_eq!(cpu.ppc, 0x0100);
         assert_eq!(cpu.ir, 0xE188);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_trace_accepts_only_supported_immediate_shift_forms() {
+        let asr = DecodedSimpleOp::decode(CpuType::M68040, 0xE247)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(matches!(
+            asr,
+            Some(JitTraceOp::ShiftReg {
+                reg: 7,
+                size: Size::Word,
+                count_or_reg: 1,
+                count_is_register: false,
+                direction: 0,
+                op: 0,
+            })
+        ));
+
+        let immediate_asl = DecodedSimpleOp::decode(CpuType::M68040, 0xE347)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(immediate_asl.is_none());
+
+        let immediate_lsl = DecodedSimpleOp::decode(CpuType::M68040, 0xE788)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(matches!(
+            immediate_lsl,
+            Some(JitTraceOp::ShiftReg {
+                reg: 0,
+                size: Size::Long,
+                count_or_reg: 3,
+                count_is_register: false,
+                direction: 1,
+                op: 1,
+            })
+        ));
+
+        let register_asr = DecodedSimpleOp::decode(CpuType::M68040, 0xE267)
+            .unwrap()
+            .to_jit_trace_op();
+        assert!(register_asr.is_none());
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_immediate_asr_matches_interpreter() {
+        let cases = [
+            (Size::Byte, 1u8, 0xA5A5_5581u32),
+            (Size::Byte, 7, 0xA5A5_557Fu32),
+            (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
+            (Size::Word, 1, 0xA5A5_8001u32), // Lemmings' E247 shape
+            (Size::Word, 4, 0xA5A5_7FF0u32),
+            (Size::Word, 0, 0xA5A5_8100u32),
+            (Size::Long, 1, 0x8000_0001u32),
+            (Size::Long, 5, 0x7FFF_FFE0u32),
+            (Size::Long, 0, 0x8100_0080u32),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, encoded_count, initial) in cases {
+                let shift = if encoded_count == 0 {
+                    8
+                } else {
+                    u32::from(encoded_count)
+                };
+                let size_code = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let opcode = 0xE000 | (u16::from(encoded_count) << 9) | (size_code << 6) | 7;
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::ShiftReg {
+                            reg: 7,
+                            size,
+                            count_or_reg: encoded_count,
+                            count_is_register: false,
+                            direction: 0,
+                            op: 0,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x60FC,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0102,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: -4,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(7, initial);
+                expected.set_ccr(0x1F);
+                let (result, shift_cycles) = expected.exec_asr(size, shift, initial & size.mask());
+                expected.set_d(7, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                actual.set_cpu_type(cpu_type);
+                actual.set_d(7, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native ASR loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    packed as u32 as i32,
+                    shift_cycles + 10,
+                    "{cpu_type:?} {size:?} #{shift} cycles"
+                );
+                assert_eq!(actual.d(7), expected.d(7), "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} #{shift} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+                assert_eq!(actual.ppc, 0x0102);
+                assert_eq!(actual.ir, 0x60FC);
+            }
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_immediate_lsl_matches_interpreter() {
+        let cases = [
+            (Size::Byte, 1u8, 0xA5A5_5581u32),
+            (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
+            (Size::Word, 4, 0xA5A5_1801u32),
+            (Size::Word, 0, 0xA5A5_8180u32),
+            (Size::Long, 3, 0x9000_0001u32), // Lemmings' E788 shape
+            (Size::Long, 0, 0x0180_0081u32),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, encoded_count, initial) in cases {
+                let shift = if encoded_count == 0 {
+                    8
+                } else {
+                    u32::from(encoded_count)
+                };
+                let size_code = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let opcode = 0xE108 | (u16::from(encoded_count) << 9) | (size_code << 6);
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::ShiftReg {
+                            reg: 0,
+                            size,
+                            count_or_reg: encoded_count,
+                            count_is_register: false,
+                            direction: 1,
+                            op: 1,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x60FC,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0102,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: -4,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(0, initial);
+                expected.set_ccr(0x1F);
+                let (result, shift_cycles) = expected.exec_lsl(size, shift, initial & size.mask());
+                expected.set_d(0, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                actual.set_cpu_type(cpu_type);
+                actual.set_d(0, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native LSL loop should compile");
+                let packed = unsafe { (compiled.func)(&mut actual) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    packed as u32 as i32,
+                    shift_cycles + 10,
+                    "{cpu_type:?} {size:?} #{shift} cycles"
+                );
+                assert_eq!(actual.d(0), expected.d(0), "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} #{shift} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+                assert_eq!(actual.ppc, 0x0102);
+                assert_eq!(actual.ir, 0x60FC);
+            }
+        }
     }
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -34,6 +34,12 @@ const TRACE_CACHE_SIZE: usize = 4096;
 pub(crate) const TRACE_MAX_OPS: usize = 128;
 pub(crate) const TRACE_MIN_OPS: usize = 3;
 const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
+/// Indirect calls pay trace validation plus a native/Rust boundary on every
+/// visit. In same-binary paired 100-million-instruction runs, six-op register
+/// traces were only 0.6% faster at the median and regressed in one of five
+/// trials. Every seven-op trial won: at least 7.2% across register,
+/// memory-ALU, and memory-heavy mixes.
+const TRACE_MIN_INDIRECT_JSR_OPS: usize = 7;
 const TRACE_HOT_THRESHOLD: u8 = 2;
 const TRACE_ADAPT_WINDOW: u8 = 64;
 const TRACE_ADAPT_MISMATCHES: u8 = 48;
@@ -227,6 +233,12 @@ pub(crate) enum JitTraceOp {
         condition: u8,
         reg: u8,
         displacement: i16,
+    },
+    /// Terminal `JSR (An)`. The target is dynamic, and the return address
+    /// store is checked against the active fastmem window before any CPU
+    /// state is committed.
+    IndirectJsr {
+        reg: u8,
     },
     /// MOVE/MOVEA with at least one register-indirect operand, executed
     /// against the fastmem window (`dst == Addr` is MOVEA). Traces
@@ -833,6 +845,11 @@ impl TraceJit {
                 self.finish_recording(cpu, next_pc);
                 return;
             }
+            JitTraceOp::IndirectJsr { .. } => {
+                self.recording.as_mut().unwrap().ops.push(op);
+                self.finish_recording(cpu, next_pc);
+                return;
+            }
             _ if next_pc != executed_pc.wrapping_add(op_len as u32) => {
                 self.finish_recording(cpu, executed_pc);
                 return;
@@ -904,12 +921,19 @@ impl TraceJit {
             );
         }
 
-        // A checked memory CMP does not amortize trace validation and the
-        // native/Rust boundary in the short non-self-loop regions measured
-        // from Lemmings. Keep those on the already-fast decoded-memory path;
-        // native compilation is profitable only when one validation can be
-        // reused across repeated self-loop iterations.
+        let ends_in_indirect_jsr = ops
+            .last()
+            .is_some_and(|op| matches!(op.op, JitTraceOp::IndirectJsr { .. }));
+        if ends_in_indirect_jsr && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS {
+            return None;
+        }
+
+        // Short checked memory ALU regions do not amortize trace validation
+        // and the native/Rust boundary. Keep those on the decoded-memory path
+        // unless the measured indirect-call length threshold above provides
+        // enough independent work to cover the fixed cost.
         if !self_loop
+            && !ends_in_indirect_jsr
             && ops
                 .iter()
                 .any(|op| matches!(op.op, JitTraceOp::AluMemToReg { .. }))
@@ -925,6 +949,7 @@ impl TraceJit {
                     | JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
+                    | JitTraceOp::IndirectJsr { .. }
             )
         });
 
@@ -1063,6 +1088,10 @@ impl TraceJit {
                     JitTraceOp::AluMemToReg { .. } => {
                         let env = mem_env.as_ref().expect("AluMemToReg implies a window env");
                         emit_alu_mem_to_reg(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
+                    JitTraceOp::IndirectJsr { reg } => {
+                        let env = mem_env.as_ref().expect("IndirectJsr implies a window env");
+                        emit_indirect_jsr(&mut builder, cpu_ptr, *op, reg, env, &mut bails, bail_at)
                     }
                     JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
@@ -1396,6 +1425,7 @@ impl JitTraceOp {
                 4 + src_c + dst_c
             }
             Self::AluMemToReg { .. } => 24,
+            Self::IndirectJsr { .. } => 16,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::AnDispUnary { .. } | Self::AnDispAddqSubq { .. } | Self::AnDispBit { .. } => 24,
@@ -1403,7 +1433,10 @@ impl JitTraceOp {
     }
 
     fn ends_trace(self) -> bool {
-        matches!(self, Self::Branch { .. } | Self::Dbcc { .. })
+        matches!(
+            self,
+            Self::Branch { .. } | Self::Dbcc { .. } | Self::IndirectJsr { .. }
+        )
     }
 
     /// The PC a taken closing branch at `pc` jumps to, if this op is one.
@@ -1433,6 +1466,9 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_branch_word_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
+    if let Some(op) = decode_indirect_jsr_trace_op(pc, opcode) {
+        return Some(op);
+    }
     if let Some(op) = decode_an_disp_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
@@ -1451,6 +1487,21 @@ fn decode_trace_op<B: AddressBus>(
         extension2: None,
         pc,
         op,
+    })
+}
+
+fn decode_indirect_jsr_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
+    if (opcode & 0xFFF8) != 0x4E90 {
+        return None;
+    }
+    Some(TraceBuildOp {
+        opcode,
+        extension: None,
+        extension2: None,
+        pc,
+        op: JitTraceOp::IndirectJsr {
+            reg: (opcode & 7) as u8,
+        },
     })
 }
 
@@ -1785,7 +1836,27 @@ fn execute_portable_op(
     ) {
         return execute_portable_an_disp(cpu, op, code_start, code_end);
     }
+    if let JitTraceOp::IndirectJsr { reg } = op.op {
+        return execute_portable_indirect_jsr(cpu, op, reg);
+    }
     Some(execute_portable_reg_op(cpu, op))
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_indirect_jsr(cpu: &mut CpuCore, trace: TraceBuildOp, reg: u8) -> Option<i32> {
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::Jsr {
+            ea: FastEa::AnInd(reg),
+        },
+    ) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
 }
 
 #[cfg(any(target_family = "wasm", test))]
@@ -2352,6 +2423,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
                 12
             }
         }
+        JitTraceOp::IndirectJsr { .. } => {
+            unreachable!("IndirectJsr is handled by execute_portable_indirect_jsr")
+        }
         JitTraceOp::MoveMem { .. } => {
             unreachable!("MoveMem is handled by execute_portable_move_mem")
         }
@@ -2747,6 +2821,9 @@ fn emit_jit_op(
         | JitTraceOp::AnDispBit { .. } => {
             unreachable!("AnDisp ops are emitted by emit_an_disp_mem")
         }
+        JitTraceOp::IndirectJsr { .. } => {
+            unreachable!("IndirectJsr is emitted by emit_indirect_jsr")
+        }
         JitTraceOp::Branch {
             condition,
             displacement,
@@ -2962,6 +3039,40 @@ fn emit_alu_mem_to_reg(
         }
         _ => unreachable!("unsupported memory-to-register ALU operation"),
     }
+    cycles_const(builder, trace.op.max_cycles())
+}
+
+/// Emit terminal `JSR (An)`. The stack write is checked before the stack
+/// pointer, flow state, or PC changes, so a miss can re-execute the call via
+/// full dispatch. A successful call ends this non-self-loop trace; writing
+/// into its code is therefore safe because any later entry revalidates it.
+#[cfg(not(target_family = "wasm"))]
+fn emit_indirect_jsr(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    reg: u8,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let target = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+    let old_sp = load_reg(builder, cpu, JitDirectReg::Addr(7));
+    let new_sp = builder.ins().iadd_imm(old_sp, -4);
+    let (off, _) = checked_window_off(builder, env, bail, new_sp, Size::Long);
+    let return_pc = iconst_u32(builder, trace.pc.wrapping_add(2));
+    window_store(builder, env, off, Size::Long, return_pc);
+
+    store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
+    store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
+    store_value_u32(builder, cpu, offset_of!(CpuCore, pc), target);
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -4041,6 +4152,65 @@ mod portable_tests {
     }
 
     #[test]
+    fn decodes_indirect_jsr_trace_boundary() {
+        let cpu = cpu();
+        let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
+        mem.write_word(0x0100, 0x4E90); // JSR (A0)
+        let jsr = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jsr.extension, None);
+        assert_eq!(jsr.length(), 2);
+        assert!(matches!(jsr.op, JitTraceOp::IndirectJsr { reg: 0 }));
+        assert!(jsr.op.ends_trace());
+    }
+
+    #[test]
+    fn portable_indirect_jsr_pushes_return_and_changes_flow() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0340);
+        cpu.set_a(7, 0x0800);
+        cpu.change_of_flow = false;
+
+        let op = TraceBuildOp {
+            opcode: 0x4E90,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::IndirectJsr { reg: 0 },
+        };
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102), Some(16));
+        assert_eq!(cpu.a(7), 0x07FC);
+        assert_eq!(&mem[0x07FC..0x0800], &0x0102u32.to_be_bytes());
+        assert_eq!(cpu.pc, 0x0340);
+        assert!(cpu.change_of_flow);
+    }
+
+    #[test]
+    fn portable_indirect_jsr_bails_without_partial_state() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0340);
+        cpu.set_a(7, 2); // decremented SP wraps outside the window
+        cpu.pc = 0x0444;
+        cpu.change_of_flow = false;
+
+        let op = TraceBuildOp {
+            opcode: 0x4E90,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::IndirectJsr { reg: 0 },
+        };
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102), None);
+        assert_eq!(cpu.a(7), 2);
+        assert_eq!(cpu.pc, 0x0444);
+        assert!(!cpu.change_of_flow);
+        assert!(mem.iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
     fn portable_cmp_memory_sets_nzvc_and_preserves_x() {
         let mut cpu = cpu();
         let mut mem = vec![0u8; 0x1000];
@@ -4314,6 +4484,162 @@ mod portable_tests {
             assert_eq!(actual.get_ccr(), expected.get_ccr(), "{cpu_type:?} flags");
             assert_eq!(actual.pc, 0x0100);
         }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn indirect_jsr_profitability_threshold_is_enforced() {
+        let ops_for = |count: usize| {
+            let mut ops = Vec::new();
+            for index in 0..count - 1 {
+                let reg = (index & 7) as u8;
+                ops.push(TraceBuildOp {
+                    opcode: 0x7001 | (u16::from(reg) << 9),
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0100 + index as u32 * 2,
+                    op: JitTraceOp::Moveq { reg, data: 1 },
+                });
+            }
+            ops.push(TraceBuildOp {
+                opcode: 0x4E90,
+                extension: None,
+                extension2: None,
+                pc: 0x0100 + (count - 1) as u32 * 2,
+                op: JitTraceOp::IndirectJsr { reg: 0 },
+            });
+            ops
+        };
+
+        let compile_cpu = cpu();
+        let mut jit = TraceJit::new();
+        assert!(
+            jit.compile_decoded_ops(
+                &compile_cpu,
+                0x0100,
+                CpuType::M68000,
+                ops_for(TRACE_MIN_INDIRECT_JSR_OPS - 1),
+                Some(0x0340),
+            )
+            .is_none(),
+            "six-op indirect-call region should remain decoded"
+        );
+        assert!(
+            jit.compile_decoded_ops(
+                &compile_cpu,
+                0x0100,
+                CpuType::M68000,
+                ops_for(TRACE_MIN_INDIRECT_JSR_OPS),
+                Some(0x0340),
+            )
+            .is_some(),
+            "seven-op indirect-call region should compile"
+        );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_indirect_jsr_commits_only_after_stack_check() {
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x7201,
+                extension: None,
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::Moveq { reg: 1, data: 1 },
+            },
+            TraceBuildOp {
+                opcode: 0x7402,
+                extension: None,
+                extension2: None,
+                pc: 0x0102,
+                op: JitTraceOp::Moveq { reg: 2, data: 2 },
+            },
+            TraceBuildOp {
+                opcode: 0x7603,
+                extension: None,
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::Moveq { reg: 3, data: 3 },
+            },
+            TraceBuildOp {
+                opcode: 0x7804,
+                extension: None,
+                extension2: None,
+                pc: 0x0106,
+                op: JitTraceOp::Moveq { reg: 4, data: 4 },
+            },
+            TraceBuildOp {
+                opcode: 0x7A05,
+                extension: None,
+                extension2: None,
+                pc: 0x0108,
+                op: JitTraceOp::Moveq { reg: 5, data: 5 },
+            },
+            TraceBuildOp {
+                opcode: 0xDE6D,
+                extension: Some(0x0010),
+                extension2: None,
+                pc: 0x010A,
+                op: JitTraceOp::AluMemToReg {
+                    op: JitBinaryOp::Add,
+                    size: Size::Word,
+                    src: JitEa::Disp(5, 0x0010),
+                    dst: 7,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x4E90,
+                extension: None,
+                extension2: None,
+                pc: 0x010E,
+                op: JitTraceOp::IndirectJsr { reg: 0 },
+            },
+        ];
+        let mut compile_cpu = cpu();
+        compile_cpu.set_a(0, 0x0340);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&compile_cpu, 0x0100, CpuType::M68000, ops, Some(0x0340))
+            .expect("indirect JSR region should compile");
+
+        let prepare = |stack: u32| {
+            let mut cpu = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            mem[0x0210..0x0212].copy_from_slice(&1u16.to_be_bytes());
+            attach_window(&mut cpu, &mut mem);
+            cpu.set_a(0, 0x0340);
+            cpu.set_a(5, 0x0200);
+            cpu.set_a(7, stack);
+            cpu.set_d(7, 0xA5A5_7FFF);
+            cpu.set_ccr(0x1F);
+            cpu.change_of_flow = false;
+            (cpu, mem)
+        };
+
+        let (mut success, success_mem) = prepare(0x0800);
+        let packed = unsafe { (compiled.func)(&mut success) };
+        assert_eq!((packed >> 32) as u32, 7);
+        assert_eq!(packed as u32 as i32, 60);
+        assert_eq!(success.d(1), 1);
+        assert_eq!(success.d(7), 0xA5A5_8000);
+        assert_eq!(success.a(7), 0x07FC);
+        assert_eq!(&success_mem[0x07FC..0x0800], &0x0110u32.to_be_bytes());
+        assert_eq!(success.pc, 0x0340);
+        assert_eq!(success.ppc, 0x010E);
+        assert_eq!(success.ir, 0x4E90);
+        assert!(success.change_of_flow);
+
+        let (mut bail, bail_mem) = prepare(2);
+        let packed = unsafe { (compiled.func)(&mut bail) };
+        assert_eq!((packed >> 32) as u32, 6);
+        assert_eq!(packed as u32 as i32, 44);
+        assert_eq!(bail.d(1), 1, "prefix remains committed");
+        assert_eq!(bail.d(7), 0xA5A5_8000, "prefix remains committed");
+        assert_eq!(bail.a(7), 2, "call itself did not commit");
+        assert_eq!(bail.pc, 0x010E, "retry the unexecuted call");
+        assert!(!bail.change_of_flow);
+        assert!(bail_mem[0x07FC..0x0800].iter().all(|&byte| byte == 0));
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -9,7 +9,7 @@ use super::cpu::{CpuCore, NFLAG_SET};
 use super::execute::RUN_MODE_BERR_AERR_RESET;
 use super::mem_ops::{BitSource, DecodedMemOp, FastEa};
 use super::memory::AddressBus;
-use super::op_cache::{BinaryOp, BitOp, CachedRunResult, DecodedSimpleOp};
+use super::op_cache::{BinaryOp, BitOp, CachedRunResult, DecodedSimpleOp, is_pre_68020};
 use super::types::{CpuType, Size};
 #[cfg(not(target_family = "wasm"))]
 use cranelift_codegen::Context;
@@ -76,8 +76,8 @@ pub(crate) enum JitDirectReg {
     Addr(u8),
 }
 
-/// Effective-address forms allowed in memory trace ops. All are one-word
-/// (no extension), so the trace's code bytes stay contiguous and cheap to
+/// Effective-address forms allowed in memory trace ops. Extension words are
+/// captured in the trace so indexed/displacement operands remain cheap to
 /// validate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum JitEa {
@@ -91,13 +91,25 @@ pub(crate) enum JitEa {
     PreDec(u8),
     /// (d16,An), with the extension word captured in the trace.
     Disp(u8, i16),
+    /// Brief (d8,An,Xn), decoded once when the trace is recorded.
+    Index {
+        base: u8,
+        index: JitDirectReg,
+        index_long: bool,
+        scale: u8,
+        displacement: i8,
+    },
 }
 
 impl JitEa {
     fn is_mem(self) -> bool {
         matches!(
             self,
-            Self::Ind(_) | Self::PostInc(_) | Self::PreDec(_) | Self::Disp(_, _)
+            Self::Ind(_)
+                | Self::PostInc(_)
+                | Self::PreDec(_)
+                | Self::Disp(_, _)
+                | Self::Index { .. }
         )
     }
 }
@@ -266,6 +278,13 @@ pub(crate) enum JitTraceOp {
         op: JitBinaryOp,
         size: Size,
         src: JitEa,
+        dst: u8,
+    },
+    /// ADD.W/L Dn,(An)+, the store/accumulate form in Lemmings' hottest
+    /// still-interpreted indexed graphics loop.
+    AddRegToPostInc {
+        size: Size,
+        src: u8,
         dst: u8,
     },
     /// Hot Classic Mac memory forms using the A5-relative global-data
@@ -1037,6 +1056,7 @@ impl TraceJit {
                 op.op,
                 JitTraceOp::MoveMem { .. }
                     | JitTraceOp::AluMemToReg { .. }
+                    | JitTraceOp::AddRegToPostInc { .. }
                     | JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::AnDispAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
@@ -1229,6 +1249,19 @@ impl TraceJit {
                     JitTraceOp::AluMemToReg { .. } => {
                         let env = mem_env.as_ref().expect("AluMemToReg implies a window env");
                         emit_alu_mem_to_reg(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
+                    JitTraceOp::AddRegToPostInc { .. } => {
+                        let env = mem_env
+                            .as_ref()
+                            .expect("AddRegToPostInc implies a window env");
+                        emit_add_reg_to_postinc(
+                            &mut builder,
+                            cpu_ptr,
+                            *op,
+                            env,
+                            &mut bails,
+                            bail_at,
+                        )
                     }
                     JitTraceOp::IndirectJsr { reg } => {
                         let env = mem_env.as_ref().expect("IndirectJsr implies a window env");
@@ -1583,6 +1616,13 @@ impl JitTraceOp {
                             8
                         }
                     }
+                    JitEa::Index { .. } => {
+                        if long {
+                            14
+                        } else {
+                            10
+                        }
+                    }
                 };
                 let dst_c = match dst {
                     JitEa::Disp(_, _) => {
@@ -1590,6 +1630,13 @@ impl JitTraceOp {
                             12
                         } else {
                             8
+                        }
+                    }
+                    JitEa::Index { .. } => {
+                        if long {
+                            14
+                        } else {
+                            10
                         }
                     }
                     _ if dst.is_mem() => {
@@ -1604,6 +1651,13 @@ impl JitTraceOp {
                 4 + src_c + dst_c
             }
             Self::AluMemToReg { .. } => 24,
+            Self::AddRegToPostInc { size, .. } => {
+                if size == Size::Long {
+                    20
+                } else {
+                    12
+                }
+            }
             Self::IndirectJsr { .. } => 16,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
@@ -1652,6 +1706,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_alu_mem_to_reg_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_add_reg_to_postinc_trace_op(pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
@@ -1872,20 +1929,25 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     let mut next_ext = pc.wrapping_add(2);
     let mut extensions = [None, None];
     let mut extension_count = 0usize;
-    let mut read_disp = |mode: u16| -> Option<i16> {
-        if mode != 5 {
+    let mut read_ea_ext = |mode: u16| -> Option<u16> {
+        if mode != 5 && mode != 6 {
             return Some(0);
         }
         let value = bus.try_read_word(cpu.address(next_ext)).ok()?;
         next_ext = next_ext.wrapping_add(2);
         extensions[extension_count] = Some(value);
         extension_count += 1;
-        Some(value as i16)
+        Some(value)
     };
-    let src_disp = read_disp(src_mode)?;
-    let dst_disp = read_disp(dst_mode)?;
-    let src = decode_jit_ea(src_mode, opcode & 7, src_disp)?;
-    let dst = decode_jit_ea(dst_mode, (opcode >> 9) & 7, dst_disp)?;
+    let src_ext = read_ea_ext(src_mode)?;
+    let dst_ext = read_ea_ext(dst_mode)?;
+    let src = decode_jit_ea(src_mode, opcode & 7, src_ext, cpu.cpu_type)?;
+    let dst = decode_jit_ea(dst_mode, (opcode >> 9) & 7, dst_ext, cpu.cpu_type)?;
+    // The measured loop only needs indexed reads. Indexed stores can be
+    // added when a profile demonstrates that their extra emitter paths pay.
+    if matches!(dst, JitEa::Index { .. }) {
+        return None;
+    }
     if !src.is_mem() && !dst.is_mem() {
         return None;
     }
@@ -1899,6 +1961,32 @@ fn decode_move_mem_trace_op<B: AddressBus>(
         extension2: extensions[1],
         pc,
         op: JitTraceOp::MoveMem { size, src, dst },
+    })
+}
+
+fn decode_add_reg_to_postinc_trace_op(
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let DecodedMemOp::AluToMem {
+        op: BinaryOp::Add,
+        size,
+        src,
+        dst: FastEa::AnPostInc(dst),
+    } = DecodedMemOp::decode(cpu_type, opcode)?
+    else {
+        return None;
+    };
+    if !matches!(size, Size::Word | Size::Long) {
+        return None;
+    }
+    Some(TraceBuildOp {
+        opcode,
+        extension: None,
+        extension2: None,
+        pc,
+        op: JitTraceOp::AddRegToPostInc { size, src, dst },
     })
 }
 
@@ -1939,14 +2027,36 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
     })
 }
 
-fn decode_jit_ea(mode: u16, reg: u16, displacement: i16) -> Option<JitEa> {
+fn decode_jit_ea(mode: u16, reg: u16, extension: u16, cpu_type: CpuType) -> Option<JitEa> {
     Some(match mode & 7 {
         0 => JitEa::Data(reg as u8),
         1 => JitEa::Addr(reg as u8),
         2 => JitEa::Ind(reg as u8),
         3 => JitEa::PostInc(reg as u8),
         4 => JitEa::PreDec(reg as u8),
-        5 => JitEa::Disp(reg as u8, displacement),
+        5 => JitEa::Disp(reg as u8, extension as i16),
+        6 => {
+            if !is_pre_68020(cpu_type) && (extension & 0x0100) != 0 {
+                return None;
+            }
+            let index_num = ((extension >> 12) & 7) as u8;
+            let index = if (extension & 0x8000) != 0 {
+                JitDirectReg::Addr(index_num)
+            } else {
+                JitDirectReg::Data(index_num)
+            };
+            JitEa::Index {
+                base: reg as u8,
+                index,
+                index_long: (extension & 0x0800) != 0,
+                scale: if is_pre_68020(cpu_type) {
+                    0
+                } else {
+                    ((extension >> 9) & 3) as u8
+                },
+                displacement: extension as u8 as i8,
+            }
+        }
         _ => return None,
     })
 }
@@ -2006,6 +2116,9 @@ fn execute_portable_op(
     }
     if matches!(op.op, JitTraceOp::AluMemToReg { .. }) {
         return execute_portable_alu_mem_to_reg(cpu, op);
+    }
+    if matches!(op.op, JitTraceOp::AddRegToPostInc { .. }) {
+        return execute_portable_add_reg_to_postinc(cpu, op, code_start, code_end);
     }
     if matches!(
         op.op,
@@ -2155,6 +2268,39 @@ fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Op
     }
 }
 
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_add_reg_to_postinc(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    code_start: u32,
+    code_end: u32,
+) -> Option<i32> {
+    let JitTraceOp::AddRegToPostInc { size, src, dst } = trace.op else {
+        return None;
+    };
+    let raw = cpu.dar[8 + dst as usize];
+    let masked = raw & cpu.address_mask;
+    if masked < code_end && masked.wrapping_add(size.bytes()) > code_start {
+        return None;
+    }
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::AluToMem {
+            op: BinaryOp::Add,
+            size,
+            src,
+            dst: FastEa::AnPostInc(dst),
+        },
+    ) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
 /// Portable MoveMem, mirroring `emit_move_mem` exactly: all checks before
 /// any commit; window reads/writes via the fastmem scratch fields.
 #[cfg(any(target_family = "wasm", test))]
@@ -2212,6 +2358,28 @@ fn execute_portable_move_mem(
         }
         JitEa::Disp(r, displacement) => {
             let a = cpu.dar[8 + r as usize].wrapping_add(displacement as i32 as u32);
+            read(cpu, locate(cpu, a)?)
+        }
+        JitEa::Index {
+            base,
+            index,
+            index_long,
+            scale,
+            displacement,
+        } => {
+            let base = cpu.dar[8 + base as usize];
+            let raw_index = match index {
+                JitDirectReg::Data(r) => cpu.dar[r as usize],
+                JitDirectReg::Addr(r) => cpu.dar[8 + r as usize],
+            };
+            let index = if index_long {
+                raw_index
+            } else {
+                raw_index as u16 as i16 as i32 as u32
+            };
+            let a = base
+                .wrapping_add(index.wrapping_shl(scale as u32))
+                .wrapping_add(displacement as i32 as u32);
             read(cpu, locate(cpu, a)?)
         }
     };
@@ -2286,6 +2454,7 @@ fn execute_portable_move_mem(
             }
             cpu.set_logic_flags(value, size);
         }
+        JitEa::Index { .. } => return None,
     }
 
     Some(JitTraceOp::MoveMem { size, src, dst }.max_cycles())
@@ -2610,6 +2779,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         }
         JitTraceOp::AluMemToReg { .. } => {
             unreachable!("AluMemToReg is handled by execute_portable_alu_mem_to_reg")
+        }
+        JitTraceOp::AddRegToPostInc { .. } => {
+            unreachable!("AddRegToPostInc is handled by execute_portable_add_reg_to_postinc")
         }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
@@ -2995,6 +3167,9 @@ fn emit_jit_op(
         JitTraceOp::AluMemToReg { .. } => {
             unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
         }
+        JitTraceOp::AddRegToPostInc { .. } => {
+            unreachable!("AddRegToPostInc is emitted by emit_add_reg_to_postinc")
+        }
         JitTraceOp::AnDispUnary { .. }
         | JitTraceOp::AnDispAddqSubq { .. }
         | JitTraceOp::AnDispBit { .. } => {
@@ -3228,6 +3403,44 @@ fn emit_alu_mem_to_reg(
     cycles_const(builder, trace.op.max_cycles())
 }
 
+/// Emit ADD.W/L Dn,(An)+. The window, alignment, and self-modification
+/// guards all run before memory, address-register, or flag state is changed.
+#[cfg(not(target_family = "wasm"))]
+fn emit_add_reg_to_postinc(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::AddRegToPostInc { size, src, dst } = trace.op else {
+        unreachable!("expected register-to-postincrement ADD trace")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let addr = load_reg(builder, cpu, JitDirectReg::Addr(dst));
+    let (off, masked) = checked_window_off(builder, env, bail, addr, size);
+    guard_store_not_code(builder, env, bail, masked, size);
+    let dst_value = window_load(builder, env, off, size);
+    let src_value = load_reg(builder, cpu, JitDirectReg::Data(src));
+    let src_value = mask_value(builder, src_value, size);
+    let result = builder.ins().iadd(dst_value, src_value);
+
+    window_store(builder, env, off, size, result);
+    let next = builder
+        .ins()
+        .iadd_imm(addr, i64::from(jit_ea_step(size, dst)));
+    store_reg(builder, cpu, JitDirectReg::Addr(dst), next);
+    set_add_flags(builder, cpu, src_value, dst_value, result, size);
+    cycles_const(builder, trace.op.max_cycles())
+}
+
 /// Emit terminal `JSR (An)`. The stack write is checked before the stack
 /// pointer, flow state, or PC changes, so a miss can re-execute the call via
 /// full dispatch. A successful call ends this non-self-loop trace; writing
@@ -3431,6 +3644,31 @@ fn emit_move_mem(
             let (off, _) = checked_window_off(builder, env, bail, a, size);
             window_load(builder, env, off, size)
         }
+        JitEa::Index {
+            base,
+            index,
+            index_long,
+            scale,
+            displacement,
+        } => {
+            let base = load_an(builder, base);
+            let raw_index = load_reg(builder, cpu, index);
+            let index = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index = if scale == 0 {
+                index
+            } else {
+                builder.ins().ishl_imm(index, i64::from(scale))
+            };
+            let a = builder.ins().iadd(base, index);
+            let a = builder.ins().iadd_imm(a, displacement as i64);
+            let (off, _) = checked_window_off(builder, env, bail, a, size);
+            window_load(builder, env, off, size)
+        }
     };
 
     // A destination base register must observe a same-register source
@@ -3502,6 +3740,7 @@ fn emit_move_mem(
             window_store(builder, env, off, size, value);
             set_logic_flags(builder, cpu, value, size);
         }
+        JitEa::Index { .. } => unreachable!("indexed MOVE destination is not traceable"),
     }
 
     cycles_const(

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -506,7 +506,40 @@ mod tests {
             .find(|row| row.start_pc == 0)
             .expect("two-op loop head was profiled");
         assert_eq!(row.compiled_ops, 2);
+        #[cfg(not(target_family = "wasm"))]
+        assert!(
+            row.native_calls > 1,
+            "two-op read/write loops retain the measured faster one-pass path"
+        );
+        #[cfg(target_family = "wasm")]
         assert!(row.native_calls > 0);
+        assert!(row.jit_retired > 0);
+    }
+
+    #[test]
+    fn cheap_self_loop_iterations_stay_in_one_native_call() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        bus.write_word(0, 0x5280); // ADDQ.L #1,D0
+        bus.write_word(2, 0x60FC); // BRA.S $0000
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 120, &[]);
+        assert_eq!(result.instructions, 120);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("cheap loop head was profiled");
+        assert_eq!(row.compiled_ops, 2);
+        #[cfg(not(target_family = "wasm"))]
+        assert_eq!(row.native_calls, 1);
+        #[cfg(target_family = "wasm")]
+        assert!(row.native_calls > 1);
         assert!(row.jit_retired > 0);
     }
 

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1360,3 +1360,38 @@ fn mem_trace_cmp_sources_match_step() {
         },
     );
 }
+
+/// Lemmings' hottest remaining graphics loop combines scaled brief-indexed
+/// byte reads with word/long ADDs through a postincrement destination. The
+/// compiled loop must match the interpreter's addresses, big-endian stores,
+/// postincrements, and NZVCX results exactly.
+#[test]
+fn mem_trace_indexed_move_and_postinc_add_matches_step() {
+    let words = &[
+        0x2545, 0x0004, // $1000: MOVE.L D5,$0004(A2)
+        0x2086, // $1004: MOVE.L D6,(A0)
+        0x1832, 0x1C00, // $1006: MOVE.B 0(A2,D1.L*4),D4
+        0xD998, // $100A: ADD.L D4,(A0)+
+        0x1832, 0x1C01, // $100C: MOVE.B 1(A2,D1.L*4),D4
+        0xD998, // $1010: ADD.L D4,(A0)+
+        0x1832, 0x1C02, // $1012: MOVE.B 2(A2,D1.L*4),D4
+        0xD958, // $1016: ADD.W D4,(A0)+
+        0x51C8, 0xFFEC, // $1018: DBRA D0,$1006
+        0xA000, // $101C: sentinel
+    ];
+    assert_fastmem_matches_step(
+        "mem-trace indexed/add-postinc",
+        words,
+        CpuType::M68040,
+        |cpu| {
+            cpu.set_a(0, 0x3000);
+            cpu.set_a(2, 0x2000);
+            cpu.set_d(0, 127);
+            cpu.set_d(1, 1);
+            cpu.set_d(4, 0xA5A5_A5A5);
+            cpu.set_d(5, 0x7F01_80FF);
+            cpu.set_d(6, 0x7FFF_FF80);
+            cpu.set_ccr(0x10);
+        },
+    );
+}


### PR DESCRIPTION
Depends on #28, and therefore transitively on #27, #26, and #25. Please review the final commit independently; prerequisite commits will disappear from this diff as the earlier PRs merge.

## Summary

- trace brief indexed `MOVE.B (d8,An,Xn),Dn` reads, including 68020+ scale and word/long index semantics
- trace the measured `ADD.W/L Dn,(An)+` store/accumulate forms
- keep indexed MOVE destinations, other ALU-to-memory forms, and 68020 full-format indexed extensions on existing paths
- emit checked native fast-memory accesses with alignment, bounds, self-modification, and precise pre-commit bailout guards
- mirror the operations in the portable trace executor and add interpreter differential coverage
- add a permanent 21-instruction benchmark reproducing the profiled Lemmings loop shape

## Why

After #28, a 109,562,805-instruction Lemmings trace-opportunity run showed one graphics loop still executing wholly through decoded memory dispatch. Its hot sites were:

- five indexed byte loads (`1832`): 978,872 executions each, 4,894,360 total
- two long postincrement ADDs (`D998`): 1,957,744 executions in that loop
- one word postincrement ADD (`D958`): 978,872 executions in that loop
- the closing `DBF`: 978,872 executions

The JIT already handled the closing `DBF`, but it could not record either memory form, so the entire loop remained interpreted. This change implements only the forms demonstrated by that profile.

## Controlled before/after benchmark

The committed `lemmings-indexed-loop` benchmark preserves the measured memory-op mix and 21-instruction loop length, with deterministic register-only filler. Release results on an Intel MacBookPro16,1 are medians of seven runs:

| Build | Median throughput |
|---|---:|
| #28 stack (before) | 78.4 M guest instructions/s |
| This PR (after) | 824.4 M guest instructions/s |

That is a **10.5x throughput increase** for the formerly decoded loop shape.

Existing benchmark medians remained stable:

| Existing workload | #28 result | This PR | Change |
|---|---:|---:|---:|
| weighted two-op memory loops | 241.4 M/s | 245.2 M/s | +1.6% |
| weighted mixed self-loops | 513.0 M/s | 525.8 M/s | +2.5% |

Those small positive differences are within normal host-frequency variation; the important result is that neither existing path regressed.

## Whole-emulator profile

Matched 30-second production samples of active Lemmings level 1 compared the #28 stack with this one additional commit:

| Sample metric | Before | After | Change |
|---|---:|---:|---:|
| `FixtureRunner` subtree | 351 | 319 | **-9.1%** |
| decoded `execute_mem_op` subtree | 56 | 47 | **-16.1%** |
| `FixtureRunner` self-time | 173 | 123 | **-28.9%** |

The application gain is expected to be much smaller than the isolated 10.5x result: the targeted loop accounts for roughly 8% of the measured guest instruction stream, while the whole sample also includes other guest code, Toolbox traps, audio, presentation, and idle time.

## Correctness and safety

- brief index extensions are decoded once into base/index register, word-vs-long width, scale, and signed displacement
- pre-68020 CPUs ignore scale bits, matching the existing fast-memory decoder
- 68020+ full-format extensions remain on the existing fallback path
- native bounds/alignment and self-modification checks run before memory, address-register, or flag state changes
- a failed check returns the exact retired/cycle progress and re-executes the uncommitted instruction normally
- the integration test compares batched/native execution with `step()` for scaled indexed reads, big-endian word/long stores, postincrement state, memory contents, instruction count, PC, and NZVCX flags on a 68040

Validation performed locally:

- `cargo test --all-targets`
- focused indexed-loop interpreter differential test
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The local Rust installation does not include `wasm32-unknown-unknown`, so I could not run a direct wasm-target check. The portable executor is compiled and exercised by the native test configuration (`cfg(test)` shares the wasm implementation).
