### PR TITLE
fix: correct public API documentation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
+      - name: Build API documentation
+        env:
+          RUSTDOCFLAGS: -D warnings -D rustdoc::private_intra_doc_links
+        run: cargo doc --all-features --locked --no-deps --document-private-items
+
       - name: Run tests (default features)
         run: cargo test --locked
 

--- a/src/core/addressing.rs
+++ b/src/core/addressing.rs
@@ -1,22 +1,45 @@
-//! Effective address calculation.
+//! Decoding of the six-bit effective-address field used by 68k opcodes.
 
+/// An effective-address encoding after splitting the opcode's mode and
+/// register fields.
+///
+/// Variants carrying a register number use the low three bits and therefore
+/// identify registers 0 through 7.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AddressingMode {
+    /// Data register direct (`Dn`).
     DataRegister(u8),
+    /// Address register direct (`An`).
     AddressRegister(u8),
+    /// Address register indirect (`(An)`).
     AddressIndirect(u8),
+    /// Address register indirect with postincrement (`(An)+`).
     AddressPostIncrement(u8),
+    /// Address register indirect with predecrement (`-(An)`).
     AddressPreDecrement(u8),
+    /// Address register indirect with a 16-bit displacement (`(d16,An)`).
     AddressDisplacement(u8),
+    /// Address register indirect with an index extension (`(d8,An,Xn)` or
+    /// the 68020+ full extension format).
     AddressIndex(u8),
+    /// Sign-extended 16-bit absolute address (`(xxx).W`).
     AbsoluteShort,
+    /// 32-bit absolute address (`(xxx).L`).
     AbsoluteLong,
+    /// Program-counter relative with a 16-bit displacement (`(d16,PC)`).
     PcDisplacement,
+    /// Program-counter relative with an index extension (`(d8,PC,Xn)` or
+    /// the 68020+ full extension format).
     PcIndex,
