### PR TITLE
feat: add bus-requested cycle boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ fn emulate(cpu: &mut CpuCore, bus: &mut impl AddressBus) {
 | **`step()`** | One instruction | Transaction-accurate `AddressBus` accesses and cycles | Surfaces A-line, F-line, `TRAP`, `BKPT`, and illegal instructions without taking their exception |
 | **`step_with_hle_handler()`** | One instruction | Same precise path as `step()` | Offers traps to `HleHandler`; unhandled traps take the hardware exception |
 | **`execute()`** | CPU cycles | Precise path; whole instructions may overshoot the requested cycles | Takes traps as hardware exceptions and returns consumed cycles |
-| **`run_for_cycles()`** | CPU cycles | Precise path with actual cycle and instruction totals | Surfaces traps like `step()` and reports STOP separately |
+| **`run_for_cycles()`** | CPU cycles | Precise path with actual cycle and instruction totals | Surfaces traps, STOP, and bus-requested instruction boundaries separately |
 | **`run_batch()`** | Instructions | Throughput path using decoded-op caching, optional direct RAM, and portable or `jit`-enabled native hot-loop traces | Surfaces traps, STOP, watched PCs, or budget exhaustion |
 
 Use **`step()`** for debugger-style control. Use **`run_for_cycles()`** when a
@@ -185,6 +185,9 @@ match result.exit {
     CycleBatchExit::Stopped => {
         // Wait for a serviceable interrupt.
     }
+    CycleBatchExit::BoundaryRequested => {
+        // Apply work queued by the bus before resuming the CPU.
+    }
     event => {
         // Handle a surfaced trap. The trapping instruction is not included
         // in result.instructions and no exception-entry cycles were charged.
@@ -192,6 +195,18 @@ match result.exit {
     }
 }
 ```
+
+An `AddressBus` can return `true` from `take_boundary_request()` when a bus
+access discovers host work that must run after the current instruction and
+before another one executes. The request is checked after the instruction's
+cycles and retirement have been counted, and it takes precedence over cycle
+budget exhaustion. Implementations should consume the request while retaining
+the associated work until the host handles the boundary exit.
+
+The 68000 and 68010 may already have instruction words in their hardware
+prefetch queue at this boundary. If the host work changes instruction-visible
+memory or mapping and those queued words must not be used, call
+`cpu.invalidate_prefetch()` before resuming.
 
 Use **`step_with_hle_handler()`** when patching selected guest OS calls while
 allowing every unhandled trap to follow hardware behavior. Use

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -197,6 +197,10 @@ impl CpuCore {
     ///   before the first handler instruction executes.
     /// - A non-positive budget returns immediately with
     ///   [`CycleBatchExit::BudgetExhausted`].
+    /// - A bus boundary request is polled after each normally completed
+    ///   instruction. It includes that instruction in both totals and takes
+    ///   precedence over simultaneous budget exhaustion. STOP and surfaced
+    ///   traps retain their existing exit reasons.
     pub fn run_for_cycles<B: AddressBus>(
         &mut self,
         bus: &mut B,
@@ -254,6 +258,13 @@ impl CpuCore {
                             cycles: self.initial_cycles - self.cycles_remaining,
                             instructions,
                             exit: CycleBatchExit::Stopped,
+                        };
+                    }
+                    if bus.take_boundary_request() {
+                        return CycleBatchResult {
+                            cycles: self.initial_cycles - self.cycles_remaining,
+                            instructions,
+                            exit: CycleBatchExit::BoundaryRequested,
                         };
                     }
                 }

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -177,6 +177,26 @@ pub trait AddressBus {
         self.last_fetch_was_cached()
     }
 
+    /// Take a pending request to return from cycle-scheduled execution at
+    /// the next retired-instruction boundary.
+    ///
+    /// [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) calls this
+    /// after an instruction completes normally and before it fetches or
+    /// executes another instruction. Returning `true` makes the runner exit
+    /// with
+    /// [`CycleBatchExit::BoundaryRequested`](crate::CycleBatchExit::BoundaryRequested).
+    /// The completed instruction's cycles and retirement count are included
+    /// in the result.
+    ///
+    /// Implementations should consume the request when returning `true`, so
+    /// execution can resume without a separate acknowledgement call. A bus
+    /// can retain any associated host work in its own queue until the caller
+    /// processes the boundary exit. The default reports no request.
+    #[inline]
+    fn take_boundary_request(&mut self) -> bool {
+        false
+    }
+
     /// Perform an interrupt-acknowledge cycle for `level`.
     ///
     /// Return an explicit vector number in the low byte, or `u32::MAX` for

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -311,6 +311,13 @@ pub enum CycleBatchExit {
     /// The requested cycle budget was met or crossed at an instruction or
     /// interrupt boundary.
     BudgetExhausted,
+    /// The address bus requested a return after the most recently retired
+    /// instruction.
+    ///
+    /// The instruction's cycles and retirement count are included in the
+    /// result. This exit takes precedence when the instruction also meets or
+    /// crosses the cycle budget.
+    BoundaryRequested,
     /// The CPU executed STOP, or was already stopped with no serviceable
     /// interrupt on entry.
     Stopped,

--- a/tests/run_for_cycles_tests.rs
+++ b/tests/run_for_cycles_tests.rs
@@ -176,14 +176,22 @@ fn stop_is_distinct_and_the_stop_instruction_is_counted() {
 #[derive(Clone)]
 struct EventBus {
     memory: Vec<u8>,
+    overlay_memory: Vec<u8>,
+    overlay_enabled: bool,
     resets: u32,
+    boundary_write_address: Option<u32>,
+    boundary_requested: bool,
 }
 
 impl EventBus {
     fn new() -> Self {
         Self {
             memory: vec![0; 0x10000],
+            overlay_memory: vec![0; 0x10000],
+            overlay_enabled: false,
             resets: 0,
+            boundary_write_address: None,
+            boundary_requested: false,
         }
     }
 
@@ -194,11 +202,22 @@ impl EventBus {
     fn load_long(&mut self, address: u32, value: u32) {
         self.write_long(address, value);
     }
+
+    fn load_overlay_word(&mut self, address: u32, value: u16) {
+        let [hi, lo] = value.to_be_bytes();
+        self.overlay_memory[address as usize & 0xFFFF] = hi;
+        self.overlay_memory[address.wrapping_add(1) as usize & 0xFFFF] = lo;
+    }
 }
 
 impl AddressBus for EventBus {
     fn read_byte(&mut self, address: u32) -> u8 {
-        self.memory[address as usize & 0xFFFF]
+        let index = address as usize & 0xFFFF;
+        if self.overlay_enabled && (0x1000..0x2000).contains(&address) {
+            self.overlay_memory[index]
+        } else {
+            self.memory[index]
+        }
     }
 
     fn read_word(&mut self, address: u32) -> u16 {
@@ -225,6 +244,9 @@ impl AddressBus for EventBus {
         let [hi, lo] = value.to_be_bytes();
         self.write_byte(address, hi);
         self.write_byte(address.wrapping_add(1), lo);
+        if self.boundary_write_address == Some(address) {
+            self.boundary_requested = true;
+        }
     }
 
     fn write_long(&mut self, address: u32, value: u32) {
@@ -237,9 +259,55 @@ impl AddressBus for EventBus {
         u32::MAX
     }
 
+    fn take_boundary_request(&mut self) -> bool {
+        std::mem::take(&mut self.boundary_requested)
+    }
+
     fn reset_devices(&mut self) {
         self.resets += 1;
     }
+}
+
+#[test]
+fn bus_request_returns_after_the_current_instruction_and_before_the_next() {
+    let mut bus = EventBus::new();
+    bus.load_word(0x1000, 0x3080); // MOVE.W D0,(A0)
+    bus.load_word(0x1002, 0x7201); // Old mapping: MOVEQ #1,D1
+    bus.load_word(0x1004, 0x4E71); // NOP
+    bus.load_overlay_word(0x1002, 0x7202); // New mapping: MOVEQ #2,D1
+    bus.load_overlay_word(0x1004, 0x4E71);
+    bus.boundary_write_address = Some(0x4000);
+
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_a(0, 0x4000);
+    cpu.set_d(0, 0xABCD);
+
+    // The boundary reason wins even though this instruction crosses the
+    // one-cycle budget.
+    let result = cpu.run_for_cycles(&mut bus, 1);
+
+    assert_eq!(result.cycles, 8);
+    assert_eq!(result.instructions, 1);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(bus.read_word(0x4000), 0xABCD);
+    assert_eq!(cpu.d(1), 0);
+    assert_eq!(cpu.pc, 0x1002);
+
+    // The 68000 prefetched the old opcode as part of the requesting
+    // instruction. Apply the mapping change and discard that stale word
+    // before resuming.
+    bus.overlay_enabled = true;
+    cpu.invalidate_prefetch();
+
+    // The request was consumed by the boundary check, so resuming starts
+    // with the instruction that follows the requesting write, fetched from
+    // the new mapping.
+    let resumed = cpu.run_for_cycles(&mut bus, 1);
+    assert_eq!(resumed.cycles, 4);
+    assert_eq!(resumed.instructions, 1);
+    assert_eq!(resumed.exit, CycleBatchExit::BudgetExhausted);
+    assert_eq!(cpu.d(1), 2);
+    assert_eq!(cpu.pc, 0x1004);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `AddressBus::take_boundary_request()` with a default no-request implementation
- return `CycleBatchExit::BoundaryRequested` after the requesting instruction retires
- preserve exact cycle and instruction totals, with boundary requests taking precedence over simultaneous budget exhaustion
- document 68000/68010 prefetch invalidation for instruction-visible mapping changes

## Root cause

`run_for_cycles()` only observed its cycle budget, STOP state, and surfaced traps. A bus could discover mandatory host work during an instruction, but had no signal that the cycle runner checked before beginning another instruction.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- strict all-feature rustdoc build
- `cargo test --locked`
- `cargo test --all-features --locked`
- `cargo package --locked`
- regression coverage for exact accounting, exit precedence, resume position, and 68000 overlay/prefetch handling

Closes #47