### PR TITLE
fix: honor bus boundaries after interrupt entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,13 @@ match result.exit {
 ```
 
 An `AddressBus` can return `true` from `take_boundary_request()` when a bus
-access discovers host work that must run after the current instruction and
-before another one executes. The request is checked after the instruction's
-cycles and retirement have been counted, and it takes precedence over cycle
-budget exhaustion. Implementations should consume the request while retaining
-the associated work until the host handles the boundary exit.
+access discovers host work that must run after the current instruction or
+interrupt entry and before another instruction executes. The request is
+checked after a normally completed instruction and after an interrupt serviced
+on batch entry. Completed cycles are included; interrupt entry does not add to
+the retirement count. The request takes precedence over cycle budget
+exhaustion. Implementations should consume the request while retaining the
+associated work until the host handles the boundary exit.
 
 The 68000 and 68010 may already have instruction words in their hardware
 prefetch queue at this boundary. If the host work changes instruction-visible

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -198,9 +198,10 @@ impl CpuCore {
     /// - A non-positive budget returns immediately with
     ///   [`CycleBatchExit::BudgetExhausted`].
     /// - A bus boundary request is polled after each normally completed
-    ///   instruction. It includes that instruction in both totals and takes
-    ///   precedence over simultaneous budget exhaustion. STOP and surfaced
-    ///   traps retain their existing exit reasons.
+    ///   instruction and after interrupt entry on batch entry. Completed work
+    ///   is included in the totals, and the request takes precedence over
+    ///   simultaneous budget exhaustion. STOP and surfaced traps retain their
+    ///   existing exit reasons.
     pub fn run_for_cycles<B: AddressBus>(
         &mut self,
         bus: &mut B,
@@ -228,7 +229,14 @@ impl CpuCore {
 
         // Interrupts are instruction-boundary events. Service one before the
         // first fetch, including when it wakes a stopped CPU.
-        self.check_and_service_interrupts(bus);
+        let serviced_entry_interrupt = self.check_and_service_interrupts(bus);
+        if serviced_entry_interrupt && bus.take_boundary_request() {
+            return CycleBatchResult {
+                cycles: self.initial_cycles - self.cycles_remaining,
+                instructions: 0,
+                exit: CycleBatchExit::BoundaryRequested,
+            };
+        }
 
         let mut instructions = 0;
         loop {
@@ -834,8 +842,8 @@ impl CpuCore {
 
     // ========== Interrupt Handling ==========
 
-    /// Check and service pending interrupts.
-    fn check_and_service_interrupts<B: AddressBus>(&mut self, bus: &mut B) {
+    /// Check and service pending interrupts, returning whether one was taken.
+    fn check_and_service_interrupts<B: AddressBus>(&mut self, bus: &mut B) -> bool {
         // NMI (level 7) always triggers, others compare to mask
         let mask_level = (self.int_mask >> 8) & 7;
         let int_level = self.int_level & 7;
@@ -847,6 +855,9 @@ impl CpuCore {
             // We clear cpu.int_level here; the test harness will re-poll and set it
             // again in the next step if another interrupt is pending.
             self.int_level = 0;
+            true
+        } else {
+            false
         }
     }
 

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -178,15 +178,16 @@ pub trait AddressBus {
     }
 
     /// Take a pending request to return from cycle-scheduled execution at
-    /// the next retired-instruction boundary.
+    /// the next completed instruction or interrupt-entry boundary.
     ///
     /// [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) calls this
-    /// after an instruction completes normally and before it fetches or
-    /// executes another instruction. Returning `true` makes the runner exit
-    /// with
+    /// after an instruction completes normally or an entry interrupt is
+    /// serviced, and before it fetches or executes another instruction.
+    /// Returning `true` makes the runner exit with
     /// [`CycleBatchExit::BoundaryRequested`](crate::CycleBatchExit::BoundaryRequested).
-    /// The completed instruction's cycles and retirement count are included
-    /// in the result.
+    /// Completed work is included in the result: an instruction contributes
+    /// its cycles and retirement count, while interrupt entry contributes its
+    /// cycles without incrementing the retirement count.
     ///
     /// Implementations should consume the request when returning `true`, so
     /// execution can resume without a separate acknowledgement call. A bus

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -311,12 +311,12 @@ pub enum CycleBatchExit {
     /// The requested cycle budget was met or crossed at an instruction or
     /// interrupt boundary.
     BudgetExhausted,
-    /// The address bus requested a return after the most recently retired
-    /// instruction.
+    /// The address bus requested a return after a completed instruction or
+    /// entry interrupt.
     ///
-    /// The instruction's cycles and retirement count are included in the
-    /// result. This exit takes precedence when the instruction also meets or
-    /// crosses the cycle budget.
+    /// Completed work is included in the result. Interrupt entry contributes
+    /// cycles but no retired instruction. This exit takes precedence when the
+    /// completed work also meets or crosses the cycle budget.
     BoundaryRequested,
     /// The CPU executed STOP, or was already stopped with no serviceable
     /// interrupt on entry.

--- a/tests/run_for_cycles_tests.rs
+++ b/tests/run_for_cycles_tests.rs
@@ -180,6 +180,7 @@ struct EventBus {
     overlay_enabled: bool,
     resets: u32,
     boundary_write_address: Option<u32>,
+    boundary_on_interrupt_acknowledge: bool,
     boundary_requested: bool,
 }
 
@@ -191,6 +192,7 @@ impl EventBus {
             overlay_enabled: false,
             resets: 0,
             boundary_write_address: None,
+            boundary_on_interrupt_acknowledge: false,
             boundary_requested: false,
         }
     }
@@ -256,6 +258,9 @@ impl AddressBus for EventBus {
     }
 
     fn interrupt_acknowledge(&mut self, _level: u8) -> u32 {
+        if self.boundary_on_interrupt_acknowledge {
+            self.boundary_requested = true;
+        }
         u32::MAX
     }
 
@@ -357,6 +362,52 @@ fn entry_interrupt_is_charged_without_counting_an_instruction() {
     assert_eq!(result.cycles, 44);
     assert_eq!(result.instructions, 0);
     assert_eq!(result.exit, CycleBatchExit::BudgetExhausted);
+    assert_eq!(cpu.pc, 0x2000);
+}
+
+#[test]
+fn entry_interrupt_boundary_returns_before_the_handler_instruction() {
+    let mut bus = EventBus::new();
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x7001); // MOVEQ #1,D0
+    bus.boundary_on_interrupt_acknowledge = true;
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    cpu.set_irq(3);
+
+    let result = cpu.run_for_cycles(&mut bus, 100);
+
+    assert_eq!(result.cycles, 44);
+    assert_eq!(result.instructions, 0);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.pc, 0x2000);
+    assert_eq!(cpu.d(0), 0);
+
+    // The request was consumed, so resuming starts with the first handler
+    // instruction rather than returning the same boundary again.
+    let resumed = cpu.run_for_cycles(&mut bus, 1);
+    assert_eq!(resumed.cycles, 4);
+    assert_eq!(resumed.instructions, 1);
+    assert_eq!(resumed.exit, CycleBatchExit::BudgetExhausted);
+    assert_eq!(cpu.pc, 0x2002);
+    assert_eq!(cpu.d(0), 1);
+}
+
+#[test]
+fn entry_interrupt_boundary_precedes_budget_exhaustion() {
+    let mut bus = EventBus::new();
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x4E71);
+    bus.boundary_on_interrupt_acknowledge = true;
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    cpu.set_irq(3);
+
+    let result = cpu.run_for_cycles(&mut bus, 1);
+
+    assert_eq!(result.cycles, 44);
+    assert_eq!(result.instructions, 0);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
     assert_eq!(cpu.pc, 0x2000);
 }
 


### PR DESCRIPTION
## Summary

- poll `AddressBus::take_boundary_request()` immediately after an interrupt serviced on `run_for_cycles()` entry
- return `BoundaryRequested` before budget exhaustion or the first handler instruction
- document interrupt-entry boundary accounting in the public API and README
- add regressions for handler resumption and boundary precedence

## Root cause

`run_for_cycles()` serviced a pending entry interrupt before its loop, but the only boundary poll was inside the successful `step()` path. The loop therefore checked cycle-budget exhaustion first, or executed a handler instruction before reaching the existing poll.

Interrupt servicing now reports whether it took an interrupt. The cycle runner polls the bus only after a serviced entry interrupt, preserving the existing behavior when no interrupt was taken. Interrupt-entry cycles are included, the retired-instruction count remains zero, and the handler PC is left untouched for resumption.

## Validation

- reproduced both failures before the implementation change
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS='-D warnings -D rustdoc::private_intra_doc_links' cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo test --locked`
- `cargo test --all-features --locked`
- `cargo package --locked`

Closes #53