+    /// Immediate data encoded in extension words.
     Immediate,
 }
 
 impl AddressingMode {
+    /// Decode the opcode's three-bit `mode` and three-bit `reg` fields.
+    ///
+    /// Returns `None` for reserved mode-7 register values and for values
+    /// outside the three-bit mode range.
     pub fn decode(mode: u8, reg: u8) -> Option<Self> {
         match mode {
             0b000 => Some(Self::DataRegister(reg)),

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -1,6 +1,4 @@
-//! CPU core state structure.
-//!
-//! Mirrors Musashi's `m68ki_cpu_core` for complete M68000 family emulation.
+//! Architectural CPU state, configuration, and memory-access helpers.
 
 use super::execute::RUN_MODE_BERR_AERR_RESET;
 use super::memory::{AddressBus, BusFaultKind};
@@ -15,25 +13,33 @@ fn precise_bus_default() -> bool {
 
 /// Flag constants for SR bits.
 pub const XFLAG_SET: u32 = 0x100;
+/// Internal representation of a set negative (N) flag.
 pub const NFLAG_SET: u32 = 0x80;
+/// Internal representation of a set overflow (V) flag.
 pub const VFLAG_SET: u32 = 0x80;
+/// Internal representation of a set carry (C) flag.
 pub const CFLAG_SET: u32 = 0x100;
+/// Internal representation of supervisor mode.
 pub const SFLAG_SET: u32 = 4;
+/// Internal representation of the 68020+ master-stack bit.
 pub const MFLAG_SET: u32 = 2;
 
 /// Function codes for memory access.
 pub const FC_USER_DATA: u32 = 1;
+/// User-program function code.
 pub const FC_USER_PROGRAM: u32 = 2;
+/// Supervisor-data function code.
 pub const FC_SUPERVISOR_DATA: u32 = 5;
+/// Supervisor-program function code.
 pub const FC_SUPERVISOR_PROGRAM: u32 = 6;
 
 /// The main CPU state structure.
 ///
-/// Matches Musashi's `m68ki_cpu_core` layout for compatibility.
-///
-/// Every field is plain runtime or configuration state (there are no
-/// lazily built decode tables), so the whole struct round-trips through
-/// serde for host save states.
+/// Public fields expose architectural registers and host-visible
+/// configuration. With the `serde` feature, state that affects subsequent
+/// architectural behavior and timing is serialized; runtime-only decode
+/// tables, FastMem pointers, fault-delivery scratch state, and trace caches
+/// are skipped and reconstructed when execution resumes.
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CpuCore {
@@ -228,7 +234,13 @@ pub struct CpuCore {
     pub cyc_reset: i32,
 
     // ========== Virtual IRQ ==========
+    /// Reserved virtual-interrupt state retained for host compatibility.
+    ///
+    /// Normal interrupt delivery uses [`CpuCore::set_irq`].
     pub virq_state: u32,
+    /// Reserved pending-NMI latch retained for host compatibility.
+    ///
+    /// Level-7 interrupt delivery uses [`CpuCore::set_irq`].
     pub nmi_pending: u32,
 
     // ========== MMU Registers ==========
@@ -239,20 +251,32 @@ pub struct CpuCore {
     // both. The two formats never coexist (the walker dispatches on `cpu_type`),
     // and the 040 root pointers carry no limit longword, so the 040 ignores the
     // `*_limit` fields.
-    pub mmu_crp_aptr: u32,  // CRP (030) / URP (040) address pointer
-    pub mmu_crp_limit: u32, // CRP limit/mode (030 only)
-    pub mmu_srp_aptr: u32,  // SRP address pointer (030 + 040)
-    pub mmu_srp_limit: u32, // SRP limit/mode (030 only)
-    pub mmu_tc: u32,        // Translation Control (030 PMOVE / 040 MOVEC 0x003)
-    pub mmu_sr: u32,        // MMU Status Register (030 + 040; layout per cpu_type)
+    /// 68030 CRP address pointer, or the 68040/68060 user root pointer.
+    pub mmu_crp_aptr: u32,
+    /// 68030 CRP limit and descriptor-mode longword.
+    pub mmu_crp_limit: u32,
+    /// Supervisor root-pointer address for the 68030, 68040, and 68060.
+    pub mmu_srp_aptr: u32,
+    /// 68030 SRP limit and descriptor-mode longword.
+    pub mmu_srp_limit: u32,
+    /// Translation Control register (68030 PMOVE; 68040/68060 MOVEC).
+    pub mmu_tc: u32,
+    /// MMU Status Register; its bit layout follows [`CpuCore::cpu_type`].
+    pub mmu_sr: u32,
     // 68030 Transparent Translation Registers
+    /// 68030 Transparent Translation Register 0.
     pub mmu_tt0: u32,
+    /// 68030 Transparent Translation Register 1.
     pub mmu_tt1: u32,
     // 68040-specific MMU registers
-    pub dacr0: u32, // Data Access Control 0 (0x008)
-    pub dacr1: u32, // Data Access Control 1 (0x009)
-    pub iacr0: u32, // Instruction Access Control 0 (0x00A)
-    pub iacr1: u32, // Instruction Access Control 1 (0x00B)
+    /// 68040 Data Access Control Register 0 (MOVEC selector `0x008`).
+    pub dacr0: u32,
+    /// 68040 Data Access Control Register 1 (MOVEC selector `0x009`).
+    pub dacr1: u32,
+    /// 68040 Instruction Access Control Register 0 (MOVEC selector `0x00A`).
+    pub iacr0: u32,
+    /// 68040 Instruction Access Control Register 1 (MOVEC selector `0x00B`).
+    pub iacr1: u32,
     // 68060-specific control registers
     /// Processor Configuration Register (MOVEC 0x808): identification and
     /// revision in the high half (read-only), EDEBUG/DFP/ESS in the low bits.
@@ -934,7 +958,7 @@ impl CpuCore {
     /// 68000 long writeback for the -(Ax),-(Ay) extended-arithmetic forms
     /// (ADDX.L/SUBX.L memory-to-memory): write the low word, perform the
     /// final prefetch, then write the high word. The IPL poll rides the
-    /// low-word write (Moira writeM<Word, POLL> on the first write).
+    /// low-word write (Moira `writeM<Word, POLL>` on the first write).
     pub fn write_long_mm_interleaved_68000<B: AddressBus>(
         &mut self,
         bus: &mut B,
@@ -1892,14 +1916,18 @@ impl CpuCore {
         }
     }
 
-    /// Execute COP0 / PMMU op0 (0xF0xx) style instructions.
+    /// Execute a COP0/PMMU `0xF0xx` instruction.
     ///
-    /// Currently supports only PMOVE to/from a subset of PMMU registers:
-    /// - TC (32-bit)
-    /// - SRP (64-bit) (limit:aptr)
-    /// - CRP (64-bit) (limit:aptr)
+    /// On the 68030 this implements PTEST and PMOVE for TC, SRP, CRP,
+    /// TT0, TT1, and MMUSR/PSR. PLOAD and PFLUSH-family encodings are
+    /// recognized as compatibility no-ops because the 68030 walker does
+    /// not retain translations in an ATC. The 68040 accepts the 030-form
+    /// PTEST probes used by 68040.library as no-ops; its architectural MMU
+    /// controls use MOVEC and dedicated opcodes. The 68060 rejects this
+    /// encoding group.
     ///
-    /// Returns 0 if not recognized/supported (caller should treat as LINE 1111).
+    /// Returns zero for an invalid or unsupported encoding so the caller
+    /// can take the Line-F exception.
     pub fn exec_mmu_op0<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         use super::ea::AddressingMode;
         use super::types::Size;
@@ -1930,9 +1958,8 @@ impl CpuCore {
         // Extension word immediately after opcode.
         let modes = self.read_imm_16(bus);
 
-        // Only handle PMOVE-family encodings for now.
-        // Reject known-but-unimplemented ops (PLOAD/PFLUSH/PTEST/etc).
-        // However, on 68040 treat PTEST as NOP since we don't have real MMU.
+        // Decode PTEST before the PMOVE register family. On the 68040,
+        // accept the 030-form compatibility probe as a NOP.
         let is_ptest = (modes & 0xE000) == 0x8000;
         let is_040 = matches!(
             self.cpu_type,
@@ -2185,26 +2212,32 @@ impl CpuCore {
     // ========== Flag Helpers ==========
 
     #[inline]
+    /// Return whether the extend (X) condition-code bit is set.
     pub fn flag_x(&self) -> bool {
         self.x_flag != 0
     }
     #[inline]
+    /// Return whether the negative (N) condition-code bit is set.
     pub fn flag_n(&self) -> bool {
         self.n_flag != 0
     }
     #[inline]
+    /// Return whether the zero (Z) condition-code bit is set.
     pub fn flag_z(&self) -> bool {
         self.not_z_flag == 0
     }
     #[inline]
+    /// Return whether the overflow (V) condition-code bit is set.
     pub fn flag_v(&self) -> bool {
         self.v_flag != 0
     }
     #[inline]
+    /// Return whether the carry (C) condition-code bit is set.
     pub fn flag_c(&self) -> bool {
         self.c_flag != 0
     }
     #[inline]
+    /// Return whether the CPU is currently in supervisor mode.
     pub fn is_supervisor(&self) -> bool {
         self.s_flag != 0
     }

--- a/src/core/ea.rs
+++ b/src/core/ea.rs
@@ -1,6 +1,7 @@
-//! Effective Address resolution.
+//! Effective-address resolution.
 //!
-//! Implements all M68000 addressing modes.
+//! Implements the M68000-family addressing modes, including the full indexed
+//! extension format introduced with the M68020.
 
 use super::cpu::CpuCore;
 use super::execute::RUN_MODE_BERR_AERR_RESET;

--- a/src/core/exceptions.rs
+++ b/src/core/exceptions.rs
@@ -9,21 +9,37 @@ use super::types::CpuType;
 
 /// Exception vector numbers.
 pub mod vector {
+    /// Reset vector-table entry containing the initial supervisor stack pointer.
     pub const RESET_SSP: u32 = 0;
+    /// Reset vector-table entry containing the initial program counter.
     pub const RESET_PC: u32 = 1;
+    /// Bus-error exception vector.
     pub const BUS_ERROR: u32 = 2;
+    /// Address-error exception vector.
     pub const ADDRESS_ERROR: u32 = 3;
+    /// Illegal-instruction exception vector.
     pub const ILLEGAL_INSTRUCTION: u32 = 4;
+    /// Integer divide-by-zero exception vector.
     pub const ZERO_DIVIDE: u32 = 5;
+    /// CHK/CHK2 bounds exception vector.
     pub const CHK: u32 = 6;
+    /// TRAPV/TRAPcc exception vector.
     pub const TRAPV: u32 = 7;
+    /// Privilege-violation exception vector.
     pub const PRIVILEGE_VIOLATION: u32 = 8;
+    /// Instruction-trace exception vector.
     pub const TRACE: u32 = 9;
+    /// Line-A emulator exception vector.
     pub const LINE_1010: u32 = 10;
+    /// Line-F emulator and coprocessor exception vector.
     pub const LINE_1111: u32 = 11;
+    /// Invalid exception-frame format vector (68010+).
     pub const FORMAT_ERROR: u32 = 14;
+    /// Uninitialized interrupt-vector exception.
     pub const UNINITIALIZED_INTERRUPT: u32 = 15;
+    /// Spurious-interrupt vector.
     pub const SPURIOUS_INTERRUPT: u32 = 24;
+    /// Base vector for `TRAP #0` through `TRAP #15`.
     pub const TRAP_BASE: u32 = 32;
 
     /// 68060: integer instructions removed from silicon (MOVEP, CHK2/CMP2,
@@ -38,9 +54,11 @@ pub mod vector {
     /// FMOVEM.L #imm) - pre-instruction, format $0.
     pub const FP_UNIMPLEMENTED_EA: u32 = 60;
 
-    // 68020+ MMU exceptions (vector numbers per 68k docs; used by 68030/68040 PMMU).
+    /// 68020+ MMU configuration-error vector.
     pub const MMU_CONFIGURATION_ERROR: u32 = 56;
+    /// 68020+ MMU illegal-operation vector.
     pub const MMU_ILLEGAL_OPERATION_ERROR: u32 = 57;
+    /// 68020+ MMU access-level-violation vector.
     pub const MMU_ACCESS_LEVEL_VIOLATION_ERROR: u32 = 58;
 }
 
@@ -118,9 +136,13 @@ fn fslw_060(
 
 /// Function code bits for exception stack frames.
 pub mod fc {
+    /// User-data address space.
     pub const USER_DATA: u16 = 1;
+    /// User-program address space.
     pub const USER_PROGRAM: u16 = 2;
+    /// Supervisor-data address space.
     pub const SUPERVISOR_DATA: u16 = 5;
+    /// Supervisor-program address space.
     pub const SUPERVISOR_PROGRAM: u16 = 6;
 }
 
@@ -707,6 +729,13 @@ impl CpuCore {
         }
     }
 
+    /// Determine whether the instruction that just retired requests a trace
+    /// exception and clear the one-instruction flow-change latch.
+    ///
+    /// T1 traces every instruction. On the 68020 and later, T0 traces only
+    /// flow-changing or pipeline-synchronizing instructions. The decision
+    /// uses [`CpuCore::sr_save`], the status register captured before the
+    /// instruction, so an RTE that restores a trace bit does not trace itself.
     pub fn check_trace(&mut self) -> bool {
         // T1 trace: trace after every instruction
         // T0 trace: trace only on change-of-flow (68020+)

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -11,10 +11,12 @@ use super::types::{BatchExit, BatchResult, CycleBatchExit, CycleBatchResult, Ste
 
 /// Stop level constants.
 pub const STOP_LEVEL_STOP: u32 = 1;
+/// Halted after a double bus/address fault; only reset can resume execution.
 pub const STOP_LEVEL_HALT: u32 = 2;
 
 /// Run mode constants.
 pub const RUN_MODE_NORMAL: u32 = 0;
+/// Bus/address-error recovery or reset processing is active.
 pub const RUN_MODE_BERR_AERR_RESET: u32 = 1;
 
 impl CpuCore {
@@ -306,8 +308,8 @@ impl CpuCore {
     ///
     /// This is the fast path for High-Level Emulation embedders that would
     /// otherwise call [`step`](Self::step) in a loop: the whole batch runs
-    /// inside the decoded-op cache / trace-JIT inner loop, and control only
-    /// returns to the caller when it has something to do:
+    /// inside the decoded-operation and trace-execution loops, and control
+    /// returns to the caller only when it has something to do:
     ///
     /// - a trap the embedder wants to intercept (A-line/F-line/TRAP/BKPT/
     ///   illegal — surfaced exactly like [`step`](Self::step), never taken
@@ -731,8 +733,6 @@ impl CpuCore {
 
         StepResult::Ok { cycles }
     }
-
-    // step_with_trap_handler removed in favor of step_with_hle_handler.
 
     // ========== Stack Operations ==========
 

--- a/src/core/instructions/bitfield.rs
+++ b/src/core/instructions/bitfield.rs
@@ -26,6 +26,10 @@ struct BitFieldSpec {
 }
 
 impl CpuCore {
+    /// Execute a decoded 68020+ bit-field instruction.
+    ///
+    /// The extension word supplies the dynamic/immediate offset and width,
+    /// while `opcode` identifies the operation and effective address.
     pub fn exec_bitfield<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         // Read extension word first (before EA extension words).
         let ext = self.read_imm_16(bus);

--- a/src/core/instructions/cmp2_chk2.rs
+++ b/src/core/instructions/cmp2_chk2.rs
@@ -1,22 +1,19 @@
 //! 68020+ CMP2 / CHK2 (bounds compare / bounds check).
 //!
-//! Based on the Musashi mc68040 test suite sources in
-//! `tests/fixtures/Musashi/test/mc68040/{cmp2,chk2}.s`.
-//!
-//! Encoding (as used by GNU as for 68040):
+//! Encoding:
 //!   opcode: 0000 0ss0 11 mmm rrr   (ss: 00=byte, 01=word, 10=long)
 //!   ext word:
 //!     - bit 11: 1 = CHK2 (may trap), 0 = CMP2
 //!     - bits 15..12: register specifier (0..7 = D0..D7, 8..15 = A0..A7)
-//!     - remaining bits unused in our fixtures
 //!
-//! Semantics (as required by the fixture):
+//! Semantics:
 //! - Reads a lower and upper bound from `<ea>` (two consecutive sized values).
-//! - Compares the specified register value against the bounds.
-//! - Sets C=1 when the value is out of range, else C=0.
-//! - For CHK2, triggers CHK exception (vector 6) when out of range.
-//!
-//! Note: The Musashi fixture expects CMP2.B to behave using unsigned comparisons for bounds/operand.
+//! - Compares them as signed values against the selected register. Byte and
+//!   word data-register operands are sign-extended; address registers retain
+//!   their full 32-bit value.
+//! - Sets Z when the operand equals either bound and C when it lies outside the
+//!   selected range, including the wrapped-range rule for reversed bounds.
+//! - CHK2 takes the CHK exception (vector 6) when C is set.
 
 use crate::core::cpu::{CFLAG_SET, CpuCore};
 use crate::core::ea::AddressingMode;
@@ -24,6 +21,10 @@ use crate::core::memory::AddressBus;
 use crate::core::types::Size;
 
 impl CpuCore {
+    /// Execute a 68020+ CMP2 or CHK2 bounds operation.
+    ///
+    /// CMP2 records an out-of-range operand in C; CHK2 additionally takes
+    /// the CHK vector when the comparison is out of range.
     pub fn exec_cmp2_chk2<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         let size = match (opcode >> 9) & 3 {
             0 => Size::Byte,

--- a/src/core/instructions/compare_swap.rs
+++ b/src/core/instructions/compare_swap.rs
@@ -1,6 +1,6 @@
 //! 68020+ compare-and-swap instructions.
 //!
-//! Implements CAS and CAS2 (long-sized, as used by the mc68040 Musashi fixture set).
+//! Implements byte, word, and long CAS plus word and long CAS2.
 
 use crate::core::cpu::CpuCore;
 use crate::core::ea::AddressingMode;
@@ -10,7 +10,8 @@ use crate::core::types::Size;
 impl CpuCore {
     /// `CAS.<size> Dc,Du,<ea>`
     ///
-    /// Musashi fixtures only use CAS.L (opcode pattern 0x0EC0..0x0EFF).
+    /// The primary opcode selects the operand size and memory effective
+    /// address; the extension word selects the compare and update registers.
     pub fn exec_cas<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         // Extension word encodes Du and Dc.
         let ext = self.read_imm_16(bus);
@@ -93,7 +94,8 @@ impl CpuCore {
 
     /// `CAS2.<size> Dc1:Dc2,Du1:Du2,(Rn1):(Rn2)`
     ///
-    /// Musashi fixtures use CAS2.L with two extension words.
+    /// The primary opcode selects the operand size. Two extension words select
+    /// the address, compare, and update register pairs.
     pub fn exec_cas2<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         let ext1 = self.read_imm_16(bus);
         let ext2 = self.read_imm_16(bus);
@@ -174,7 +176,7 @@ impl CpuCore {
         if rn >= 8 {
             self.a((rn - 8) as usize)
         } else {
-            // Not expected in our fixtures; treat as data register containing address.
+            // CAS2 permits either data or address registers as address sources.
             self.d(rn as usize)
         }
     }
@@ -182,7 +184,7 @@ impl CpuCore {
 
 #[inline]
 fn decode_cas2_ext(ext: u16) -> (u8, usize, usize) {
-    // Layout (as used by Musashi fixtures):
+    // Architectural extension-word layout:
     // - bits 15..12: Rn (0..15; 8..15 == A0..A7)
     // - bits 8..6: Du
     // - bits 2..0: Dc

--- a/src/core/instructions/data_movement.rs
+++ b/src/core/instructions/data_movement.rs
@@ -151,7 +151,7 @@ impl CpuCore {
     /// high word first, then low word (long destinations). Splitting keeps
     /// the host's per-access IPL samples, so a poll point placed right
     /// after this write pins the sample taken at the FINAL word's start
-    /// (Moira's writeOp<POLL> polls before the low word of a long write).
+    /// (Moira's `writeOp<POLL>` polls before the low word of a long write).
     fn write_move_dest_68000<B: AddressBus>(
         &mut self,
         bus: &mut B,
@@ -297,7 +297,7 @@ impl CpuCore {
 
     /// Execute LINK instruction.
     ///
-    /// LINK An, #<displacement>
+    /// `LINK An,#disp16`
     /// The 68040 performs LINK's A7 predecrement before reading the source
     /// register; the 68000-030 and the 68060 read the source first.
     fn link_predecrements_first(&self) -> bool {
@@ -309,6 +309,8 @@ impl CpuCore {
         )
     }
 
+    /// Execute `LINK An,#disp16`, creating a stack frame for address register
+    /// `reg`.
     pub fn exec_link<B: AddressBus>(&mut self, bus: &mut B, reg: usize) -> i32 {
         // 68000 bus order: the displacement word is consumed (with its
         // prefetch) BEFORE the An push.
@@ -671,7 +673,7 @@ impl CpuCore {
 
     /// RMW writeback whose IPL poll point is the final prefetch BEFORE the
     /// write (the 68000 logic/shift/bit/CLR/NEG/NOT/ADDQ/Scc class: Moira
-    /// `prefetch<POLL>` then writeOp). The writeback accesses do not re-latch
+    /// `prefetch<POLL>` then `writeOp`). The writeback accesses do not re-latch
     /// the boundary sample, so an interrupt that rises while the write is
     /// arbitrating is not taken until one instruction later.
     pub fn write_resolved_ea_np_poll<B: AddressBus>(

--- a/src/core/instructions/move16.rs
+++ b/src/core/instructions/move16.rs
@@ -1,11 +1,9 @@
-// MOVE16 - 16-byte Aligned Block Transfer (68040/68060)
-//
-// Five forms:
-//   0xF600 (Ay)+,(xxx).L    0xF608 (xxx).L,(Ay)+
-//   0xF610 (Ay),(xxx).L     0xF618 (xxx).L,(Ay)
-//   0xF620 (Ax)+,(Ay)+  with extension word 1yyy 0000 0000 0000
-// Both addresses are forced to 16-byte alignment (the low four bits are
-// ignored; there is no address error).
+//! MOVE16 16-byte aligned block transfers (68040/68060).
+//!
+//! The five encodings cover `(Ay)+,(xxx).L`, `(xxx).L,(Ay)+`,
+//! `(Ay),(xxx).L`, `(xxx).L,(Ay)`, and `(Ax)+,(Ay)+`. Both addresses are
+//! forced to 16-byte alignment: the low four bits are ignored and do not
+//! raise an address error.
 
 use crate::core::cpu::CpuCore;
 use crate::core::memory::AddressBus;

--- a/src/core/instructions/moves.rs
+++ b/src/core/instructions/moves.rs
@@ -1,9 +1,8 @@
-// MOVES - Move to/from Address Space (68010+)
-//
-// Opcode: 0000 1110 ssmm mrrr
-// Extension word: 1aaa rrrd 0000 0000
-//   a/rrr = register number (0-7 for Dn, A for An)
-//   d = direction (0 = register to EA, 1 = EA to register)
+//! MOVES transfers to and from an alternate address space (68010+).
+//!
+//! The extension word selects a data/address register and the transfer
+//! direction. Memory accesses use DFC for register-to-memory transfers and
+//! SFC for memory-to-register transfers, including MMU function-code lookup.
 
 use crate::core::cpu::CpuCore;
 use crate::core::ea::AddressingMode;
@@ -11,12 +10,12 @@ use crate::core::memory::AddressBus;
 use crate::core::types::Size;
 
 impl CpuCore {
-    /// MOVES - Move to/from address space using SFC/DFC.
-    /// The Amiga bus does not decode function codes, so the access itself is
-    /// a normal memory access -- but with the PMMU enabled the address space
-    /// matters: the data cycle translates under SFC/DFC (mmu_fc_override),
-    /// which selects the 030 FCL table branch / TTR matches and the 040
-    /// user-vs-supervisor root pointer.
+    /// MOVES - move to or from the address space selected by SFC or DFC.
+    ///
+    /// The memory transfer uses the normal [`AddressBus`] interface. When the
+    /// PMMU is enabled, translation uses SFC for a memory-to-register transfer
+    /// and DFC for a register-to-memory transfer instead of the current
+    /// user/supervisor data function code.
     pub fn exec_moves<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         // Check supervisor mode
         if self.s_flag == 0 {

--- a/src/core/instructions/mul_div_long.rs
+++ b/src/core/instructions/mul_div_long.rs
@@ -1,6 +1,5 @@
-//! 68020+ long multiply/divide instructions (MULU.L/MULS.L, DIVU.L/DIVS.L and remainder forms).
-//!
-//! This matches the Musashi mc68040 fixture programs (`mul_long.s`, `divu_long.s`, `divs_long.s`).
+//! 68020+ long multiply/divide instructions (MULU.L/MULS.L, DIVU.L/DIVS.L
+//! and their wide-result or remainder forms).
 
 use crate::core::cpu::CpuCore;
 use crate::core::ea::AddressingMode;
@@ -11,7 +10,7 @@ impl CpuCore {
     /// DIVU.L / DIVS.L / DIVUL.L / DIVSL.L family.
     ///
     /// Opcode word: 0x4C40..0x4C7F (EA in low 6 bits)
-    /// Extension word (Musashi-style, as observed in fixtures):
+    /// Extension word:
     /// - bit 11 (0x0800): signed (DIVS) when set, unsigned (DIVU) when clear
     /// - bit 10 (0x0400): 64-bit dividend when set (hi part in remainder reg)
     /// - bits 14..12: quotient destination register (Dq)
@@ -115,7 +114,7 @@ impl CpuCore {
     /// MULU.L / MULS.L family.
     ///
     /// Opcode word: 0x4C00..0x4C3F (EA in low 6 bits)
-    /// Extension word (Musashi-style, as observed in fixtures):
+    /// Extension word:
     /// - bit 11 (0x0800): signed (MULS) when set, unsigned (MULU) when clear
     /// - bit 10 (0x0400): 64-bit result when set (high in Dh, low in Dl)
     /// - bits 14..12: low (and primary) destination register Dl

--- a/src/core/mem_ops.rs
+++ b/src/core/mem_ops.rs
@@ -118,7 +118,7 @@ pub(crate) enum DecodedMemOp {
         src: FastEa,
         dst: FastEa,
     },
-    /// MOVEM.W (An)+,<register list>. The fast path accepts data-register-
+    /// `MOVEM.W (An)+,<register-list>`. The fast path accepts data-register-
     /// only masks at execution time; other lists fall back atomically.
     MovemWordPostInc {
         base: u8,

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -10,7 +10,9 @@ pub enum BusFaultKind {
 /// A bus-level fault that occurred during a memory access.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BusFault {
+    /// Classification of the failed bus transaction.
     pub kind: BusFaultKind,
+    /// Bus address at which the transaction failed.
     pub address: u32,
 }
 
@@ -48,12 +50,24 @@ pub struct FastMem {
     pub len: u32,
 }
 
+/// Host-provided memory and device bus used by [`CpuCore`](crate::CpuCore).
+///
+/// Multi-byte values use the 68k's big-endian byte order. The six basic
+/// read/write methods are required; the remaining hooks have conservative
+/// defaults for functional emulators and can be overridden for precise
+/// faults, timing, interrupts, caches, and batch acceleration.
 pub trait AddressBus {
+    /// Read one byte from `address`.
     fn read_byte(&mut self, address: u32) -> u8;
+    /// Read one big-endian 16-bit word from `address`.
     fn read_word(&mut self, address: u32) -> u16;
+    /// Read one big-endian 32-bit longword from `address`.
     fn read_long(&mut self, address: u32) -> u32;
+    /// Write one byte to `address`.
     fn write_byte(&mut self, address: u32, value: u8);
+    /// Write one big-endian 16-bit word to `address`.
     fn write_word(&mut self, address: u32, value: u16);
+    /// Write one big-endian 32-bit longword to `address`.
     fn write_long(&mut self, address: u32, value: u32);
 
     /// Precise-timing callback (Part E.2): called immediately before each bus
@@ -75,33 +89,54 @@ pub trait AddressBus {
     fn try_read_byte(&mut self, address: u32) -> Result<u8, BusFault> {
         Ok(self.read_byte(address))
     }
+    /// Fallible word read used for bus/MMU fault delivery.
+    ///
+    /// The default delegates to [`AddressBus::read_word`] and cannot fault.
     #[inline]
     fn try_read_word(&mut self, address: u32) -> Result<u16, BusFault> {
         Ok(self.read_word(address))
     }
+    /// Fallible longword read used for bus/MMU fault delivery.
+    ///
+    /// The default delegates to [`AddressBus::read_long`] and cannot fault.
     #[inline]
     fn try_read_long(&mut self, address: u32) -> Result<u32, BusFault> {
         Ok(self.read_long(address))
     }
+    /// Fallible byte write used for bus/MMU fault delivery.
+    ///
+    /// The default delegates to [`AddressBus::write_byte`] and cannot fault.
     #[inline]
     fn try_write_byte(&mut self, address: u32, value: u8) -> Result<(), BusFault> {
         self.write_byte(address, value);
         Ok(())
     }
+    /// Fallible word write used for bus/MMU fault delivery.
+    ///
+    /// The default delegates to [`AddressBus::write_word`] and cannot fault.
     #[inline]
     fn try_write_word(&mut self, address: u32, value: u16) -> Result<(), BusFault> {
         self.write_word(address, value);
         Ok(())
     }
+    /// Fallible longword write used for bus/MMU fault delivery.
+    ///
+    /// The default delegates to [`AddressBus::write_long`] and cannot fault.
     #[inline]
     fn try_write_long(&mut self, address: u32, value: u32) -> Result<(), BusFault> {
         self.write_long(address, value);
         Ok(())
     }
 
+    /// Read an instruction-stream word.
+    ///
+    /// Override this when opcode/immediate fetches use a distinct bus path.
     fn read_immediate_word(&mut self, address: u32) -> u16 {
         self.read_word(address)
     }
+    /// Read an instruction-stream longword.
+    ///
+    /// Override this when opcode/immediate fetches use a distinct bus path.
     fn read_immediate_long(&mut self, address: u32) -> u32 {
         self.read_long(address)
     }
@@ -112,6 +147,10 @@ pub trait AddressBus {
     fn try_read_immediate_word(&mut self, address: u32) -> Result<u16, BusFault> {
         Ok(self.read_immediate_word(address))
     }
+    /// Fallible instruction-stream longword read.
+    ///
+    /// The default delegates to [`AddressBus::read_immediate_long`] and
+    /// cannot fault.
     #[inline]
     fn try_read_immediate_long(&mut self, address: u32) -> Result<u32, BusFault> {
         Ok(self.read_immediate_long(address))
@@ -138,6 +177,10 @@ pub trait AddressBus {
         self.last_fetch_was_cached()
     }
 
+    /// Perform an interrupt-acknowledge cycle for `level`.
+    ///
+    /// Return an explicit vector number in the low byte, or `u32::MAX` for
+    /// the level's autovector. The default requests an autovector.
     fn interrupt_acknowledge(&mut self, _level: u8) -> u32 {
         0xFFFF_FFFF
     }
@@ -162,6 +205,7 @@ pub trait AddressBus {
     /// earlier in the faulted instruction must not survive into the handler.
     fn ipl_release_sample(&mut self) {}
 
+    /// Notify attached devices that the CPU asserted the external RESET line.
     fn reset_devices(&mut self) {}
 
     /// Expose a direct window into contiguous, side-effect-free guest RAM.
@@ -178,16 +222,18 @@ pub trait AddressBus {
     }
 }
 
-/// Optional companion trait for buses that can version instruction-visible memory.
+/// Optional companion trait for buses that version instruction-visible memory.
 ///
 /// This is intentionally separate from `AddressBus`: adding methods to the hot bus trait changes
-/// code generation for opcode fetches in release builds. Future code caches/JIT paths can require
-/// this trait without slowing existing interpreter users.
+/// code generation for opcode fetches in release builds. Embedders can use it
+/// to coordinate external code caches without slowing buses that need only
+/// [`AddressBus`].
 pub trait InstructionCacheBus: AddressBus {
     /// Stable version for instruction memory at `address`, when known.
     ///
-    /// Returning `Some(version)` tells future code caches that fetches from this address may be
-    /// reused until the version changes. Returning `None` is conservative.
+    /// Returning `Some(version)` tells an instruction cache that fetches from
+    /// this address may be reused until the version changes. Returning `None`
+    /// is conservative.
     #[inline]
     fn instruction_cache_version(&mut self, _address: u32) -> Option<u64> {
         None
@@ -236,21 +282,31 @@ impl LinearMemoryBus {
     }
 
     #[inline]
+    /// Return the number of bytes in the backing buffer.
     pub fn len(&self) -> usize {
         self.memory.len()
     }
 
     #[inline]
+    /// Return whether the backing buffer is empty.
+    ///
+    /// A constructed `LinearMemoryBus` is never empty because
+    /// [`LinearMemoryBus::from_vec`] rejects an empty buffer.
     pub fn is_empty(&self) -> bool {
         self.memory.is_empty()
     }
 
     #[inline]
+    /// Borrow the complete backing buffer.
     pub fn as_slice(&self) -> &[u8] {
         &self.memory
     }
 
     #[inline]
+    /// Mutably borrow the complete backing buffer.
+    ///
+    /// Taking a mutable slice advances the instruction-memory version
+    /// conservatively because the caller may change executable bytes.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.bump_instruction_version();
         &mut self.memory
@@ -269,11 +325,13 @@ impl LinearMemoryBus {
     }
 
     #[inline]
+    /// Write one big-endian word, wrapping within the backing buffer.
     pub fn write_word_at(&mut self, address: u32, value: u16) {
         self.write_word(address, value);
     }
 
     #[inline]
+    /// Write one big-endian longword, wrapping within the backing buffer.
     pub fn write_long_at(&mut self, address: u32, value: u32) {
         self.write_long(address, value);
     }

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1,9 +1,10 @@
 //! Decoded simple operation cache.
 //!
-//! This is the first JIT-facing execution substrate: cache a small decoded micro-op for
-//! simple one-word instructions that do not touch memory, read extension words, trap, or need
-//! rollback. One-word short branches are included because their fetch timing is fully local to
-//! the current instruction.
+//! Caches compact decoded operations for simple one-word instructions and
+//! FastMem-backed memory operations. The same operations feed the portable
+//! trace executor and, with the `jit` feature on native targets, Cranelift.
+//! One-word short branches are included because their fetch timing is fully
+//! local to the current instruction.
 //! Instruction fetch still occurs at the normal instruction boundary, so bus/address-error timing
 //! stays aligned with the interpreter.
 

--- a/src/core/registers.rs
+++ b/src/core/registers.rs
@@ -1,6 +1,3 @@
-//! Register access methods.
+//! Reserved compatibility module.
 //!
-//! Legacy compatibility module - main accessors now in cpu.rs.
-
-// Register accessors are now implemented directly in cpu.rs.
-// This module is kept for any legacy compatibility needs.
+//! Register accessors are inherent methods on [`CpuCore`](super::cpu::CpuCore).

--- a/src/core/status.rs
+++ b/src/core/status.rs
@@ -1,13 +1,18 @@
-//! Status register and CCR flag constants.
-//!
-//! Flag manipulation methods are now in cpu.rs.
+//! Status-register and condition-code bit masks.
 
 /// Status Register bit positions.
 pub const SR_CARRY: u16 = 0x0001;
+/// Overflow (V) condition-code bit.
 pub const SR_OVERFLOW: u16 = 0x0002;
+/// Zero (Z) condition-code bit.
 pub const SR_ZERO: u16 = 0x0004;
+/// Negative (N) condition-code bit.
 pub const SR_NEGATIVE: u16 = 0x0008;
+/// Extend (X) condition-code bit.
 pub const SR_EXTEND: u16 = 0x0010;
+/// Three-bit interrupt-priority mask.
 pub const SR_INT_MASK: u16 = 0x0700;
+/// Supervisor-mode (S) bit.
 pub const SR_SUPERVISOR: u16 = 0x2000;
+/// Trace-on-every-instruction (T1) bit.
 pub const SR_TRACE: u16 = 0x8000;

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -3,16 +3,17 @@
 //! The MC68020 User's Manual section 8.2 publishes three timing columns:
 //! best case (instruction overlap), cache case (cached instruction stream
 //! without overlap), and worst case (uncached stream without overlap).
-//! Copperline does not yet model the 020 execution-stage overlap, so an
+//! The core does not model the 020 execution-stage overlap, so an
 //! instruction selects Cache Case only when all of its opcode, extension,
 //! and immediate words hit the instruction cache; any miss selects Worst
 //! Case.
 //!
 //! The published totals include zero-wait, aligned transfers on a 32-bit
-//! bus. Copperline bills the real target bus while the instruction executes;
-//! the host advances only the part of this total not already consumed by
-//! those accesses. Consequently chip-RAM arbitration and narrower buses can
-//! extend a table time, but a table entry never hides a real wait.
+//! bus. The core bills transfers through [`AddressBus`](super::memory::AddressBus)
+//! while an instruction executes and charges only the portion of the table
+//! total not already consumed by those accesses. Consequently wait states and
+//! narrower buses can extend a table time, but a table entry never hides a
+//! real wait.
 //!
 //! Full-format indexed extension words cannot be distinguished from the
 //! brief form after the instruction has retired. Indexed entries therefore
@@ -25,10 +26,7 @@
 //! stages, so the target instruction cannot begin until the pipe refills from
 //! the cache. The manual accounts for that in the *following* instruction's
 //! head, which a per-instruction model with no overlap stage cannot express,
-//! so the cost is charged where the flush happens. Without it a `dbra` loop
-//! runs 6 clocks per iteration instead of 8 (`timing-test` rows 4, 5, 7, 14,
-//! 28, 29, 30, all 25% fast against the A1200 reference in
-//! `timing-test/README.md`).
+//! so the cost is charged where the flush happens.
 
 use super::cpu::CpuCore;
 use super::types::Size;

--- a/src/core/timing_060.rs
+++ b/src/core/timing_060.rs
@@ -12,8 +12,8 @@
 //! count here never double-bills a bus access. The classification is
 //! deliberately pessimistic where the manual's rules are finer than an
 //! opcode-word decode can see (pessimism under-pairs; it never over-pairs).
-//! The per-instruction constants are calibration knobs - see the timing-test
-//! ADF rows and docs/internals/cpu.md.
+//! The per-instruction constants are estimates for pipeline effects that the
+//! opcode classification alone cannot derive.
 
 use super::cpu::CpuCore;
 use std::sync::OnceLock;
@@ -66,6 +66,7 @@ impl Info060 {
         Self((class as u16) << CLASS_SHIFT | (cycles & CYCLES_MASK) << CYCLES_SHIFT | flags)
     }
 
+    /// Return the instruction's operand-execution-pipeline dispatch class.
     pub fn class(self) -> OepClass {
         match (self.0 >> CLASS_SHIFT) & 3 {
             0 => OepClass::PoepSoep,
@@ -75,17 +76,18 @@ impl Info060 {
         }
     }
 
+    /// Return the packed primary-pipeline occupancy in clocks.
     pub fn cycles(self) -> i32 {
         i32::from((self.0 >> CYCLES_SHIFT) & CYCLES_MASK)
     }
 
+    /// Return whether the packed entry contains `flag`.
     pub fn has(self, flag: u16) -> bool {
         self.0 & flag != 0
     }
 }
 
-// Calibration knobs (all approximate pending timing-test/WinUAE cross-checks;
-// see docs/internals/cpu.md "68060 timing").
+// Pipeline-effect estimates kept separate from the opcode classification.
 /// Taken Bcc/BRA/BSR without branch-cache help: pipeline refill.
 pub const CYC_060_BRANCH_TAKEN: i32 = 7;
 /// Not-taken conditional branch.
@@ -136,6 +138,7 @@ impl BranchCache060 {
         ((pc >> 1) & 0xFF) as usize
     }
 
+    /// Invalidate every branch-cache entry (CACR.CABC).
     pub fn clear_all(&mut self) {
         self.state.iter_mut().for_each(|s| *s = 0);
     }
@@ -200,6 +203,7 @@ pub struct PendingHead060 {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Oep060Timing {
+    /// Direct-mapped 68060 branch-prediction cache.
     pub branch_cache: BranchCache060,
     /// Retrospective pairing: the previous instruction, when it left an
     /// sOEP slot open. None after any pipeline break.

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -273,7 +273,7 @@ pub(crate) enum JitTraceOp {
         src: JitEa,
         dst: JitEa,
     },
-    /// MOVEM.W (An)+,<data-register mask>. Keeping this deliberately narrow
+    /// `MOVEM.W (An)+,<data-register-mask>`. Keeping this deliberately narrow
     /// avoids the architectural corner cases of address registers in a
     /// postincrement MOVEM list.
     MovemWordPostInc {

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -1,8 +1,9 @@
-//! Opt-in trace-JIT opportunity profiling.
+//! Opt-in trace and decoded-operation profiling.
 //!
 //! Enable the `trace-profile` Cargo feature and set `M68K_TRACE_PROFILE=1`
 //! to print a report when the CPU thread exits. The normal build contains
-//! none of this module or its hot-path hooks.
+//! none of this module or its hot-path hooks. Profiling works with both the
+//! portable trace executor and the native `jit` backend.
 
 use super::types::CpuType;
 use std::cell::RefCell;
@@ -11,32 +12,56 @@ use std::fmt::Write;
 use std::hash::{BuildHasherDefault, Hasher};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Per-trace-head profiling counters.
 pub struct TraceProfileRow {
+    /// Guest program counter at which the trace starts.
     pub start_pc: u32,
+    /// CPU model active for this trace.
     pub cpu_type: CpuType,
+    /// Backward branches observed at the trace head.
     pub backward_hits: u64,
+    /// Trace-entry attempts rejected by an unsupported operation.
     pub rejected_hits: u64,
+    /// Number of trace-recording attempts.
     pub recording_attempts: u64,
+    /// Longest supported prefix before the recorded blocker.
     pub prefix_ops: u32,
+    /// Guest PC of the operation that blocked trace construction.
     pub blocker_pc: Option<u32>,
+    /// Opcode word that blocked trace construction.
     pub blocker_opcode: Option<u16>,
+    /// Number of operations in the current compiled/portable trace.
     pub compiled_ops: u32,
+    /// Number of calls into the trace executor.
+    ///
+    /// The field name is retained for compatibility; portable trace calls
+    /// are counted here as well.
     pub native_calls: u64,
+    /// Total guest instructions retired by trace execution.
     pub jit_retired: u64,
+    /// Exits caused by a guarded branch taking an unrecorded direction.
     pub guarded_branch_exits: u64,
+    /// Trace re-recordings triggered by adaptive branch behavior.
     pub adaptive_rerecords: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Execution count aggregated by decoded memory-operation opcode.
 pub struct DecodedMemProfileRow {
+    /// Guest opcode word.
     pub opcode: u16,
+    /// Number of executions through the decoded memory fast path.
     pub executions: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Execution count for one decoded memory-operation site.
 pub struct DecodedMemSiteProfileRow {
+    /// Guest program counter of the operation.
     pub pc: u32,
+    /// Guest opcode word.
     pub opcode: u16,
+    /// Number of executions through the decoded memory fast path.
     pub executions: u64,
 }
 
@@ -51,17 +76,26 @@ impl TraceProfileRow {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Snapshot of all trace and decoded-memory profiling counters.
 pub struct TraceProfileSnapshot {
+    /// Per-trace-head counters.
     pub rows: Vec<TraceProfileRow>,
+    /// Decoded memory counts aggregated by opcode.
     pub decoded_mem_ops: Vec<DecodedMemProfileRow>,
+    /// Decoded memory counts split by guest PC and opcode.
     pub decoded_mem_sites: Vec<DecodedMemSiteProfileRow>,
+    /// Total observed backward branches.
     pub backward_hits: u64,
+    /// Total rejected trace-entry opportunities.
     pub rejected_hits: u64,
+    /// Total calls into a trace executor.
     pub native_calls: u64,
+    /// Total instructions retired by trace executors.
     pub jit_retired: u64,
 }
 
 impl TraceProfileSnapshot {
+    /// Format the snapshot as a ranked, human-readable profiling report.
     pub fn report(&self) -> String {
         let mut rows = self.rows.clone();
         rows.sort_unstable_by(|a, b| {
@@ -330,10 +364,12 @@ thread_local! {
     static PROFILE: RefCell<ProfileState> = RefCell::new(ProfileState(Profile::default()));
 }
 
+/// Clear every counter in the current thread's profiler.
 pub fn reset() {
     PROFILE.with_borrow_mut(|profile| profile.0 = Profile::default());
 }
 
+/// Capture the current thread's profiling counters without resetting them.
 pub fn snapshot() -> TraceProfileSnapshot {
     PROFILE.with_borrow(|profile| profile.0.snapshot())
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -8,18 +8,30 @@ use super::memory::AddressBus;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u32)]
 pub enum CpuType {
+    /// Sentinel used before a concrete processor model is selected.
     Invalid = 0,
+    /// Original 16/32-bit M68000.
     #[default]
     M68000 = 1,
+    /// M68010 with VBR, restartable faults, and loop mode.
     M68010 = 2,
+    /// Embedded 68020 variant with a 24-bit external address bus.
     M68EC020 = 3,
+    /// Full M68020.
     M68020 = 4,
+    /// M68030 without an on-chip PMMU.
     M68EC030 = 5,
+    /// Full M68030 with PMMU.
     M68030 = 6,
+    /// M68040 without an MMU or FPU.
     M68EC040 = 7,
+    /// M68040 with an MMU but without an FPU.
     M68LC040 = 8,
+    /// Full M68040 with MMU and FPU.
     M68040 = 9,
+    /// Philips SCC68070 system-controller CPU.
     SCC68070 = 10,
+    /// Full superscalar M68060.
     M68060 = 11,
 }
 
@@ -86,7 +98,10 @@ pub trait HleHandler {
     }
 }
 
-/// A no-op HLE handler that takes all exceptions (default behavior).
+/// HLE handler that declines every interception.
+///
+/// Passing this handler to [`CpuCore::step_with_hle_handler`] causes each trap
+/// to fall back to its architectural hardware exception.
 #[derive(Default, Clone, Copy)]
 pub struct NoOpHleHandler;
 
@@ -95,13 +110,17 @@ impl HleHandler for NoOpHleHandler {}
 /// Operand size for instructions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Size {
+    /// Eight-bit operand.
     Byte,
+    /// Sixteen-bit operand.
     Word,
+    /// Thirty-two-bit operand.
     Long,
 }
 
 impl Size {
     #[inline]
+    /// Return the operand width in bytes.
     pub const fn bytes(self) -> u32 {
         match self {
             Size::Byte => 1,
@@ -111,6 +130,7 @@ impl Size {
     }
 
     #[inline]
+    /// Return the operand width in bits.
     pub const fn bits(self) -> u8 {
         match self {
             Size::Byte => 8,
@@ -120,6 +140,7 @@ impl Size {
     }
 
     #[inline]
+    /// Return a low-bit mask covering the operand width.
     pub const fn mask(self) -> u32 {
         match self {
             Size::Byte => 0xFF,
@@ -129,6 +150,7 @@ impl Size {
     }
 
     #[inline]
+    /// Return the most-significant-bit mask for the operand width.
     pub const fn msb_mask(self) -> u32 {
         match self {
             Size::Byte => 0x80,
@@ -141,8 +163,8 @@ impl Size {
 /// Internal result from instruction dispatch.
 ///
 /// This is used internally by `dispatch_instruction` and `step_with_hle_handler`.
-/// It includes trap variants for internal handling - the public `StepResult`
-/// doesn't expose these since traps are handled via callbacks.
+/// It includes trap variants that [`CpuCore::step`] exposes to its caller and
+/// that [`CpuCore::step_with_hle_handler`] routes through callbacks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InternalStepResult {
     /// Instruction executed normally.
@@ -161,8 +183,10 @@ pub(crate) enum InternalStepResult {
 
 /// Result from executing a single CPU instruction.
 ///
-/// This enum is simplified - traps are handled internally via `step_with_hle_handler()`.
-/// For HLE interception, implement `HleHandler` and use `step_with_hle_handler()`.
+/// [`CpuCore::step`] returns trap variants without taking their hardware
+/// exceptions. [`CpuCore::step_with_hle_handler`] instead offers those traps to
+/// an [`HleHandler`] and returns [`StepResult::Ok`] after either interception or
+/// architectural exception delivery.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StepResult {
     /// Instruction executed normally.
@@ -171,15 +195,30 @@ pub enum StepResult {
         cycles: i32,
     },
     /// A-line trap (0xAxxx opcode).
-    AlineTrap { opcode: u16 },
+    AlineTrap {
+        /// Trapping opcode word.
+        opcode: u16,
+    },
     /// F-line trap (0xFxxx opcode).
-    FlineTrap { opcode: u16 },
+    FlineTrap {
+        /// Trapping opcode word.
+        opcode: u16,
+    },
     /// TRAP #n instruction.
-    TrapInstruction { trap_num: u8 },
+    TrapInstruction {
+        /// Trap number from 0 through 15.
+        trap_num: u8,
+    },
     /// BKPT #n instruction.
-    Breakpoint { bp_num: u8 },
+    Breakpoint {
+        /// Breakpoint number encoded by the instruction.
+        bp_num: u8,
+    },
     /// Illegal instruction.
-    IllegalInstruction { opcode: u16 },
+    IllegalInstruction {
+        /// Illegal opcode word.
+        opcode: u16,
+    },
     /// CPU is stopped (STOP instruction executed).
     Stopped,
 }
@@ -216,17 +255,35 @@ pub enum BatchExit {
     Stopped,
     /// Execution reached a PC in the caller's watch list. The instruction
     /// at the watched PC has **not** been executed yet.
-    WatchedPc { pc: u32 },
+    WatchedPc {
+        /// Watched program-counter value.
+        pc: u32,
+    },
     /// A-line trap (0xAxxx opcode).
-    AlineTrap { opcode: u16 },
+    AlineTrap {
+        /// Trapping opcode word.
+        opcode: u16,
+    },
     /// F-line trap (0xFxxx opcode).
-    FlineTrap { opcode: u16 },
+    FlineTrap {
+        /// Trapping opcode word.
+        opcode: u16,
+    },
     /// TRAP #n instruction.
-    TrapInstruction { trap_num: u8 },
+    TrapInstruction {
+        /// Trap number from 0 through 15.
+        trap_num: u8,
+    },
     /// BKPT #n instruction.
-    Breakpoint { bp_num: u8 },
+    Breakpoint {
+        /// Breakpoint number encoded by the instruction.
+        bp_num: u8,
+    },
     /// Illegal instruction.
-    IllegalInstruction { opcode: u16 },
+    IllegalInstruction {
+        /// Illegal opcode word.
+        opcode: u16,
+    },
 }
 
 /// Result of a [`CpuCore::run_batch`](crate::CpuCore::run_batch) call.
@@ -258,15 +315,30 @@ pub enum CycleBatchExit {
     /// interrupt on entry.
     Stopped,
     /// A-line trap (0xAxxx opcode).
-    AlineTrap { opcode: u16 },
+    AlineTrap {
+        /// Trapping opcode word.
+        opcode: u16,
+    },
     /// F-line trap (0xFxxx opcode).
-    FlineTrap { opcode: u16 },
+    FlineTrap {
+        /// Trapping opcode word.
+        opcode: u16,
+    },
     /// TRAP #n instruction.
-    TrapInstruction { trap_num: u8 },
+    TrapInstruction {
+        /// Trap number from 0 through 15.
+        trap_num: u8,
+    },
     /// BKPT #n instruction.
-    Breakpoint { bp_num: u8 },
+    Breakpoint {
+        /// Breakpoint number encoded by the instruction.
+        bp_num: u8,
+    },
     /// Illegal instruction.
-    IllegalInstruction { opcode: u16 },
+    IllegalInstruction {
+        /// Illegal opcode word.
+        opcode: u16,
+    },
 }
 
 /// Result of [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles).

--- a/src/dasm/format.rs
+++ b/src/dasm/format.rs
@@ -1,6 +1,6 @@
 //! Instruction disassembly/formatting.
 //!
-//! Provides human-readable disassembly of M68000 instructions.
+//! Provides a human-readable summary of one M68000-family opcode word.
 
 use crate::core::types::CpuType;
 
@@ -25,9 +25,12 @@ fn size_suffix(size: u8) -> &'static str {
 
 /// Disassemble a single instruction.
 ///
-/// Returns (mnemonic_string, instruction_size_in_bytes).
-/// Note: For multi-word instructions, only the first word is analyzed here.
-/// A full disassembler would need access to the following words.
+/// Returns the formatted mnemonic and an estimated instruction size in bytes.
+///
+/// Only `opcode` is decoded. Instructions that require extension words use
+/// placeholders such as `#xx` or `<ea>`, so the returned size cannot account
+/// for every effective-address extension. `cpu_type` selects model-specific
+/// F-line formatting; `pc` is reserved for future relative-address rendering.
 pub fn disassemble(_pc: u32, opcode: u16, cpu_type: CpuType) -> (String, u32) {
     let op_hi = (opcode >> 12) & 0xF;
 

--- a/src/dasm/mod.rs
+++ b/src/dasm/mod.rs
@@ -1,4 +1,8 @@
-//! Disassembler
+//! Opcode-word disassembly helpers.
+//!
+//! This module formats the information available in a single opcode word. It
+//! does not read extension words or operand memory; see [`disassemble`] for the
+//! resulting placeholders and size estimate.
 
 mod format;
 

--- a/src/fpu/mod.rs
+++ b/src/fpu/mod.rs
@@ -1,4 +1,11 @@
-//! FPU emulation (68881/68882/68040)
+//! Floating-point emulation for the 68881/68882 and the on-chip
+//! 68040/68060 FPUs.
+//!
+//! The public register value is [`FloatX80`]. Instruction execution uses a
+//! pure-Rust 80-bit extended-precision engine, including FPCR rounding modes,
+//! exception accumulation, packed-decimal conversion, and transcendental
+//! operations. CPU-specific instruction availability and exception behavior
+//! are enforced by [`CpuCore`](crate::CpuCore).
 
 mod dd;
 mod operations;

--- a/src/fpu/operations.rs
+++ b/src/fpu/operations.rs
@@ -1,7 +1,9 @@
-//! FPU operations (68040/68881-class).
+//! FPU instruction decode and execution for 68881/68882, 68040, and 68060
+//! configurations.
 //!
-//! Note: This is currently a **minimal bring-up** focused on plumbing + a few
-//! OS-critical operations. Expect expansion over time.
+//! Arithmetic uses the pure-Rust extended-precision engine, including FPCR
+//! rounding, FPSR exception state, packed-decimal formats, transcendentals,
+//! conditionals, register moves, and CPU-specific FSAVE/FRESTORE frames.
 
 use super::packed;
 use super::softfloat::{self, ExcFlags, FpCmp, Precision, RoundCtx, RoundMode};
@@ -24,8 +26,9 @@ enum FpuEa {
 
 /// Round an f64 to an integer using the FPCR rounding mode and saturate
 /// into the destination integer width, as the 6888x does for FMOVE to an
-/// integer format (out-of-range and NaN produce the most negative value
-/// and would set OPERR, which the emulated FPU does not raise).
+/// integer format. Out-of-range values and NaNs produce the most negative
+/// destination value; this conversion helper does not currently report the
+/// corresponding OPERR status.
 fn f64_to_int_saturating(value: f64, fpcr: u32, min: i64, max: i64) -> i64 {
     if value.is_nan() {
         return min;
@@ -119,10 +122,11 @@ fn words_to_bytes(w0: u32, w1: u32, w2: u32) -> [u8; 12] {
 }
 
 impl CpuCore {
-    /// 68040 FPU "op0" entrypoint (opcode pattern 0xF2xx in Musashi: `040fpu0`).
+    /// Execute a general 6888x/68040/68060 F-line operation (`0xF2xx`).
     ///
-    /// Handles the implemented 6888x/68040 ALU, FMOVE, control, and condition-code subset.
-    /// Unsupported encodings return 0 so the caller can raise the Line-F exception.
+    /// Handles arithmetic, FMOVE, control, conditional, and save/restore
+    /// operations according to the configured CPU model. Unsupported encodings
+    /// return zero so the caller can raise the Line-F exception.
     pub fn exec_fpu_op0<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         use crate::core::types::CpuType;
 
@@ -527,9 +531,10 @@ impl CpuCore {
         4
     }
 
-    /// 68040 FPU "op1" entrypoint (opcode pattern 0xF3xx in Musashi: `040fpu1`).
+    /// FPU "op1" entrypoint for the `0xF3xx` encoding group.
     ///
-    /// Implements a minimal subset: `FSAVE <ea>` and `FRESTORE <ea>` for a NULL/IDLE frame.
+    /// This group contains `FSAVE <ea>` and `FRESTORE <ea>`; frame formats
+    /// follow the configured CPU/FPU generation.
     pub fn exec_fpu_op1<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         // FSAVE/FRESTORE also take the disabled trap when PCR.DFP is set.
         if self.is_060() && (self.pcr & crate::core::cpu::PCR_DFP) != 0 {
@@ -639,9 +644,8 @@ impl CpuCore {
     /// 68060 FSAVE: the floating-point state frame carries its format in
     /// bits 15:8 of the first long word: $00 = NULL (FPU untouched since
     /// reset), $60 = IDLE. A NULL frame is a single long word - the same
-    /// one-long NULL every part since the 68881 has used, and the size
-    /// AmigaOS's hand-built task contexts rely on - while IDLE occupies
-    /// the full three long words. The EXCP frame ($E0, carrying pending-
+    /// one-long NULL used since the 68881, while IDLE occupies the full three
+    /// long words. The EXCP frame ($E0, carrying pending-
     /// exception operands) is not modeled: the softfloat FPU completes
     /// every operation before retiring.
     fn exec_fsave_060<B: AddressBus>(&mut self, bus: &mut B, ea_mode: u8, ea_reg: usize) -> i32 {
@@ -888,10 +892,11 @@ impl CpuCore {
         self.fpsr |= aexc;
     }
 
-    /// Evaluate a 6888x conditional predicate against FPSR. The upper
-    /// half of the condition space (bit 5 (actually bit 4 of the 5-bit
-    /// field)) only differs by signalling BSUN on NaN, which the emulated
-    /// FPU does not raise, so it folds onto the lower half.
+    /// Evaluate a 6888x conditional predicate against FPSR.
+    ///
+    /// Signaling predicates (condition bit 4 set) currently evaluate like
+    /// their non-signaling counterparts; this helper does not set BSUN when
+    /// the unordered condition is present.
     fn fpu_condition(&self, condition: u8) -> bool {
         const FPCC_N: u32 = 0x0800_0000;
         const FPCC_Z: u32 = 0x0400_0000;
@@ -923,17 +928,15 @@ impl CpuCore {
 
     /// Apply a general FPU ALU operation `opmode` to destination register
     /// `dst` using the source operand `src` (an FPm register or an
-    /// <ea>/immediate operand). This is the single dispatch table shared by
+    /// `<ea>`/immediate operand). This is the single dispatch table shared by
     /// the register-source (`subop 0x0`) and memory/immediate-source (`subop
     /// 0x2`) paths so the two cannot drift apart. FMOVECR has no source
     /// operand and is handled by the callers.
     ///
-    /// Phase 0: arithmetic is still computed via an f64 bridge
-    /// (`src.to_f64()` ... `FloatX80::from_f64(result)`) so results match the
-    /// previous core exactly while the register file is the extended type;
-    /// Phase 1 swaps each arm onto the softfloat engine. The 6888x
-    /// single/double rounding-precision variants (FSxxx/FDxxx) still fold
-    /// onto their base op here.
+    /// Arithmetic is evaluated by the extended-precision softfloat and
+    /// transcendental engines. The 6888x single/double
+    /// rounding-precision variants (FSxxx/FDxxx) select their specified
+    /// result precision before the value is written back.
     fn fpu_apply_op(&mut self, opmode: u16, dst: usize, src: FloatX80) -> i32 {
         match opmode {
             0x00 | 0x40 | 0x44 => {
@@ -1178,7 +1181,7 @@ impl CpuCore {
         }
     }
 
-    /// FScc <ea> trap on the 68060: the instruction is emulated by the
+    /// `FScc <ea>` trap on the 68060: the instruction is emulated by the
     /// 68060SP. Resolve the byte-sized destination EA for the frame.
     pub(crate) fn fpu_060_scc_trap<B: AddressBus>(
         &mut self,
@@ -1229,9 +1232,9 @@ impl CpuCore {
 
     /// Read the ALU/FMOVE source operand in `fmt` (0=long, 1=single,
     /// 2=extended, 4=word, 6=byte, 5=double) as an extended value. The
-    /// extended format (2) is read losslessly; the others go through an f64
-    /// bridge for now (Phase 1 replaces these with exact widening). Packed
-    /// decimal (3) is unimplemented and reports as unhandled (F-line).
+    /// extended format (2) is read losslessly. Integer, binary32, and
+    /// binary64 inputs are widened exactly to the extended register format;
+    /// packed decimal (3) is decoded by the packed-decimal engine.
     fn fpu_read_source<B: AddressBus>(
         &mut self,
         bus: &mut B,
@@ -1323,9 +1326,9 @@ impl CpuCore {
     }
 
     /// Write `value` to the FMOVE destination in `fmt`. Integer formats
-    /// round per FPCR and saturate; packed decimal (3 and 7) is
-    /// unimplemented and reports as unhandled (F-line). Returns false if
-    /// the format/EA combination cannot be carried out.
+    /// round per FPCR and saturate; packed-decimal formats 3 and 7 honor
+    /// their static or dynamic k-factor. Returns false if the format/EA
+    /// combination is invalid.
     fn fpu_write_dest<B: AddressBus>(
         &mut self,
         bus: &mut B,

--- a/src/fpu/packed.rs
+++ b/src/fpu/packed.rs
@@ -7,7 +7,7 @@
 //! The value is  (-1)^SM * D0.D1D2...D16 * 10^((-1)^SE * e2e1e0).
 //! An exponent field of $FFF encodes Inf (zero mantissa) or NaN.
 //!
-//! Decimal<->binary scaling goes through the floatx80 engine (powers of ten
+//! Decimal-to-binary scaling goes through the floatx80 engine (powers of ten
 //! built by exponentiation-by-squaring); the leading decimal exponent for the
 //! binary->decimal direction is estimated with an f64 log10. This is the
 //! 6888x "round to a decimal string" behavior, which is inherently inexact;

--- a/src/fpu/transcendental.rs
+++ b/src/fpu/transcendental.rs
@@ -3,10 +3,11 @@
 //! Each function reduces its argument, evaluates a Taylor/atanh series in the
 //! double-double layer (`dd.rs`) -- whose coefficients are exact rationals, so
 //! no minimax tooling is needed -- and rounds the ~128-bit result to 64-bit
-//! extended under the caller's FPCR mode, setting INEX/OPERR/DZ. Accuracy is
-//! faithful to ~64 bits (validated by identities and exact anchors); it is not
-//! chip-bit-exact (the 6888x uses its own CORDIC/polynomial microcode, and a
-//! bare 68040 traps these to a software FPSP). FMOD/FREM are exact.
+//! extended under the caller's FPCR mode, setting INEX/OPERR/DZ. The test suite
+//! checks finite normal results against 200-bit `astro-float` references with a
+//! one-ULP tolerance across all FPCR rounding modes. Results are not
+//! chip-bit-exact: the 6888x uses its own CORDIC/polynomial microcode, and a
+//! bare 68040 traps these operations to a software FPSP. FMOD/FREM are exact.
 
 use super::dd::{self, Df};
 use super::softfloat::{self, ExcFlags, FpCmp, RoundCtx, RoundMode};

--- a/src/fpu/types.rs
+++ b/src/fpu/types.rs
@@ -7,7 +7,9 @@
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FloatX80 {
+    /// Explicit 64-bit significand, including the integer bit at bit 63.
     pub mantissa: u64,
+    /// Sign in bit 15 and biased exponent in bits 14 through 0.
     pub sign_exp: u16,
 }
 
@@ -46,6 +48,7 @@ impl FloatX80 {
         self.sign_exp & 0x7FFF
     }
 
+    /// Return whether the value is a quiet or signaling NaN.
     pub const fn is_nan(self) -> bool {
         self.biased_exp() == 0x7FFF && (self.mantissa << 1) != 0
     }
@@ -55,14 +58,17 @@ impl FloatX80 {
         self.is_nan() && (self.mantissa & 0x4000_0000_0000_0000) == 0
     }
 
+    /// Return whether the value is positive or negative infinity.
     pub const fn is_inf(self) -> bool {
         self.biased_exp() == 0x7FFF && (self.mantissa << 1) == 0
     }
 
+    /// Return whether the value is positive or negative zero.
     pub const fn is_zero(self) -> bool {
         self.biased_exp() == 0 && self.mantissa == 0
     }
 
+    /// Return whether the value is a finite nonzero denormal.
     pub const fn is_denormal(self) -> bool {
         self.biased_exp() == 0 && self.mantissa != 0
     }
@@ -90,10 +96,11 @@ impl FloatX80 {
         (self.sign_exp, self.mantissa)
     }
 
-    /// Convert to the nearest f64. Lossy for values outside f64's range or
-    /// precision; used by the temporary arithmetic bridge and (permanently)
-    /// by the transcendental shim. Values that originated from an f64
-    /// round-trip back exactly.
+    /// Convert to the nearest `f64`.
+    ///
+    /// The conversion is lossy for values outside binary64's range or
+    /// precision. Values produced by [`FloatX80::from_f64`] round-trip
+    /// exactly, including signed zero, infinity, and NaN classification.
     pub fn to_f64(self) -> f64 {
         let sign = (self.sign_exp >> 15) & 1;
         let exp = (self.sign_exp & 0x7FFF) as i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,58 @@
-//! # m68k
+//! A safe, embeddable Motorola M68000-family CPU emulator.
 //!
-//! A safe Rust M68000 family CPU emulator.
+//! The core supports the M68000, M68010, M68EC020, M68020, M68EC030,
+//! M68030, M68EC040, M68LC040, M68040, M68060, and SCC68070. It includes
+//! generation-specific exception frames, instruction prefetch, integer and
+//! floating-point execution, 68030/68040/68060 MMU translation, and
+//! per-generation timing models.
 //!
-//! Supports: M68000, M68010, M68EC020, M68020, M68EC030, M68030,
-//! M68EC040, M68LC040, M68040, M68060, and SCC68070.
+//! # Getting started
+//!
+//! Implement [`AddressBus`] for a machine with devices, or use
+//! [`LinearMemoryBus`] for a contiguous RAM-backed address space:
+//!
+//! ```no_run
+//! use m68k::{CpuCore, CpuType, LinearMemoryBus, StepResult};
+//!
+//! let mut memory = LinearMemoryBus::new(1024 * 1024);
+//! memory.write_long_at(0, 0x0008_0000); // reset SSP
+//! memory.write_long_at(4, 0x0000_1000); // reset PC
+//! memory.write_word_at(0x1000, 0x4E71); // NOP
+//!
+//! let mut cpu = CpuCore::new();
+//! cpu.set_cpu_type(CpuType::M68000);
+//! cpu.reset(&mut memory);
+//! assert!(matches!(cpu.step(&mut memory), StepResult::Ok { .. }));
+//! ```
+//!
+//! [`CpuCore::step`] and [`CpuCore::execute`] preserve transaction-level bus
+//! ordering and expose internal-clock gaps through [`AddressBus::sync`].
+//! [`CpuCore::run_for_cycles`] retains cycle accounting with lower dispatch
+//! overhead, while [`CpuCore::run_batch`] is an instruction-budgeted
+//! throughput path that can use [`FastMem`].
+//!
+//! # Cargo features
+//!
+//! - `serde` serializes the architectural CPU state for deterministic save
+//!   states. Decode tables, FastMem pointers, and trace caches are deliberately
+//!   omitted and rebuilt after loading.
+//! - `jit` lowers eligible hot traces to native code with Cranelift on
+//!   non-WebAssembly targets. Without it—and on WebAssembly—the same trace
+//!   machinery uses the portable Rust executor.
+//! - `trace-profile` adds opt-in trace and decoded-operation profiling,
+//!   activated at runtime with `M68K_TRACE_PROFILE=1`.
+//!
+//! No features are enabled by default.
+
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod core;
 pub mod dasm;
 pub mod fpu;
 pub mod mmu;
 
-// Re-export commonly used types from core
+// Re-export the embedding API at the crate root.
 pub use core::cpu::CpuCore;
 pub use core::cpu::{
     CACR_040_DE, CACR_040_IE, CACR_060_CABC, CACR_060_CUBC, CACR_060_EBC, CACR_060_EDC,

--- a/src/mmu/mod.rs
+++ b/src/mmu/mod.rs
@@ -1,4 +1,15 @@
-//! MMU emulation (68030/68040 PMMU)
+//! PMMU emulation for the M68030, M68040, and M68060.
+//!
+//! The 68030 path implements its programmable multi-level table format,
+//! CRP/SRP selection, function-code lookup, transparent translation, PTEST,
+//! and accumulated write/supervisor protection. The 68040 and 68060 use the
+//! fixed root/pointer/page table format, instruction/data transparent
+//! translation registers, and a direct-mapped address-translation cache.
+//!
+//! Table-walk bus errors and protection failures retain enough cause detail
+//! for generation-specific exception frames. Used/modified descriptor
+//! write-back, 68030 root-descriptor limit checks, and a DT=1 page descriptor
+//! directly in the 68030 root pointer are not modeled.
 
 pub mod atc;
 mod translation;
@@ -12,9 +23,13 @@ pub(crate) use translation::ptest_030;
 pub use translation::translate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Architectural class of an MMU operation or translation fault.
 pub enum MmuFaultKind {
+    /// Translation-control or root-pointer configuration is invalid.
     ConfigurationError,
+    /// The requested PMMU operation or descriptor form is illegal.
     IllegalOperation,
+    /// A mapping is absent or denies the attempted access.
     AccessLevelViolation,
     /// A physical bus error occurred while walking tables / fetching descriptors.
     BusError,
@@ -45,21 +60,25 @@ pub enum MmuFaultCause {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// MMU failure returned to the CPU's exception-delivery path.
 pub struct MmuFault {
+    /// Architectural fault class used to select the exception vector.
     pub kind: MmuFaultKind,
+    /// Logical or table address associated with the failure.
     pub address: u32,
+    /// Detailed translation cause used by generation-specific stack frames.
     pub cause: MmuFaultCause,
 }
 
+/// Result of an MMU translation or PMMU operation.
 pub type MmuResult<T> = Result<T, MmuFault>;
 
-/// Translate a logical address using the CPU's PMMU state (68030/68040 style).
+/// Translate a logical address using the configured CPU's PMMU state.
 ///
-/// This is currently based on the (vendored) Musashi PMMU algorithm and focuses on the common
-/// CRP/SRP + TC table-walk behavior. Access permission checks and detailed MMUSR bits are TODO.
-///
-/// The `instruction` parameter indicates whether this is an instruction fetch (true) or
-/// data access (false), used for ITT/DTT selection on 68040.
+/// `write` selects read versus write permission checking, `supervisor`
+/// selects the user/supervisor root and protection domain, and `instruction`
+/// selects instruction versus data transparent-translation registers.
+/// Disabled or absent PMMUs return the logical address unchanged.
 pub fn translate_address<B: AddressBus>(
     cpu: &mut CpuCore,
     bus: &mut B,

--- a/src/mmu/translation.rs
+++ b/src/mmu/translation.rs
@@ -1,4 +1,4 @@
-//! Address translation (PMMU table walk)
+//! Generation-specific PMMU table walks and PTEST evaluation.
 
 use crate::core::cpu::CpuCore;
 use crate::core::memory::{AddressBus, BusFaultKind};
@@ -45,18 +45,18 @@ fn read_u32_phys<B: AddressBus>(bus: &mut B, addr: u32) -> MmuResult<u32> {
     })
 }
 
-/// Perform 68030/68040 PMMU translation.
+/// Translate one logical address through the configured 68030, 68040, or
+/// 68060 PMMU.
 ///
-/// This implementation follows the structure of Musashi's `pmmu_translate_addr()` algorithm.
-/// It currently supports:
-/// - CRP/SRP selection via TC bit 25 (0x0200_0000)
-/// - Root/table modes 2 (4-byte descriptors) and 3 (8-byte descriptors)
-/// - Early-termination descriptors (mode 1) at table A/B/C
-/// - Transparent Translation Registers (TTRs) for 68030/68040
+/// The 68030 path selects CRP/SRP and supports short and long table
+/// descriptors, early termination, indirect descriptors, function-code
+/// levels, transparent translation, write protection, and supervisor-only
+/// subtrees. The 68040/68060 path implements their fixed three-level table,
+/// indirect pages, 4/8 KiB pages, ITT/DTT bypass, protection, and ATC fills.
 ///
-/// TODO:
-/// - Access permission checks and precise MMUSR (`mmu_sr`) bits
-/// - Page descriptor root mode (root_limit & 3 == 1)
+/// If the selected CPU has no enabled PMMU, the address is returned
+/// unchanged. Translation and table-fetch failures return [`MmuFault`] with
+/// the address and cause required by the CPU's exception-frame builder.
 pub fn translate<B: AddressBus>(
     cpu: &mut CpuCore,
     bus: &mut B,
@@ -431,11 +431,11 @@ pub(crate) fn ptest_030<B: AddressBus>(
 /// Perform 68040 PMMU translation.
 ///
 /// The 68040 uses a fixed three-level table (root -> pointer -> page) with
-/// 4-byte descriptors, indexed by logical bits [31:25] / [24:18] / [17:12]
-/// (4 KB pages) or [17:13] (8 KB pages, TC bit 14 set). The root pointer is
+/// 4-byte descriptors, indexed by logical bits `31:25` / `24:18` / `17:12`
+/// (4 KB pages) or `17:13` (8 KB pages, TC bit 14 set). The root pointer is
 /// URP in user mode and SRP in supervisor mode (no TC bit-25 gate -- that is
-/// 68030-only). Table-level descriptors use UDT (bits [1:0]): >=2 = resident;
-/// page descriptors use PDT (bits [1:0]): 0 = invalid, 2 = indirect, 1/3 =
+/// 68030-only). Table-level descriptors use UDT (bits `1:0`): >=2 = resident;
+/// page descriptors use PDT (bits `1:0`): 0 = invalid, 2 = indirect, 1/3 =
 /// resident.
 ///
 /// Any access through an invalid/unconfigured descriptor raises an access

--- a/src/mmu/ttr.rs
+++ b/src/mmu/ttr.rs
@@ -8,14 +8,14 @@ use crate::core::types::CpuType;
 
 /// TTR register format (68030/68040):
 /// ```text
-/// [31:24] Base Address (compared against address[31:24])
-/// [23:16] Address Mask (1 = ignore bit during comparison)
+/// `31:24` Base Address (compared against address bits `31:24`)
+/// `23:16` Address Mask (1 = ignore bit during comparison)
 /// [15]    E: Enable
 /// [14]    CI: Cache Inhibit (ignored by us)
 /// [13]    R/W: 0=read-only, 1=read/write (68030) or W (68040)
 /// [12]    RWM: R/W Mask (68030) or 0 (68040)
-/// [10:8]  FC Base (function code to match)
-/// [4:2]   FC Mask (1 = ignore FC bit)
+/// `10:8`  FC Base (function code to match)
+/// `4:2`   FC Mask (1 = ignore FC bit)
 /// ```
 const TTR_ENABLE: u32 = 0x8000;
 const TTR_BASE_MASK: u32 = 0xFF00_0000;


### PR DESCRIPTION
Closes #42

## Summary
- audit and correct crate, module, and public API rustdocs across the CPU, FPU, MMU, memory, timing, and tracing APIs
- enforce complete public documentation and valid intra-doc links at the crate level
- build all-feature public and private-item rustdocs with warnings denied in CI

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --locked`
- `cargo test --all-features --locked`
- `RUSTDOCFLAGS="-D warnings -D rustdoc::private_intra_doc_links" cargo doc --locked --all-features --no-deps --document-private-items`
- `cargo package --locked`