### PR TITLE
perf: JIT data-only MOVEM.W postincrement loops

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -180,9 +180,9 @@ fn measure_batch_loop_at(words: &[u16], instrs: u32, code_base: usize) -> f64 {
     };
 
     let mut warm_cpu = prepare_cpu();
-    // Systemless always watches PC 0 as its clean-exit sentinel. An
-    // unrelated watched PC must not force a nonzero self-loop to execute
-    // only one iteration per native trace call.
+    // Some callers always watch PC 0 as a clean-exit sentinel. An unrelated
+    // watched PC must not force a nonzero self-loop to execute only one
+    // iteration per native trace call.
     let warm = warm_cpu.run_batch(&mut bus, 5_000_000, &[0]);
     assert_eq!(warm.instructions, 5_000_000);
 
@@ -214,9 +214,9 @@ fn bench_one_shot_trace(head_ops: usize, instrs: u32) {
     );
 }
 
-fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
+fn bench_one_shot_displacement_trace(head_ops: usize, instrs: u32) {
     assert!((2..=9).contains(&head_ops));
-    let a5_ops: &[&[u16]] = &[
+    let displacement_ops: &[&[u16]] = &[
         &[0x4A2D, 0x0100],         // TST.B $0100(A5)
         &[0x526D, 0x0100],         // ADDQ.W #1,$0100(A5)
         &[0x322D, 0x0100],         // MOVE.W $0100(A5),D1
@@ -226,7 +226,7 @@ fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
     ];
     let mut words = Vec::new();
     for i in 0..head_ops - 1 {
-        words.extend_from_slice(a5_ops[i % a5_ops.len()]);
+        words.extend_from_slice(displacement_ops[i % displacement_ops.len()]);
     }
     words.push(0x6002); // BRA.B over the padding word
     words.push(0x4E71); // padding, never executed
@@ -238,7 +238,7 @@ fn bench_one_shot_a5_trace(head_ops: usize, instrs: u32) {
 
     bench_batch_loop_at(
         "batch",
-        &format!("A5 one-shot {head_ops}"),
+        &format!("d16(An) one-shot {head_ops}"),
         &words,
         instrs,
         0x800 + head_ops * 0x40,
@@ -295,11 +295,10 @@ fn blocked_self_loop(prefix_ops: usize, blocker: &[u16]) -> Vec<u16> {
     words
 }
 
-/// Isolate the largest rejected trace from the Lemmings profile: a hot
-/// region executed 24 traceable operations before `ASR.W #1,D7`, then seven
-/// more before `LSL.L #3,D0`. The surrounding ADDQs are synthetic; this
-/// benchmark measures the cost of rejecting versus compiling that topology,
-/// while the application profile measures its end-to-end importance.
+/// Measure a rejected-trace shape with 24 traceable operations before
+/// `ASR.W #1,D7`, then seven more before `LSL.L #3,D0`. The surrounding
+/// ADDQs are synthetic so the benchmark isolates the cost of rejecting
+/// versus compiling that topology.
 fn bench_immediate_shift_trace() {
     let mut words = vec![0x5280; 24];
     words.push(0xE247);
@@ -318,11 +317,9 @@ fn bench_immediate_shift_trace() {
     );
 }
 
-/// Isolate the largest remaining rejected trace in the post-shift Lemmings
-/// profile: seven traceable operations followed by `ADD.W d16(A5),D7`.
-/// The ADDQ prefix is synthetic; the measured application profile establishes
-/// how often the real trace executes, while this benchmark measures the cost
-/// of admitting its memory-source ADD rather than rejecting the whole trace.
+/// Measure seven traceable operations followed by `ADD.W d16(A5),D7`.
+/// The ADDQ prefix is synthetic so the benchmark isolates the cost of
+/// admitting its memory-source ADD rather than rejecting the whole trace.
 fn bench_memory_add_trace() {
     let words = blocked_self_loop(7, &[0xDE6D, 0x0100]);
     bench_batch_loop_at("batch", "ADD.W d16(A5),D7 p7", &words, 200_000_000, 0x7800);
@@ -391,7 +388,7 @@ impl IndirectJsrMix {
 /// Measure a non-self-loop region ending in `JSR (A0)`, followed by an RTS
 /// and a backward branch that re-enters the region. The three mixes separate
 /// fixed trace/call overhead from the savings available for register-only,
-/// Lemmings-like memory-ALU, and memory-heavy Classic Mac code.
+/// memory-ALU, and memory-heavy code.
 fn measure_indirect_jsr_region(
     mix: IndirectJsrMix,
     head_ops: usize,
@@ -463,15 +460,14 @@ fn bench_indirect_jsr_case(mix: IndirectJsrMix, head_ops: usize, instrs: u32) {
     );
 }
 
-/// Replay the three dominant rejected-trace shapes observed during a
-/// 206,780,516-instruction Lemmings run. Instruction budgets preserve their
-/// measured rejected-loop ratio (483,003 : 399,980 : 407,271). These are the
-/// dynamic backedges minus the initial visit that installs each trace
+/// Replay three profiled rejected-trace shapes. Instruction budgets preserve
+/// their measured rejected-loop ratio (483,003 : 399,980 : 407,271). These
+/// are the dynamic backedges minus the initial visit that installs each trace
 /// candidate; consulting the actual trace slot avoids undercounting when the
 /// PC falls out of the CPU's four-entry skip filter. Each case's instruction
 /// budget also includes its full synthetic loop length, avoiding the prefix-
 /// length double-weighting that a projected-dispatch ratio causes.
-fn bench_lemmings_opportunities() {
+fn bench_profiled_opportunities() {
     const SCALE: u32 = 10;
     let cases = [
         (
@@ -507,16 +503,16 @@ fn bench_lemmings_opportunities() {
         );
     }
     println!(
-        "batch     Lemmings weighted  {:8.1} M instr/s",
+        "batch     profiled weighted  {:8.1} M instr/s",
         total_instrs as f64 / total_elapsed / 1_000_000.0
     );
 }
 
-/// Optimistic counterpart to `lemmings-opportunities`: the same measured
+/// Optimistic counterpart to `profiled-opportunities`: the same measured
 /// blocker mix when the instruction following the captured prefix eventually
 /// closes directly back to the trace head. This is the only topology for
 /// which memory CMP traces are admitted after the round-trip regression test.
-fn bench_lemmings_self_loops() {
+fn bench_profiled_self_loops() {
     const SCALE: u32 = 10;
     let cases = [
         (
@@ -551,7 +547,7 @@ fn bench_lemmings_self_loops() {
         );
     }
     println!(
-        "batch     Lemmings self-loop {:8.1} M instr/s",
+        "batch     profiled self-loop {:8.1} M instr/s",
         total_instrs as f64 / total_elapsed / 1_000_000.0
     );
 }
@@ -560,7 +556,7 @@ fn bench_lemmings_self_loops() {
 /// traces are two-instruction copy/fill loops. Each synthetic outer loop
 /// resets its pointers and counter so the measured inner DBRA loop can run
 /// indefinitely without leaving the fastmem window.
-fn bench_lemmings_two_op_memory_loops() {
+fn bench_profiled_two_op_memory_loops() {
     const SCALE: u32 = 10;
     let cases = [
         (
@@ -612,18 +608,16 @@ fn bench_lemmings_two_op_memory_loops() {
         );
     }
     println!(
-        "batch     Lemmings two-op loops   {:8.1} M instr/s",
+        "batch     profiled two-op loops   {:8.1} M instr/s",
         total_instrs as f64 / total_elapsed / 1_000_000.0
     );
 }
 
-/// Reproduce the hottest wholly interpreted loop in the post-batching
-/// Lemmings profile.  The real loop has five indexed byte loads, two long
-/// and one word register-to-memory ADDs, twelve register-only instructions,
-/// and a closing DBRA.  Keeping the same 21-instruction shape makes this a
-/// useful end-to-end measure of whether tracing the missing memory forms
-/// amortizes validation, guards, and native entry.
-fn bench_lemmings_indexed_memory_loop() {
+/// Exercise five indexed byte loads, two long and one word register-to-memory
+/// ADDs, twelve register-only instructions, and a closing DBRA. Keeping the
+/// same 21-instruction shape provides an end-to-end measure of whether tracing
+/// the missing memory forms amortizes validation, guards, and native entry.
+fn bench_indexed_memory_loop() {
     const INSTRS: u32 = 210_000_000;
     let words = [
         0x2042, // outer: MOVEA.L D2,A0
@@ -640,12 +634,65 @@ fn bench_lemmings_indexed_memory_loop() {
         0x51C8, 0xFFCC, // DBRA D0,inner
         0x60C2, // BRA.S outer
     ];
-    bench_batch_loop_at("batch", "Lemmings indexed loop", &words, INSTRS, 0x7000);
+    bench_batch_loop_at("batch", "indexed memory loop", &words, INSTRS, 0x7000);
 }
 
-/// Reproduce the path bias observed at Lemmings `$2AD5C`: the trace is first
-/// recorded through an uncommon conditional edge, then the workload settles
-/// into a copy loop reached through the opposite edge. A first-path-only
+/// Exercise a MOVEM.W that loads seven signed lookup indexes, seven indexed
+/// byte MOVEs that write looked-up values contiguously, and a closing DBRA.
+/// Keeping MOVEM in the complete loop ensures the benchmark covers trace
+/// admission as well as the indexed operations.
+fn bench_movem_indexed_loop() {
+    const INSTRS: u32 = 210_000_000;
+    const CODE_BASE: u32 = 0x7000;
+    let words = [
+        0x204B, // outer: MOVEA.L A3,A0 (index-list source)
+        0x224C, // MOVEA.L A4,A1 (byte destination)
+        0x244D, // MOVEA.L A5,A2 (lookup table)
+        0x707F, // MOVEQ #127,D0
+        0x4C98, 0x00FE, // inner: MOVEM.W (A0)+,D1-D7
+        0x12F2, 0x1000, // MOVE.B 0(A2,D1.W),(A1)+
+        0x12F2, 0x2000, // MOVE.B 0(A2,D2.W),(A1)+
+        0x12F2, 0x3000, // MOVE.B 0(A2,D3.W),(A1)+
+        0x12F2, 0x4000, // MOVE.B 0(A2,D4.W),(A1)+
+        0x12F2, 0x5000, // MOVE.B 0(A2,D5.W),(A1)+
+        0x12F2, 0x6000, // MOVE.B 0(A2,D6.W),(A1)+
+        0x12F2, 0x7000, // MOVE.B 0(A2,D7.W),(A1)+
+        0x51C8, 0xFFDE, // DBRA D0,inner
+        0x60D2, // BRA.S outer
+    ];
+    let mut bus = LinearMemoryBus::new(0x10000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(3, 0x4000);
+        cpu.set_a(4, 0x5000);
+        cpu.set_a(5, 0x6000);
+        cpu.set_a(7, 0x8000);
+        cpu
+    };
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "batch     MOVEM indexed loop      {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
+/// Reproduce a path-biased trace that is first recorded through an uncommon
+/// conditional edge before settling into a copy loop on the opposite edge.
+/// A first-path-only
 /// recorder keeps side-exiting after the CMP/branch pair and interprets the
 /// MOVE/DBRA pair even though the four-op common path is a profitable loop.
 fn bench_trace_branch_bias() {
@@ -785,20 +832,24 @@ fn main() {
         }
         return;
     }
-    if only.as_deref() == Some("lemmings-opportunities") {
-        bench_lemmings_opportunities();
+    if only.as_deref() == Some("profiled-opportunities") {
+        bench_profiled_opportunities();
         return;
     }
-    if only.as_deref() == Some("lemmings-self-loops") {
-        bench_lemmings_self_loops();
+    if only.as_deref() == Some("profiled-self-loops") {
+        bench_profiled_self_loops();
         return;
     }
-    if only.as_deref() == Some("lemmings-two-op-loops") {
-        bench_lemmings_two_op_memory_loops();
+    if only.as_deref() == Some("profiled-two-op-loops") {
+        bench_profiled_two_op_memory_loops();
         return;
     }
-    if only.as_deref() == Some("lemmings-indexed-loop") {
-        bench_lemmings_indexed_memory_loop();
+    if only.as_deref() == Some("indexed-memory-loop") {
+        bench_indexed_memory_loop();
+        return;
+    }
+    if only.as_deref() == Some("movem-indexed-loop") {
+        bench_movem_indexed_loop();
         return;
     }
     if only.as_deref() == Some("trace-branch-bias") {
@@ -836,9 +887,9 @@ fn main() {
         }
         return;
     }
-    if only.as_deref() == Some("a5-trace-calls") {
+    if only.as_deref() == Some("displacement-trace-calls") {
         for head_ops in 2..=9 {
-            bench_one_shot_a5_trace(head_ops, 50_000_000);
+            bench_one_shot_displacement_trace(head_ops, 50_000_000);
         }
         return;
     }
@@ -868,13 +919,12 @@ fn main() {
         bench_set::<PlainBenchBus>("plain");
         bench_set::<LinearMemoryBus>("linearbus");
     }
-    // A5-relative globals and stack temporaries dominate classic Mac code.
-    // This loop mirrors the hottest Lemmings opcode forms found by runtime
-    // profiling while remaining deterministic and self-contained.
+    // Exercise displacement-based globals and stack temporaries in a
+    // deterministic, self-contained loop.
     if only.as_deref() != Some("legacy") {
         bench_batch_loop(
             "batch",
-            "classic Mac mix",
+            "displacement mix",
             &[
                 0x4A2D, 0x0100, // TST.B $0100(A5)
                 0x082D, 0x0003, 0x0100, // BTST #3,$0100(A5)

--- a/src/core/mem_ops.rs
+++ b/src/core/mem_ops.rs
@@ -118,6 +118,11 @@ pub(crate) enum DecodedMemOp {
         src: FastEa,
         dst: FastEa,
     },
+    /// MOVEM.W (An)+,<register list>. The fast path accepts data-register-
+    /// only masks at execution time; other lists fall back atomically.
+    MovemWordPostInc {
+        base: u8,
+    },
     /// ADD/SUB/AND/OR/CMP `<ea>,Dn`
     AluToReg {
         op: BinaryOp,
@@ -323,6 +328,12 @@ fn decode_group_0(opcode: u16) -> Option<DecodedMemOp> {
 fn decode_group_4(cpu_type: CpuType, opcode: u16) -> Option<DecodedMemOp> {
     if opcode == 0x4E75 {
         return Some(DecodedMemOp::Rts);
+    }
+
+    if (opcode & 0xFFF8) == 0x4C98 {
+        return Some(DecodedMemOp::MovemWordPostInc {
+            base: (opcode & 7) as u8,
+        });
     }
 
     // LEA: 0100 rrr1 11mm mrrr
@@ -773,11 +784,47 @@ fn fast_move(cpu: &mut CpuCore, win: Win, size: Size, src: FastEa, dst: FastEa) 
     Some(true)
 }
 
-/// Specialized execution for the common A5-relative data accesses emitted
-/// by classic Mac compilers. AnDisp is unusually hot because A5 is the
-/// application's global-data base. Keeping the extension cursor, resolved
-/// offset and value in locals avoids the generic Ctx/Pending/Loc state
-/// machine while retaining its all-checks-before-commit fallback contract.
+/// Data-register-only MOVEM.W (An)+. The extension word and complete source
+/// span are checked before any destination register or An is changed.
+#[inline]
+fn fast_movem_word_postinc(cpu: &mut CpuCore, win: Win, base: u8) -> bool {
+    let Some(mask_off) = win.off(cpu.address(cpu.pc), 2) else {
+        return false;
+    };
+    let mask = win.read(mask_off, Size::Word) as u16;
+    if mask == 0 || (mask & 0xFF00) != 0 {
+        return false;
+    }
+    let data_mask = mask as u8;
+    let bytes = data_mask.count_ones() * 2;
+    let raw = cpu.dar[8 + base as usize];
+    if cpu.is_pre_68020 && (raw & 1) != 0 {
+        return false;
+    }
+    let masked = cpu.address(raw);
+    if bytes > win.len || masked as u64 + bytes as u64 > cpu.address_mask as u64 + 1 {
+        return false;
+    }
+    let Some(mut off) = win.off(masked, bytes) else {
+        return false;
+    };
+
+    for reg in 0..8 {
+        if (data_mask & (1 << reg)) == 0 {
+            continue;
+        }
+        cpu.dar[reg] = win.read(off, Size::Word) as u16 as i16 as i32 as u32;
+        off += 2;
+    }
+    cpu.dar[8 + base as usize] = raw.wrapping_add(bytes);
+    cpu.pc = cpu.pc.wrapping_add(2);
+    true
+}
+
+/// Specialized execution for d16(An) data accesses. Keeping the extension
+/// cursor, resolved offset, and value in locals avoids the generic
+/// Ctx/Pending/Loc state machine while retaining its all-checks-before-commit
+/// fallback contract.
 #[inline]
 fn fast_an_disp(cpu: &mut CpuCore, win: Win, op: DecodedMemOp) -> Option<bool> {
     let read_word = |cpu: &CpuCore, pc: u32| -> Result<u32, ()> {
@@ -1291,6 +1338,10 @@ pub(crate) fn execute_mem_op(cpu: &mut CpuCore, op: DecodedMemOp) -> bool {
         return handled;
     }
 
+    if let DecodedMemOp::MovemWordPostInc { base } = op {
+        return fast_movem_word_postinc(cpu, win, base);
+    }
+
     if let Some(handled) = fast_an_disp(cpu, win, op) {
         return handled;
     }
@@ -1343,6 +1394,9 @@ pub(crate) fn execute_mem_op(cpu: &mut CpuCore, op: DecodedMemOp) -> bool {
             cpu.set_logic_flags(value, size);
             finish_pc!();
             true
+        }
+        DecodedMemOp::MovemWordPostInc { .. } => {
+            unreachable!("MOVEM.W postincrement is handled by its fast path")
         }
         DecodedMemOp::AluToReg { op, size, src, dst } => {
             let Some(src_loc) = resolve(cpu, win, src, size, &mut ctx) else {
@@ -1730,6 +1784,46 @@ mod tests {
         cpu.pc = 0x100;
         cpu.set_a(5, 0x400);
         cpu
+    }
+
+    #[test]
+    fn fast_movem_word_postincrement_is_atomic_and_sign_extends() {
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x100..0x102].copy_from_slice(&0x00FEu16.to_be_bytes());
+        let words = [0x8000u16, 1, 0x7FFF, 0xFFFF, 0, 0x1234, 0xABCD];
+        for (index, word) in words.into_iter().enumerate() {
+            mem[0x200 + index * 2..0x202 + index * 2].copy_from_slice(&word.to_be_bytes());
+        }
+        let mut cpu = cpu_with_window(&mut mem);
+        cpu.set_a(0, 0x200);
+        cpu.set_ccr(0x1F);
+        assert!(execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::MovemWordPostInc { base: 0 }
+        ));
+        assert_eq!(cpu.pc, 0x102);
+        assert_eq!(cpu.a(0), 0x20E);
+        assert_eq!(cpu.d(1), 0xFFFF_8000);
+        assert_eq!(cpu.d(2), 1);
+        assert_eq!(cpu.d(3), 0x7FFF);
+        assert_eq!(cpu.d(4), 0xFFFF_FFFF);
+        assert_eq!(cpu.d(7), 0xFFFF_ABCD);
+        assert_eq!(cpu.get_ccr(), 0x1F);
+
+        cpu.pc = 0x100;
+        cpu.set_a(0, 0x0FFA); // complete seven-word source span is outside RAM
+        for reg in 1..8 {
+            cpu.set_d(reg, 0xA000_0000 | reg as u32);
+        }
+        assert!(!execute_mem_op(
+            &mut cpu,
+            DecodedMemOp::MovemWordPostInc { base: 0 }
+        ));
+        assert_eq!(cpu.pc, 0x100);
+        assert_eq!(cpu.a(0), 0x0FFA);
+        for reg in 1..8 {
+            assert_eq!(cpu.d(reg), 0xA000_0000 | reg as u32);
+        }
     }
 
     #[test]

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1043,8 +1043,8 @@ impl CpuCore {
                 probe = false;
                 // A self-loop only needs to stop after one iteration when
                 // returning to its own head would hit a watched PC. Merely
-                // having an unrelated watch (Systemless always watches PC
-                // 0 for clean exit) must not serialize every JIT iteration.
+                // having an unrelated watch (for example, a clean-exit
+                // sentinel at PC 0) must not serialize every JIT iteration.
                 let single_iter = watch && watch_pcs.contains(&self.pc);
                 if let Some((result, instructions)) = trace_jit::try_execute_trace(
                     self,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -272,6 +272,14 @@ pub(crate) enum JitTraceOp {
         src: JitEa,
         dst: JitEa,
     },
+    /// MOVEM.W (An)+,<data-register mask>. Keeping this deliberately narrow
+    /// avoids the architectural corner cases of address registers in a
+    /// postincrement MOVEM list.
+    MovemWordPostInc {
+        base: u8,
+        data_mask: u8,
+        cycles: i32,
+    },
     /// Read-only ALU operation from fast memory to a data register. The
     /// decoder admits measured CMP/ADD/SUB `(An)`/`d16(An)` sources.
     AluMemToReg {
@@ -280,16 +288,14 @@ pub(crate) enum JitTraceOp {
         src: JitEa,
         dst: u8,
     },
-    /// ADD.W/L Dn,(An)+, the store/accumulate form in Lemmings' hottest
-    /// still-interpreted indexed graphics loop.
+    /// ADD.W/L Dn,(An)+ store/accumulate operations.
     AddRegToPostInc {
         size: Size,
         src: u8,
         dst: u8,
     },
-    /// Hot Classic Mac memory forms using the A5-relative global-data
-    /// convention. These require extension words, so they are represented
-    /// explicitly rather than going through the register-only trace ops.
+    /// Displacement-memory forms that require extension words, represented
+    /// explicitly rather than through the register-only trace operations.
     AnDispUnary {
         op: JitUnaryOp,
         size: Size,
@@ -348,8 +354,8 @@ struct CompiledTrace {
     /// extra loop-carried state costs more than the saved call boundary.
     #[cfg(not(target_family = "wasm"))]
     native_loop: bool,
-    /// Contains `MoveMem` ops: only executable while a fastmem window is
-    /// active (i.e. inside `run_batch`).
+    /// Contains memory ops: only executable while a fastmem window is active
+    /// (i.e. inside `run_batch`).
     needs_window: bool,
     /// Address-masked range of the trace's code bytes; trace stores into
     /// this range bail so self-modification is observed like the
@@ -611,8 +617,8 @@ impl TraceJit {
             if instr_budget < ops_len {
                 return None;
             }
-            // A generated loop clearly amortizes the ABI boundary for the
-            // mixed 3+-op and read-only loops measured from Lemmings. A
+            // A generated loop clearly amortizes the ABI boundary for
+            // profiled mixed 3+-op and read-only loops. A
             // two-op read/write MoveMem loop is already dominated by its two
             // checked guest accesses; carrying native loop state made that
             // case 3.5% slower at the median, so retain the old one-pass
@@ -1055,6 +1061,7 @@ impl TraceJit {
             matches!(
                 op.op,
                 JitTraceOp::MoveMem { .. }
+                    | JitTraceOp::MovemWordPostInc { .. }
                     | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::AddRegToPostInc { .. }
                     | JitTraceOp::AnDispUnary { .. }
@@ -1111,8 +1118,8 @@ impl TraceJit {
             aligned_only,
             address_mask,
         } = params;
-        // Matched Lemmings and microbenchmark profiles show a clear win for
-        // mixed 3+-op and read-only self-loops. A two-op read/write MoveMem
+        // Matched application and microbenchmark profiles show a clear win
+        // for mixed 3+-op and read-only self-loops. A two-op read/write MoveMem
         // loop regresses when it carries counters around the generated loop,
         // so compile that shape with the original linear body instead of
         // trying to disable batching only at call time.
@@ -1241,6 +1248,19 @@ impl TraceJit {
                                 src,
                                 dst,
                             },
+                            env,
+                            &mut bails,
+                            bail_at,
+                        )
+                    }
+                    JitTraceOp::MovemWordPostInc { .. } => {
+                        let env = mem_env
+                            .as_ref()
+                            .expect("MovemWordPostInc implies a window env");
+                        emit_movem_word_postinc(
+                            &mut builder,
+                            cpu_ptr,
+                            *op,
                             env,
                             &mut bails,
                             bail_at,
@@ -1650,6 +1670,7 @@ impl JitTraceOp {
                 };
                 4 + src_c + dst_c
             }
+            Self::MovemWordPostInc { cycles, .. } => cycles,
             Self::AluMemToReg { .. } => 24,
             Self::AddRegToPostInc { size, .. } => {
                 if size == Size::Long {
@@ -1711,6 +1732,9 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_add_reg_to_postinc_trace_op(pc, opcode, cpu_type) {
         return Some(op);
     }
+    if let Some(op) = decode_movem_word_postinc_trace_op(cpu, bus, pc, opcode) {
+        return Some(op);
+    }
     if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
@@ -1723,6 +1747,40 @@ fn decode_trace_op<B: AddressBus>(
         extension2: None,
         pc,
         op,
+    })
+}
+
+/// Decode data-register-only MOVEM.W postincrement. Restricting the mask to
+/// D0-D7 makes the loads and final address update independent: no loaded
+/// register can alias the base An, so the operation has a simple all-or-bail
+/// implementation.
+fn decode_movem_word_postinc_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+) -> Option<TraceBuildOp> {
+    // 0100 1100 10 011 rrr = MOVEM.W (Ar)+,<register list>.
+    if (opcode & 0xFFF8) != 0x4C98 {
+        return None;
+    }
+    let mask = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+    if mask == 0 || (mask & 0xFF00) != 0 {
+        return None;
+    }
+    let data_mask = mask as u8;
+    let cycles = 12 + 4 * data_mask.count_ones() as i32;
+    // The per-mode timing overhead is zero for (An)+ on every CPU path.
+    Some(TraceBuildOp {
+        opcode,
+        extension: Some(mask),
+        extension2: None,
+        pc,
+        op: JitTraceOp::MovemWordPostInc {
+            base: (opcode & 7) as u8,
+            data_mask,
+            cycles,
+        },
     })
 }
 
@@ -1990,9 +2048,9 @@ fn decode_add_reg_to_postinc_trace_op(
     })
 }
 
-/// CMP/ADD/SUB `<ea>,Dn` for the two addressing forms that dominate rejected
-/// Lemmings traces. The access itself is emitted against the fastmem window;
-/// the extension word is captured for validation and displacement baking.
+/// CMP/ADD/SUB `<ea>,Dn` for indirect and displacement source forms. The
+/// access itself is emitted against the fastmem window; the extension word
+/// is captured for validation and displacement baking.
 fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
     cpu: &CpuCore,
     bus: &mut B,
@@ -2114,6 +2172,9 @@ fn execute_portable_op(
     if let JitTraceOp::MoveMem { size, src, dst } = op.op {
         return execute_portable_move_mem(cpu, size, src, dst, code_start, code_end);
     }
+    if matches!(op.op, JitTraceOp::MovemWordPostInc { .. }) {
+        return execute_portable_movem_word_postinc(cpu, op);
+    }
     if matches!(op.op, JitTraceOp::AluMemToReg { .. }) {
         return execute_portable_alu_mem_to_reg(cpu, op);
     }
@@ -2132,6 +2193,50 @@ fn execute_portable_op(
         return execute_portable_indirect_jsr(cpu, op, reg);
     }
     Some(execute_portable_reg_op(cpu, op))
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn execute_portable_movem_word_postinc(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
+    let JitTraceOp::MovemWordPostInc {
+        base,
+        data_mask,
+        cycles,
+    } = trace.op
+    else {
+        return None;
+    };
+    let bytes = data_mask.count_ones() * 2;
+    let raw = cpu.dar[8 + base as usize];
+    if cpu.is_pre_68020 && (raw & 1) != 0 {
+        return None;
+    }
+    let masked = raw & cpu.address_mask;
+    if bytes == 0
+        || bytes > cpu.fm_len
+        || masked as u64 + bytes as u64 > cpu.address_mask as u64 + 1
+    {
+        return None;
+    }
+    let off = masked.wrapping_sub(cpu.fm_base);
+    if off > cpu.fm_len - bytes {
+        return None;
+    }
+
+    let mut next_off = off as usize;
+    for reg in 0..8 {
+        if (data_mask & (1 << reg)) == 0 {
+            continue;
+        }
+        let value = unsafe {
+            let p = (cpu.fm_ptr as *const u8).add(next_off);
+            u16::from_be_bytes([*p, *p.add(1)]) as i16 as i32 as u32
+        };
+        cpu.dar[reg] = value;
+        next_off += 2;
+    }
+    cpu.dar[8 + base as usize] = raw.wrapping_add(bytes);
+    cpu.pc = trace.pc.wrapping_add(4);
+    Some(cycles)
 }
 
 #[cfg(any(target_family = "wasm", test))]
@@ -2777,6 +2882,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::MoveMem { .. } => {
             unreachable!("MoveMem is handled by execute_portable_move_mem")
         }
+        JitTraceOp::MovemWordPostInc { .. } => {
+            unreachable!("MovemWordPostInc is handled by execute_portable_movem_word_postinc")
+        }
         JitTraceOp::AluMemToReg { .. } => {
             unreachable!("AluMemToReg is handled by execute_portable_alu_mem_to_reg")
         }
@@ -3164,6 +3272,9 @@ fn emit_jit_op(
             cycles_const(builder, base + 2 * shift as i32)
         }
         JitTraceOp::MoveMem { .. } => unreachable!("MoveMem is emitted by emit_move_mem"),
+        JitTraceOp::MovemWordPostInc { .. } => {
+            unreachable!("MovemWordPostInc is emitted by emit_movem_word_postinc")
+        }
         JitTraceOp::AluMemToReg { .. } => {
             unreachable!("AluMemToReg is emitted by emit_alu_mem_to_reg")
         }
@@ -3297,6 +3408,78 @@ fn window_load(builder: &mut FunctionBuilder<'_>, env: &MemEnv, off: Value, size
             builder.ins().bswap(v)
         }
     }
+}
+
+/// Emit a data-register-only MOVEM.W (An)+. A single check covers the
+/// contiguous register list before any register or address state changes;
+/// the individual big-endian loads are then safe to emit without guards.
+#[cfg(not(target_family = "wasm"))]
+fn emit_movem_word_postinc(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::MovemWordPostInc {
+        base,
+        data_mask,
+        cycles,
+    } = trace.op
+    else {
+        unreachable!("expected MOVEM.W postincrement trace")
+    };
+    let bytes = data_mask.count_ones() * 2;
+    debug_assert!(bytes != 0 && bytes <= 16);
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let raw = load_reg(builder, cpu, JitDirectReg::Addr(base));
+    if env.aligned_only {
+        let low = builder.ins().band_imm(raw, 1);
+        let bad = builder.ins().icmp_imm(IntCC::NotEqual, low, 0);
+        branch_guard(builder, bail, bad);
+    }
+    let masked = builder.ins().band_imm(raw, env.address_mask as i64);
+    let last_valid_start = env.address_mask.saturating_sub(bytes - 1);
+    let wraps = builder.ins().icmp_imm(
+        IntCC::UnsignedGreaterThan,
+        masked,
+        i64::from(last_valid_start),
+    );
+    branch_guard(builder, bail, wraps);
+    let too_short = builder
+        .ins()
+        .icmp_imm(IntCC::UnsignedLessThan, env.fm_len, i64::from(bytes));
+    branch_guard(builder, bail, too_short);
+    let off = builder.ins().isub(masked, env.fm_base);
+    let limit = builder.ins().iadd_imm(env.fm_len, -i64::from(bytes));
+    let outside = builder.ins().icmp(IntCC::UnsignedGreaterThan, off, limit);
+    branch_guard(builder, bail, outside);
+
+    let mut ordinal = 0i64;
+    for reg in 0..8 {
+        if (data_mask & (1 << reg)) == 0 {
+            continue;
+        }
+        let word_off = if ordinal == 0 {
+            off
+        } else {
+            builder.ins().iadd_imm(off, ordinal * 2)
+        };
+        let word = window_load(builder, env, word_off, Size::Word);
+        let value = sign_extend_word(builder, word);
+        store_reg(builder, cpu, JitDirectReg::Data(reg), value);
+        ordinal += 1;
+    }
+    let next = builder.ins().iadd_imm(raw, i64::from(bytes));
+    store_reg(builder, cpu, JitDirectReg::Addr(base), next);
+    cycles_const(builder, cycles)
 }
 
 /// Big-endian sized store of (sized) `value` into the window.
@@ -3475,9 +3658,9 @@ fn emit_indirect_jsr(
     cycles_const(builder, trace.op.max_cycles())
 }
 
-/// Emit the displacement-memory operations that dominate Classic Mac code.
-/// The displacement is baked into the trace; only the live An value and
-/// fastmem bounds need checking at runtime.
+/// Emit displacement-memory operations with the displacement baked into the
+/// trace, leaving only the live An value and fastmem bounds to check at
+/// runtime.
 #[cfg(not(target_family = "wasm"))]
 fn emit_an_disp_mem(
     builder: &mut FunctionBuilder<'_>,
@@ -4526,6 +4709,147 @@ mod portable_tests {
         assert_eq!(cpu.a(0), 0x204);
     }
 
+    fn movem_word_postinc_op() -> TraceBuildOp {
+        TraceBuildOp {
+            opcode: 0x4C98,
+            extension: Some(0x00FE),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::MovemWordPostInc {
+                base: 0,
+                data_mask: 0xFE,
+                cycles: 40,
+            },
+        }
+    }
+
+    #[test]
+    fn decodes_movem_word_postincrement() {
+        let cpu = cpu();
+        let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
+        mem.write_word(0x0100, 0x4C98);
+        mem.write_word(0x0102, 0x00FE);
+        let op = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(op.length(), 4);
+        assert!(matches!(
+            op.op,
+            JitTraceOp::MovemWordPostInc {
+                base: 0,
+                data_mask: 0xFE,
+                cycles: 40,
+            }
+        ));
+
+        mem.write_word(0x0102, 0x0101); // address-register masks stay interpreted
+        assert!(decode_movem_word_postinc_trace_op(&cpu, &mut mem, 0x0100, 0x4C98).is_none());
+    }
+
+    #[test]
+    fn portable_movem_word_postincrement_sign_extends_and_preserves_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        let words = [0x8000u16, 1, 0x7FFF, 0xFFFF, 0, 0x1234, 0xABCD];
+        for (index, word) in words.into_iter().enumerate() {
+            mem[0x0200 + index * 2..0x0202 + index * 2].copy_from_slice(&word.to_be_bytes());
+        }
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0200);
+        cpu.set_ccr(0x1F);
+
+        assert_eq!(
+            execute_portable_op(&mut cpu, movem_word_postinc_op(), 0x0100, 0x0104),
+            Some(40)
+        );
+        assert_eq!(cpu.d(0), 0);
+        assert_eq!(cpu.d(1), 0xFFFF_8000);
+        assert_eq!(cpu.d(2), 1);
+        assert_eq!(cpu.d(3), 0x0000_7FFF);
+        assert_eq!(cpu.d(4), 0xFFFF_FFFF);
+        assert_eq!(cpu.d(5), 0);
+        assert_eq!(cpu.d(6), 0x0000_1234);
+        assert_eq!(cpu.d(7), 0xFFFF_ABCD);
+        assert_eq!(cpu.a(0), 0x020E);
+        assert_eq!(cpu.pc, 0x0104);
+        assert_eq!(cpu.get_ccr(), 0x1F, "MOVEM does not affect flags");
+    }
+
+    #[test]
+    fn portable_movem_word_postincrement_bails_without_partial_state() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x0208]; // seven words do not fit at $0200
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0200);
+        for reg in 1..8 {
+            cpu.set_d(reg, 0xA000_0000 | reg as u32);
+        }
+        cpu.pc = 0x0444;
+
+        assert_eq!(
+            execute_portable_op(&mut cpu, movem_word_postinc_op(), 0x0100, 0x0104),
+            None
+        );
+        assert_eq!(cpu.a(0), 0x0200);
+        assert_eq!(cpu.pc, 0x0444);
+        for reg in 1..8 {
+            assert_eq!(cpu.d(reg), 0xA000_0000 | reg as u32);
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn native_movem_word_postincrement_matches_portable_and_bails_atomically() {
+        let ops = vec![
+            movem_word_postinc_op(),
+            TraceBuildOp {
+                opcode: 0x51C8,
+                extension: Some(0xFFFA),
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::Dbcc {
+                    condition: 1,
+                    reg: 0,
+                    displacement: -6,
+                },
+            },
+        ];
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        let words = [0x8000u16, 1, 0x7FFF, 0xFFFF, 0, 0x1234, 0xABCD];
+        for (index, word) in words.into_iter().enumerate() {
+            mem[0x0200 + index * 2..0x0202 + index * 2].copy_from_slice(&word.to_be_bytes());
+        }
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(0, 0x0200);
+        cpu.set_d(0, 2);
+        cpu.set_ccr(0x1F);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&cpu, 0x0100, CpuType::M68000, ops, Some(0x0100))
+            .expect("MOVEM/DBRA loop should compile");
+
+        let packed = unsafe { compiled.call_native(&mut cpu, 1) };
+        assert_eq!((packed >> 32) as u32, 2);
+        assert_eq!(packed as u32, 50);
+        assert_eq!(cpu.d(0), 1);
+        assert_eq!(cpu.d(1), 0xFFFF_8000);
+        assert_eq!(cpu.d(7), 0xFFFF_ABCD);
+        assert_eq!(cpu.a(0), 0x020E);
+        assert_eq!(cpu.pc, 0x0100);
+        assert_eq!(cpu.get_ccr(), 0x1F);
+
+        cpu.set_a(0, 0x00FF_FFF8); // the register list crosses the address mask
+        for reg in 1..8 {
+            cpu.set_d(reg, 0xB000_0000 | reg as u32);
+        }
+        let packed = unsafe { compiled.call_native(&mut cpu, 1) };
+        assert_eq!(packed, 0, "bail retires no instructions or cycles");
+        assert_eq!(cpu.pc, 0x0100);
+        assert_eq!(cpu.a(0), 0x00FF_FFF8);
+        for reg in 1..8 {
+            assert_eq!(cpu.d(reg), 0xB000_0000 | reg as u32);
+        }
+    }
+
     #[test]
     fn decodes_hot_alu_memory_sources() {
         let cpu = cpu();
@@ -5078,7 +5402,7 @@ mod portable_tests {
     }
 
     #[test]
-    fn portable_trace_executes_classic_mac_a5_mix() {
+    fn portable_trace_executes_displacement_memory_mix() {
         let mut cpu = cpu();
         let mut mem = vec![0u8; 0x10000];
         attach_window(&mut cpu, &mut mem);
@@ -5478,7 +5802,7 @@ mod portable_tests {
             (Size::Byte, 1u8, 0xA5A5_5581u32),
             (Size::Byte, 7, 0xA5A5_557Fu32),
             (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
-            (Size::Word, 1, 0xA5A5_8001u32), // Lemmings' E247 shape
+            (Size::Word, 1, 0xA5A5_8001u32),
             (Size::Word, 4, 0xA5A5_7FF0u32),
             (Size::Word, 0, 0xA5A5_8100u32),
             (Size::Long, 1, 0x8000_0001u32),
@@ -5572,7 +5896,7 @@ mod portable_tests {
             (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
             (Size::Word, 4, 0xA5A5_1801u32),
             (Size::Word, 0, 0xA5A5_8180u32),
-            (Size::Long, 3, 0x9000_0001u32), // Lemmings' E788 shape
+            (Size::Long, 3, 0x9000_0001u32),
             (Size::Long, 0, 0x0180_0081u32),
         ];
 

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -62,9 +62,9 @@ fn budget_exhausted_count_is_exact_with_jit_traces() {
 
 #[test]
 fn unrelated_watch_keeps_jit_loop_budget_exact() {
-    // Systemless always watches PC 0 for a clean exit. A trace whose loop
-    // head is elsewhere may run multiple iterations per native call, but
-    // must still stop at the exact requested instruction budget.
+    // A caller may always watch PC 0 as a clean-exit sentinel. A trace whose
+    // loop head is elsewhere may run multiple iterations per native call,
+    // but must still stop at the exact requested instruction budget.
     let mut bus = bus_with(&[(0x1000, 0x5280), (0x1002, 0x60FC)]);
     let mut cpu = cpu_at(0x1000);
 
@@ -164,8 +164,8 @@ fn multi_block_trace_guard_side_exit_matches_step() {
 #[test]
 fn multi_block_trace_path_change_matches_step() {
     // First record the BNE path, then switch to the opposite, dominant path.
-    // The common path is the same CMP/branch/copy/DBRA topology observed in
-    // Lemmings; the outer path resets its pointers and counter.
+    // The common path is a CMP/branch/copy/DBRA topology; the outer path
+    // resets its pointers and counter.
     let words = [
         (0x1000, 0xB210), // CMP.B (A0),D1
         (0x1002, 0x6606), // BNE.S outer
@@ -1325,8 +1325,8 @@ fn mem_trace_unaligned_matches_step_on_68020() {
     });
 }
 
-/// The two memory-source CMP forms found at the hottest rejected Lemmings
-/// trace heads must compile without changing architectural behavior.
+/// Common memory-source CMP forms must compile without changing
+/// architectural behavior.
 #[test]
 fn mem_trace_cmp_sources_match_step() {
     let indirect = &[
@@ -1361,10 +1361,9 @@ fn mem_trace_cmp_sources_match_step() {
     );
 }
 
-/// Lemmings' hottest remaining graphics loop combines scaled brief-indexed
-/// byte reads with word/long ADDs through a postincrement destination. The
-/// compiled loop must match the interpreter's addresses, big-endian stores,
-/// postincrements, and NZVCX results exactly.
+/// A loop combining scaled brief-indexed byte reads with word/long ADDs
+/// through a postincrement destination must match the interpreter's
+/// addresses, big-endian stores, postincrements, and NZVCX results exactly.
 #[test]
 fn mem_trace_indexed_move_and_postinc_add_matches_step() {
     let words = &[


### PR DESCRIPTION
Supersedes #30 with a clean, conventional commit on the current `master`.

This keeps the reusable parts of the original change:

- adds decoded, native, and portable trace execution for data-register-only `MOVEM.W (An)+`
- preserves atomic fallback behavior, address wrapping, sign extension, and cycle accounting
- renames profiled benchmarks, CLI options, comments, and tests so the generic 68k crate does not reference individual games or downstream runtimes

Validated locally with:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `cargo package --locked`