### PR TITLE
feat: calibrate 020 taken-branch refill and model result forwarding from real hardware

### DIFF
--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -84,6 +84,11 @@ pub struct CpuCore {
     pub dtt1: u32,
     /// Instruction Register (current opcode)
     pub ir: u32,
+    /// Data register left in the execution unit's result latch by the
+    /// previous instruction (a register-to-register MOVE), for the 68020
+    /// result-forwarding refund; see `timing_020.rs`.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub(crate) result_latch_020: Option<u8>,
 
     // ========== FPU Registers (68881/68882/68040) ==========
     /// FPU Data Registers (FP0-FP7) - 80-bit extended precision.
@@ -501,6 +506,7 @@ impl CpuCore {
             dtt0: 0,
             dtt1: 0,
             ir: 0,
+            result_latch_020: None,
             fpr: [FloatX80::default(); 8],
             fpiar: 0,
             fpsr: 0,

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -607,6 +607,7 @@ impl CpuCore {
 
     /// Set CPU type and configure appropriate masks/timing.
     pub fn set_cpu_type(&mut self, cpu_type: CpuType) {
+        self.clear_execution_pipeline_state();
         self.cpu_type = cpu_type;
         self.is_pre_68020 = matches!(
             cpu_type,
@@ -726,6 +727,7 @@ impl CpuCore {
 
     /// Pulse reset (initialize CPU state without loading vectors).
     pub fn pulse_reset(&mut self) {
+        self.clear_execution_pipeline_state();
         self.stopped = 0;
         self.t1_flag = 0;
         self.t0_flag = 0;
@@ -793,11 +795,20 @@ impl CpuCore {
         if self.precise_bus == precise {
             return;
         }
+        self.clear_execution_pipeline_state();
         self.precise_bus = precise;
         self.prefetch_count = 0;
         self.pending_sync_clocks = 0;
         self.consume_without_prefetch = false;
         self.loop_mode = false;
+    }
+
+    /// Clear timing-model state that cannot survive a reset, exception, or
+    /// transition between execution engines.
+    #[inline]
+    pub(crate) fn clear_execution_pipeline_state(&mut self) {
+        self.result_latch_020 = None;
+        self.break_060_pipeline();
     }
 
     // ========== Precise per-access timing (Part E.2, 68000 only) ==========

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -569,6 +569,10 @@ impl CpuCore {
             opcode_fetch_cached
         };
 
+        if !matches!(result, InternalStepResult::Ok { .. }) {
+            self.clear_execution_pipeline_state();
+        }
+
         let res = match result {
             InternalStepResult::Ok { cycles } => StepResult::Ok {
                 cycles: self.finalize_cycles(cycles, fetch_cached),
@@ -676,6 +680,13 @@ impl CpuCore {
             opcode_fetch_cached
         };
 
+        // A surfaced or HLE-handled trap still represents an architectural
+        // execution boundary. Clear timing state before invoking callbacks,
+        // since a handler may itself resume execution.
+        if !matches!(result, InternalStepResult::Ok { .. }) {
+            self.clear_execution_pipeline_state();
+        }
+
         // Handle trap results via callbacks, fallback to exception if not handled
         let cycles = match result {
             InternalStepResult::Ok { cycles } => self.finalize_cycles(cycles, fetch_cached),
@@ -683,9 +694,6 @@ impl CpuCore {
                 if !handler.handle_aline(self, bus, opcode) {
                     self.take_aline_exception(bus)
                 } else {
-                    // On real hardware this is an exception: no pairing
-                    // window survives it.
-                    self.break_060_pipeline();
                     0 // HLE handled, 0 cycles for now
                 }
             }
@@ -693,7 +701,6 @@ impl CpuCore {
                 if !handler.handle_fline(self, bus, opcode) {
                     self.take_fline_exception(bus)
                 } else {
-                    self.break_060_pipeline();
                     0
                 }
             }
@@ -787,8 +794,8 @@ impl CpuCore {
 
     /// Jump to an exception vector.
     pub fn jump_vector<B: AddressBus>(&mut self, bus: &mut B, vector: u32) {
-        // Any exception entry breaks an open 68060 pairing window.
-        self.break_060_pipeline();
+        // Any exception entry breaks open execution-pipeline state.
+        self.clear_execution_pipeline_state();
         // An earlier poll-point hold must not survive into the handler:
         // the refill below is a fresh IPL poll point (Moira jumpToVector
         // polls during the final refill read).
@@ -973,12 +980,13 @@ impl CpuCore {
 
     /// Halt the CPU.
     pub fn halt(&mut self) {
+        self.clear_execution_pipeline_state();
         self.stopped |= STOP_LEVEL_HALT;
     }
 
     /// Stop the CPU (STOP instruction).
     pub fn stop(&mut self, new_sr: u16) {
-        self.break_060_pipeline();
+        self.clear_execution_pipeline_state();
         self.set_sr(new_sr);
         self.stopped |= STOP_LEVEL_STOP;
     }

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -27,12 +27,21 @@
 //! the cache. The manual accounts for that in the *following* instruction's
 //! head, which a per-instruction model with no overlap stage cannot express,
 //! so the cost is charged where the flush happens.
+//!
+//! The refill constant is calibrated against real hardware: a 68EC020 at
+//! 14.19 MHz (Amiga 1200) measures 7 clocks per cached taken `dbra` in three
+//! independent E-clock-referenced loop tests, i.e. the manual's cache-case 6
+//! plus 1, and every other measured loop (`move`, shift, `mulu`, paired ops)
+//! agrees with the same +1 once the loop branch is accounted for. A refill of
+//! 2 reproduced FS-UAE, which the same disk shows over-billing each taken
+//! branch by one clock against the real machine.
 
 use super::cpu::CpuCore;
 use super::types::Size;
 
-/// Clocks a taken branch loses refilling the 020's instruction pipeline.
-const TAKEN_BRANCH_REFILL: i32 = 2;
+/// Clocks a taken branch loses refilling the 020's instruction pipeline
+/// (real-A1200 calibrated: cached taken dbra = 7 clocks total).
+const TAKEN_BRANCH_REFILL: i32 = 1;
 
 #[derive(Clone, Copy)]
 struct Case {

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -811,6 +811,20 @@ const fn reg_to_reg_move_dest(op: u16) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::memory::{AddressBus, LinearMemoryBus};
+    use crate::core::types::{CpuType, HleHandler, StepResult};
+
+    fn prime_result_latch(cpu: &mut CpuCore) {
+        cpu.ir = 0x3002; // MOVE.W D2,D0
+        assert_eq!(cpu.cycles_020(4, true), 2);
+    }
+
+    fn assert_result_latch_cleared(cpu: &mut CpuCore) {
+        assert_eq!(cpu.result_latch_020, None);
+        cpu.instruction_exception_vector = None;
+        cpu.ir = 0x3200; // MOVE.W D0,D1
+        assert_eq!(cpu.cycles_020(4, true), 2);
+    }
 
     fn timed(op: u16, raw: i32, cached: bool) -> i32 {
         let mut cpu = CpuCore::new();
@@ -821,7 +835,7 @@ mod tests {
     #[test]
     fn result_forwarding_refunds_one_clock_on_a_raw_reg_move_pair() {
         let mut cpu = CpuCore::new();
-        cpu.set_cpu_type(crate::core::types::CpuType::M68EC020);
+        cpu.set_cpu_type(CpuType::M68EC020);
         cpu.ir = 0x3002; // MOVE.W D2,D0
         assert_eq!(cpu.cycles_020(4, true), 2);
         cpu.ir = 0x3200; // MOVE.W D0,D1: source still in the result latch
@@ -843,6 +857,75 @@ mod tests {
         let _ = cpu.cycles_020(4, false);
         cpu.ir = 0x3200;
         assert_eq!(cpu.cycles_020(4, false), 3);
+    }
+
+    #[test]
+    fn execution_boundaries_clear_the_result_latch() {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68EC020);
+
+        prime_result_latch(&mut cpu);
+        cpu.set_cpu_type(CpuType::M68020);
+        assert_result_latch_cleared(&mut cpu);
+
+        prime_result_latch(&mut cpu);
+        cpu.pulse_reset();
+        assert_result_latch_cleared(&mut cpu);
+
+        prime_result_latch(&mut cpu);
+        cpu.set_precise_bus(false);
+        cpu.set_precise_bus(true);
+        assert_result_latch_cleared(&mut cpu);
+
+        prime_result_latch(&mut cpu);
+        let mut bus = LinearMemoryBus::new(0x100);
+        cpu.jump_vector(&mut bus, 4);
+        assert_result_latch_cleared(&mut cpu);
+
+        prime_result_latch(&mut cpu);
+        cpu.stop(0x2700);
+        assert_result_latch_cleared(&mut cpu);
+
+        prime_result_latch(&mut cpu);
+        cpu.halt();
+        assert_result_latch_cleared(&mut cpu);
+    }
+
+    #[test]
+    fn surfaced_and_hle_handled_traps_clear_the_result_latch() {
+        struct AssertClearedHandler;
+
+        impl HleHandler for AssertClearedHandler {
+            fn handle_aline(
+                &mut self,
+                cpu: &mut CpuCore,
+                _bus: &mut dyn AddressBus,
+                _opcode: u16,
+            ) -> bool {
+                assert_eq!(cpu.result_latch_020, None);
+                true
+            }
+        }
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68EC020);
+        let mut bus = LinearMemoryBus::new(0x100);
+        bus.write_word_at(0, 0xA000);
+
+        prime_result_latch(&mut cpu);
+        assert!(matches!(
+            cpu.step(&mut bus),
+            StepResult::AlineTrap { opcode: 0xA000 }
+        ));
+        assert_result_latch_cleared(&mut cpu);
+
+        cpu.pc = 0;
+        prime_result_latch(&mut cpu);
+        assert!(matches!(
+            cpu.step_with_hle_handler(&mut bus, &mut AssertClearedHandler),
+            StepResult::Ok { .. }
+        ));
+        assert_result_latch_cleared(&mut cpu);
     }
 
     #[test]

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -772,25 +772,25 @@ impl CpuCore {
         };
         let mut cycles = cycles.unwrap_or_else(|| legacy_fallback(raw));
         if is_020 {
-            if let Some(dest) = reg_to_reg_move_dest(op) {
-                // The moved value is produced through the execution unit's
-                // result latch; leave its register for the next instruction.
-                self.result_latch_020 = Some(dest);
-                if fetch_cached && forwarded == Some((op & 7) as u8) {
-                    // Result forwarding: the source is still in the result
-                    // latch from the immediately preceding register-to-
-                    // register MOVE, so the operand's register-file read
-                    // micro-cycle is skipped. A real 68EC020 runs the RAW-
-                    // dependent pair `move.w d2,d0 + move.w d0,d1` one clock
-                    // per loop iteration faster than the independent pair
-                    // `move.w d2,d0 + move.w d3,d1` (Copperline timing-test
-                    // rows 29 and 28: 10 against 11 clocks including the
-                    // loop dbra), which only a forwarding path can produce.
-                    // Only the measured register-to-register MOVE case is
-                    // refunded; wider forwarding is deliberately not
-                    // modelled without hardware data.
-                    cycles = (cycles - 1).max(1);
-                }
+            // A register-to-register MOVE leaves its value in the execution
+            // unit's result latch for the next instruction; anything else
+            // leaves the latch cleared (it was taken above).
+            self.result_latch_020 = reg_to_reg_move_dest(op);
+            if self.result_latch_020.is_some() && fetch_cached && forwarded == Some((op & 7) as u8)
+            {
+                // Result forwarding: the source is still in the result
+                // latch from the immediately preceding register-to-register
+                // MOVE, so the operand's register-file read micro-cycle is
+                // skipped. A real 68EC020 runs the RAW-dependent pair
+                // `move.w d2,d0 + move.w d0,d1` one clock per loop
+                // iteration faster than the independent pair
+                // `move.w d2,d0 + move.w d3,d1` (Copperline timing-test
+                // rows 29 and 28: 10 against 11 clocks including the loop
+                // dbra), which only a forwarding path can produce. Only the
+                // measured register-to-register MOVE case is refunded;
+                // wider forwarding is deliberately not modelled without
+                // hardware data.
+                cycles = (cycles - 1).max(1);
             }
         }
         cycles

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -745,12 +745,18 @@ impl CpuCore {
     /// just retired. Instructions not covered by the integer tables (notably
     /// coprocessor operations and full-format indexed detail) retain the old
     /// conservative scale until a dedicated model exists.
-    pub(crate) fn cycles_020(&self, raw: i32, fetch_cached: bool) -> i32 {
+    pub(crate) fn cycles_020(&mut self, raw: i32, fetch_cached: bool) -> i32 {
+        let is_020 = matches!(
+            self.cpu_type,
+            super::types::CpuType::M68EC020 | super::types::CpuType::M68020
+        );
         if let Some(cycles) = exception_cycles(self, raw, fetch_cached) {
+            self.result_latch_020 = None;
             return cycles;
         }
 
         let op = self.ir as u16;
+        let forwarded = self.result_latch_020.take();
         let cycles = match op >> 12 {
             0x0 => group_0(self, op, fetch_cached),
             0x1 => Some(move_cycles(op, Size::Byte, fetch_cached)),
@@ -764,7 +770,41 @@ impl CpuCore {
             0xE => group_e(op, fetch_cached),
             _ => None,
         };
-        cycles.unwrap_or_else(|| legacy_fallback(raw))
+        let mut cycles = cycles.unwrap_or_else(|| legacy_fallback(raw));
+        if is_020 {
+            if let Some(dest) = reg_to_reg_move_dest(op) {
+                // The moved value is produced through the execution unit's
+                // result latch; leave its register for the next instruction.
+                self.result_latch_020 = Some(dest);
+                if fetch_cached && forwarded == Some((op & 7) as u8) {
+                    // Result forwarding: the source is still in the result
+                    // latch from the immediately preceding register-to-
+                    // register MOVE, so the operand's register-file read
+                    // micro-cycle is skipped. A real 68EC020 runs the RAW-
+                    // dependent pair `move.w d2,d0 + move.w d0,d1` one clock
+                    // per loop iteration faster than the independent pair
+                    // `move.w d2,d0 + move.w d3,d1` (Copperline timing-test
+                    // rows 29 and 28: 10 against 11 clocks including the
+                    // loop dbra), which only a forwarding path can produce.
+                    // Only the measured register-to-register MOVE case is
+                    // refunded; wider forwarding is deliberately not
+                    // modelled without hardware data.
+                    cycles = (cycles - 1).max(1);
+                }
+            }
+        }
+        cycles
+    }
+}
+
+/// Destination register of a register-to-register MOVE (`MOVE.B/W/L Dx,Dy`),
+/// the shape whose result-forwarding refund is measured on real hardware.
+const fn reg_to_reg_move_dest(op: u16) -> Option<u8> {
+    let group = op >> 12;
+    if (group == 1 || group == 2 || group == 3) && (op >> 3) & 7 == 0 && (op >> 6) & 7 == 0 {
+        Some(((op >> 9) & 7) as u8)
+    } else {
+        None
     }
 }
 
@@ -776,6 +816,33 @@ mod tests {
         let mut cpu = CpuCore::new();
         cpu.ir = u32::from(op);
         cpu.cycles_020(raw, cached)
+    }
+
+    #[test]
+    fn result_forwarding_refunds_one_clock_on_a_raw_reg_move_pair() {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(crate::core::types::CpuType::M68EC020);
+        cpu.ir = 0x3002; // MOVE.W D2,D0
+        assert_eq!(cpu.cycles_020(4, true), 2);
+        cpu.ir = 0x3200; // MOVE.W D0,D1: source still in the result latch
+        assert_eq!(cpu.cycles_020(4, true), 1);
+        cpu.ir = 0x3203; // MOVE.W D3,D1: independent, full register read
+        assert_eq!(cpu.cycles_020(4, true), 2);
+
+        // A non-MOVE between the pair clears the latch: no refund across it.
+        cpu.ir = 0x3002; // MOVE.W D2,D0
+        assert_eq!(cpu.cycles_020(4, true), 2);
+        cpu.ir = 0xD280; // ADD.L D0,D1
+        assert_eq!(cpu.cycles_020(4, true), 2);
+        cpu.ir = 0x3200; // MOVE.W D0,D1: D0 is stale in the latch
+        assert_eq!(cpu.cycles_020(4, true), 2);
+
+        // An uncached stream gets no refund (only the cached case is
+        // measured).
+        cpu.ir = 0x3002;
+        let _ = cpu.cycles_020(4, false);
+        cpu.ir = 0x3200;
+        assert_eq!(cpu.cycles_020(4, false), 3);
     }
 
     #[test]

--- a/src/core/timing_060.rs
+++ b/src/core/timing_060.rs
@@ -704,8 +704,8 @@ impl CpuCore {
         true
     }
 
-    /// Clear any open pairing window: called at every exception entry
-    /// (jump_vector), on HLE-handled traps, reset, and STOP.
+    /// Clear any open pairing window. Execution-boundary callers use
+    /// `clear_execution_pipeline_state` so every CPU model is reset together.
     #[inline]
     pub(crate) fn break_060_pipeline(&mut self) {
         self.oep060.pending_head = None;


### PR DESCRIPTION
## Summary

Two 020 timing calibrations against a real 68EC020 (stock Amiga 1200 at 14.19 MHz) running an E-clock-referenced timing test disk ([Copperline's `timing-test/`](https://github.com/CopperlineHQ/Copperline/tree/main/timing-test)), whose loop rows isolate individual instruction costs.

### 1. `TAKEN_BRANCH_REFILL` drops from 2 to 1

Three independent `dbra`-loop rows measure a cached taken `dbra` at 7 clocks per iteration (the MC68020UM section-8.2 cache-case 6 plus 1), and the `move`, shift, `mulu`, paired-op and DIV rows all agree with the same refill once the loop branch is accounted for:

| loop row | real A1200 | refill = 1 | refill = 2 |
|---|---|---|---|
| dbra only (x3 rows) | 7 clocks | 7 | 8 |
| move.w Dn,Dn + dbra | 9 | 9 | 10 |
| lsl.l #8,Dn + dbra | 11 | 11 | 12 |
| mulu.w #imm,Dn + dbra | 36 | 36 | 37 |
| beam advance across a 64x DIVU loop under 6-bitplane display DMA | 888 cck | 886 | 906 |

The previous value of 2 was calibrated against FS-UAE (it reproduced FS-UAE's columns exactly); the same disk on the real machine shows FS-UAE over-bills every taken branch by one clock.

### 2. Result forwarding on register-to-register MOVE pairs

The disk's two register-pair rows discriminate a forwarding path: the RAW-dependent pair `move.w d2,d0 + move.w d0,d1` runs at **10 clocks** per loop iteration on real silicon against **11** for the independent pair `move.w d2,d0 + move.w d3,d1` - the dependent pair is *faster*, which only result forwarding can produce (the source is still in the execution unit's result latch, skipping the register-file read micro-cycle). Modelled as a one-clock refund on a register-to-register MOVE whose source is the register the immediately preceding register-to-register MOVE wrote, cached case only; wider forwarding is deliberately not modelled without hardware data. The latch register is CpuCore state (`serde(default)`), cleared by any other instruction and by exceptions.

With both changes patched into Copperline, every one of the disk's 22 confidently-read real-hardware rows lands within 1%, most within 1-2 E-clock ticks.

## Testing

- Full suite passes (SST fixtures + Musashi submodules); new unit test covers the forwarding refund, its RAW discrimination, latch clearing, and the uncached case.
- `cargo fmt --check` clean.
- End-to-end regression: TRSI Cubic Dream on A1200 (the demo whose crash introduced the refill; needs >33 frames of loader margin) runs clean past 140 s with both changes.

## Note for consumers

`CpuCore` gains a serialized field, so bincode-style snapshots of the core change shape with this release.