### PR TITLE
feat: add exact-width memory bit-field bus accesses

### DIFF
--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -1696,6 +1696,72 @@ impl CpuCore {
         }
     }
 
+    /// Read a three-byte operand from memory (data space), returned in the
+    /// low 24 bits.
+    ///
+    /// The 68020/68030 transfer an operand at the size it spans - byte, word,
+    /// three-byte or long (MC68020UM 5.3.1). Only the memory bit-field
+    /// instructions produce a three-byte operand, so only the 68020 and later
+    /// reach this path; the 68000/68010 have no three-byte transfer.
+    #[inline]
+    pub fn read_24<B: AddressBus>(&mut self, bus: &mut B, addr: u32) -> u32 {
+        if self.faulted() {
+            return 0;
+        }
+        // Part E.2: report internal clocks elapsed before this bus access.
+        self.flush_sync(bus);
+        let mut addr = self.address(addr);
+        if self.has_pmmu && self.pmmu_enabled {
+            let pm = self.mmu_page_mask();
+            if addr & pm > pm - 2 {
+                // Three-byte operand straddling an MMU page: a word cycle and
+                // a byte cycle, each translated on its own page (read_16
+                // sub-splits further if its half straddles the boundary).
+                let hi = self.read_16(bus, addr) as u32;
+                if self.faulted() {
+                    return 0;
+                }
+                let lo = self.read_8(bus, addr.wrapping_add(2)) as u32;
+                return (hi << 8) | lo;
+            }
+        }
+        if let Some((a, v)) = self.mmu_read_override
+            && a == addr
+        {
+            // RTE'd 030 bus-fault frame with DF cleared: the handler
+            // supplied this read's result in the data input buffer.
+            self.mmu_read_override = None;
+            return v & 0x00FF_FFFF;
+        }
+        {
+            if self.has_pmmu && self.pmmu_enabled {
+                match crate::mmu::translate_address(
+                    self,
+                    bus,
+                    addr,
+                    /*write=*/ false,
+                    self.is_supervisor(),
+                    /*instruction=*/ false,
+                ) {
+                    Ok(p) => addr = self.address(p),
+                    Err(f) => {
+                        self.handle_mmu_fault(bus, f, false, false, 3);
+                        return 0;
+                    }
+                }
+            }
+        }
+        match bus.try_read_three_bytes(addr) {
+            Ok(v) => v & 0x00FF_FFFF,
+            Err(f) => {
+                if matches!(f.kind, BusFaultKind::BusError) {
+                    self.trigger_bus_error(bus, addr, false, false, 3);
+                }
+                0
+            }
+        }
+    }
+
     /// Write byte to memory (data space).
     #[inline]
     pub fn write_8<B: AddressBus>(&mut self, bus: &mut B, addr: u32, value: u8) {
@@ -1795,6 +1861,64 @@ impl CpuCore {
             && matches!(f.kind, BusFaultKind::BusError)
         {
             self.trigger_bus_error(bus, addr, true, false, 2);
+        }
+    }
+
+    /// Write the low 24 bits of `value` to memory (data space) as a
+    /// three-byte operand.
+    ///
+    /// See [`CpuCore::read_24`]: the memory bit-field instructions are the
+    /// only producers of a three-byte operand.
+    #[inline]
+    pub fn write_24<B: AddressBus>(&mut self, bus: &mut B, addr: u32, value: u32) {
+        if self.faulted() {
+            return;
+        }
+        // Part E.2: report internal clocks elapsed before this bus access.
+        self.flush_sync(bus);
+        let mut addr = self.address(addr);
+        if self.has_pmmu && self.pmmu_enabled {
+            let pm = self.mmu_page_mask();
+            if addr & pm > pm - 2 {
+                // Three-byte operand straddling an MMU page: a word cycle and
+                // a byte cycle, each translated (and fault-suppressed) on its
+                // own page.
+                self.write_16(bus, addr, (value >> 8) as u16);
+                if self.faulted() {
+                    return;
+                }
+                self.write_8(bus, addr.wrapping_add(2), value as u8);
+                return;
+            }
+        }
+        if self.mmu_write_suppress == Some(addr) {
+            // See write_8: DF-cleared write fault, already completed.
+            self.mmu_write_suppress = None;
+            return;
+        }
+        self.pending_fault_wdata = value & 0x00FF_FFFF;
+        {
+            if self.has_pmmu && self.pmmu_enabled {
+                match crate::mmu::translate_address(
+                    self,
+                    bus,
+                    addr,
+                    /*write=*/ true,
+                    self.is_supervisor(),
+                    /*instruction=*/ false,
+                ) {
+                    Ok(p) => addr = self.address(p),
+                    Err(f) => {
+                        self.handle_mmu_fault(bus, f, true, false, 3);
+                        return;
+                    }
+                }
+            }
+        }
+        if let Err(f) = bus.try_write_three_bytes(addr, value & 0x00FF_FFFF)
+            && matches!(f.kind, BusFaultKind::BusError)
+        {
+            self.trigger_bus_error(bus, addr, true, false, 3);
         }
     }
 

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -188,6 +188,12 @@ pub struct CpuCore {
     /// debugger field below, this is cleared before every opcode fetch.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) instruction_exception_vector: Option<u32>,
+    /// True when the bit-field instruction currently being timed spanned a
+    /// five-byte memory window (MC68020UM 8.2.14 bills those one operand
+    /// cycle higher than fields within four bytes). Set by the memory-form
+    /// bit-field executor, consumed by the 020 timing model on retirement.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) bitfield_mem_wide_span: bool,
     /// Vector number of the most recent exception entry (trap, fault, or
     /// interrupt -- everything routed through `jump_vector`), for the
     /// host debugger's exception catchpoints. Polled and cleared by the
@@ -540,6 +546,7 @@ impl CpuCore {
             run_mode: 0,
             exception_processing: false,
             instruction_exception_vector: None,
+            bitfield_mem_wide_span: false,
             last_exception_vector: None,
             has_pmmu: false,
             pmmu_enabled: false,

--- a/src/core/exceptions.rs
+++ b/src/core/exceptions.rs
@@ -105,6 +105,8 @@ fn fslw_060(
 ) -> u32 {
     use crate::mmu::MmuFaultCause;
     let mut w = if write { fslw::RW_W } else { fslw::RW_R };
+    // As on the 68040, there is no three-byte size encoding (0b11 is a line
+    // transfer), so a three-byte operand reports as a long.
     w |= match size {
         1 => 0b01 << fslw::SIZE_SHIFT,
         2 => 0b10 << fslw::SIZE_SHIFT,
@@ -462,6 +464,8 @@ impl CpuCore {
                 // gurus instead of demand-faulting.
                 let rw = if write { 0 } else { 0x0100 }; // SSW bit 8: 1 = read
                 let atc = if cause.is_some() { 0x0400u16 } else { 0 }; // SSW bit 10
+                // The 68040 bus has no three-byte encoding (SZ 11 is a line
+                // transfer), so a three-byte operand reports as a long here.
                 let sz = match size {
                     1 => 0x0020, // byte
                     2 => 0x0040, // word
@@ -532,9 +536,13 @@ impl CpuCore {
                     if !write {
                         ssw |= 0x0040; // RW: read
                     }
+                    // SIZ 11 is the three-byte transfer the 68020/68030 bus
+                    // performs for a dynamically sized access or a bit-field
+                    // operand spanning three bytes.
                     ssw |= match size {
                         1 => 0x0010, // SIZ 01: byte
                         2 => 0x0020, // SIZ 10: word
+                        3 => 0x0030, // SIZ 11: three byte
                         _ => 0x0000, // SIZ 00: long
                     };
                 } else {

--- a/src/core/instructions/bitfield.rs
+++ b/src/core/instructions/bitfield.rs
@@ -332,10 +332,10 @@ fn bf_extract_mem_window_msb0<B: AddressBus>(
     // width is therefore the model to hold, being the one that touches
     // only what the instruction selects.
     //
-    // AddressBus has no three-byte transfer, so a three-byte span composes
-    // a word and a byte. It reads the right bytes and only those, at the
-    // cost of one extra access on hosts that bill per access - the one
-    // place this shape departs from the measured single operand cycle.
+    // Each span is one access, three bytes included: read_24 goes through
+    // the AddressBus three-byte hook, so a host that bills bus cycles
+    // charges the single operand cycle the hardware measures rather than a
+    // word plus a byte.
     //
     // The window is 40-bit big-endian aligned (byte 0 of the span in bits
     // 39..32) so the callers' fixed shift arithmetic holds for every span,
@@ -343,10 +343,7 @@ fn bf_extract_mem_window_msb0<B: AddressBus>(
     let mut window = match bytes_len {
         1 => (cpu.read_8(bus, start_addr) as u64) << 32,
         2 => (cpu.read_16(bus, start_addr) as u64) << 24,
-        3 => {
-            ((cpu.read_16(bus, start_addr) as u64) << 24)
-                | ((cpu.read_8(bus, start_addr.wrapping_add(2)) as u64) << 16)
-        }
+        3 => (cpu.read_24(bus, start_addr) as u64) << 16,
         _ => (cpu.read_32(bus, start_addr) as u64) << 8,
     };
     if bytes_len == 5 {
@@ -369,10 +366,7 @@ fn bf_store_mem_window<B: AddressBus>(
     match bytes_len {
         1 => cpu.write_8(bus, start_addr, (window >> 32) as u8),
         2 => cpu.write_16(bus, start_addr, (window >> 24) as u16),
-        3 => {
-            cpu.write_16(bus, start_addr, (window >> 24) as u16);
-            cpu.write_8(bus, start_addr.wrapping_add(2), (window >> 16) as u8);
-        }
+        3 => cpu.write_24(bus, start_addr, (window >> 16) as u32),
         _ => cpu.write_32(bus, start_addr, (window >> 8) as u32),
     }
     if bytes_len == 5 {

--- a/src/core/instructions/bitfield.rs
+++ b/src/core/instructions/bitfield.rs
@@ -134,6 +134,10 @@ impl CpuCore {
 
                 let (field, mut window, bytes_len) =
                     bf_extract_mem_window_msb0(self, bus, start_addr, bit_in_byte, spec.width);
+                // Retain the span for the 020 timing model: the MC68020UM
+                // bills a five-byte field one operand cycle above a field
+                // within four bytes.
+                self.bitfield_mem_wide_span = bytes_len == 5;
 
                 match op {
                     0x8 => {
@@ -310,10 +314,43 @@ fn bf_extract_mem_window_msb0<B: AddressBus>(
     width: u32,
 ) -> (u32, u64, usize) {
     let bytes_len = (bit_in_byte + width).div_ceil(8) as usize;
-    // Always read 5 bytes (40 bits) for simplicity; only write back bytes_len.
-    let mut window = 0u64;
-    for i in 0..5u32 {
-        window = (window << 8) | cpu.read_8(bus, start_addr.wrapping_add(i)) as u64;
+    // The operand access covers exactly the bytes the field spans and no
+    // others. A 68020 transfers an operand at the size it needs - byte,
+    // word, three-byte or long (MC68020UM 5.3.1) - so a field within four
+    // bytes is one operand cycle (8.2.14) without the processor ever
+    // driving a byte outside the field. Widening the transfer to a long
+    // would read and write up to three neighbouring bytes, which is
+    // observable on memory-mapped registers and moves the fault boundary
+    // past the end of a mapped region.
+    //
+    // The real-A1200 bfprobe column (Copperline timing-test/bfprobe.asm)
+    // measures spans of one, two, three and four bytes at exactly the same
+    // cost, with only a five-byte span adding an access. That confirms the
+    // single operand cycle, but it cannot pin the transfer width: the
+    // A1200's chip RAM is 32 bits wide, so every span up to four bytes is
+    // one bus cycle whatever size the processor asks for. The spanned
+    // width is therefore the model to hold, being the one that touches
+    // only what the instruction selects.
+    //
+    // AddressBus has no three-byte transfer, so a three-byte span composes
+    // a word and a byte. It reads the right bytes and only those, at the
+    // cost of one extra access on hosts that bill per access - the one
+    // place this shape departs from the measured single operand cycle.
+    //
+    // The window is 40-bit big-endian aligned (byte 0 of the span in bits
+    // 39..32) so the callers' fixed shift arithmetic holds for every span,
+    // and bf_store_mem_window writes back exactly the same bytes.
+    let mut window = match bytes_len {
+        1 => (cpu.read_8(bus, start_addr) as u64) << 32,
+        2 => (cpu.read_16(bus, start_addr) as u64) << 24,
+        3 => {
+            ((cpu.read_16(bus, start_addr) as u64) << 24)
+                | ((cpu.read_8(bus, start_addr.wrapping_add(2)) as u64) << 16)
+        }
+        _ => (cpu.read_32(bus, start_addr) as u64) << 8,
+    };
+    if bytes_len == 5 {
+        window |= cpu.read_8(bus, start_addr.wrapping_add(4)) as u64;
     }
     let shift = 40 - (bit_in_byte + width);
     let field = ((window >> shift) as u32) & bf_mask(width);
@@ -327,9 +364,18 @@ fn bf_store_mem_window<B: AddressBus>(
     window: u64,
     bytes_len: usize,
 ) {
-    for i in 0..bytes_len {
-        let shift = (4 - i) * 8;
-        let b = ((window >> shift) & 0xFF) as u8;
-        cpu.write_8(bus, start_addr.wrapping_add(i as u32), b);
+    // Mirror the extract exactly, so the read-modify-write drives back
+    // only the bytes the field spans and never a neighbour.
+    match bytes_len {
+        1 => cpu.write_8(bus, start_addr, (window >> 32) as u8),
+        2 => cpu.write_16(bus, start_addr, (window >> 24) as u16),
+        3 => {
+            cpu.write_16(bus, start_addr, (window >> 24) as u16);
+            cpu.write_8(bus, start_addr.wrapping_add(2), (window >> 16) as u8);
+        }
+        _ => cpu.write_32(bus, start_addr, (window >> 8) as u32),
+    }
+    if bytes_len == 5 {
+        cpu.write_8(bus, start_addr.wrapping_add(4), (window & 0xFF) as u8);
     }
 }

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -128,6 +128,64 @@ pub trait AddressBus {
         Ok(())
     }
 
+    /// Read a big-endian three-byte operand from `address`, returned in the
+    /// low 24 bits.
+    ///
+    /// The 68020/68030 transfer an operand at the size it spans - byte, word,
+    /// three-byte or long (MC68020UM 5.3.1) - so a bit field covering three
+    /// bytes is a single operand transfer, not a word plus a byte. The
+    /// default composes one anyway, which is correct for every bus that only
+    /// moves data; hosts that bill bus cycles or count transactions should
+    /// override it so the access costs what the hardware charges.
+    ///
+    /// The 68040/68060 bus has no three-byte encoding. A host modelling one
+    /// may split the access however that processor does, provided it still
+    /// touches only these three bytes.
+    ///
+    /// The core reaches this through [`AddressBus::try_read_three_bytes`];
+    /// override that variant as well on a bus that reports faults.
+    #[inline]
+    fn read_three_bytes(&mut self, address: u32) -> u32 {
+        let hi = self.read_word(address) as u32;
+        let lo = self.read_byte(address.wrapping_add(2)) as u32;
+        (hi << 8) | lo
+    }
+
+    /// Write the low 24 bits of `value` as a big-endian three-byte operand.
+    ///
+    /// See [`AddressBus::read_three_bytes`] for when the core uses this and
+    /// why a host may want to override it.
+    #[inline]
+    fn write_three_bytes(&mut self, address: u32, value: u32) {
+        self.write_word(address, (value >> 8) as u16);
+        self.write_byte(address.wrapping_add(2), value as u8);
+    }
+
+    /// Fallible three-byte read used for bus/MMU fault delivery. **This is
+    /// the variant the core calls**, so a host that bills bus cycles must
+    /// override it (as well as [`AddressBus::read_three_bytes`]) for the
+    /// billing to take effect.
+    ///
+    /// The default composes the fallible word and byte reads rather than
+    /// delegating to the infallible variant, so an existing bus keeps
+    /// reporting a fault on whichever half of the operand fails.
+    #[inline]
+    fn try_read_three_bytes(&mut self, address: u32) -> Result<u32, BusFault> {
+        let hi = self.try_read_word(address)? as u32;
+        let lo = self.try_read_byte(address.wrapping_add(2))? as u32;
+        Ok((hi << 8) | lo)
+    }
+
+    /// Fallible three-byte write used for bus/MMU fault delivery.
+    ///
+    /// See [`AddressBus::try_read_three_bytes`]: this is the variant the core
+    /// calls, and the default composes the fallible word and byte writes.
+    #[inline]
+    fn try_write_three_bytes(&mut self, address: u32, value: u32) -> Result<(), BusFault> {
+        self.try_write_word(address, (value >> 8) as u16)?;
+        self.try_write_byte(address.wrapping_add(2), value as u8)
+    }
+
     /// Read an instruction-stream word.
     ///
     /// Override this when opcode/immediate fetches use a distinct bus path.

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -689,30 +689,59 @@ fn group_6(cpu: &CpuCore, op: u16, cached: bool) -> i32 {
     }
 }
 
-fn group_e(op: u16, cached: bool) -> Option<i32> {
+fn group_e(cpu: &CpuCore, op: u16, cached: bool) -> Option<i32> {
     let mode = (op >> 3) & 7;
     let reg = op & 7;
 
     if op & 0x00C0 == 0x00C0 && (op >> 8) & 0xF >= 8 {
         let selector = (op >> 8) & 0xF;
+        // Internal (non-bus) costs calibrated against the real-A1200
+        // bfprobe column (Copperline timing-test/bfprobe.asm, 2026-08-03).
+        // A memory form whose field lies within four bytes performs one
+        // operand cycle - a read, plus a write for the modify forms - and
+        // a five-byte span adds a second one; the host bills those
+        // accesses, so these rows carry only the remainder. On the
+        // reference A1200 an 8192-iteration BFSET (An){0:1} + DBcc loop
+        // measures 28.10 clocks (BFTST 24.12, BFEXTU and BFINS 28.10, the
+        // five-byte BFSET 44.32, register-form BFSET 20.02), with the
+        // dynamic offset free and the DBcc alignment clock absorbed by
+        // the operand access.
+        //
+        // The rows are independent of the operand's transfer width: the
+        // A1200 moves any span up to four bytes across its 32-bit chip
+        // bus in one cycle, so they hold whether the executor asks for a
+        // byte, a word or a long. The one exception is a three-byte span,
+        // which the executor composes from a word and a byte for want of
+        // a three-byte AddressBus transfer; a cycle-billing host charges
+        // that span one access more than the silicon does.
+        //
+        // BFFFO and the five-byte rows of the non-BFSET forms keep the
+        // MC68020UM relative deltas and are not yet hardware-measured.
         let base = if mode == 0 {
             match selector {
                 0x8 => Case::new(6, 7),
                 0x9 | 0xB => Case::new(8, 8),
-                0xA | 0xC | 0xE => Case::new(12, 12),
+                0xA | 0xC | 0xE => Case::new(14, 14), // real: BFSET Dn loop 20.02
                 0xD => Case::new(18, 18),
                 0xF => Case::new(10, 10),
                 _ => return None,
             }
-        } else {
-            // Use the five-byte row: the executor can span five bytes and
-            // does not retain the extension-derived span after retirement.
+        } else if cpu.bitfield_mem_wide_span {
             match selector {
-                0x8 => Case::new(15, 16),
-                0x9 | 0xB => Case::new(18, 18),
-                0xA | 0xC | 0xE => Case::new(24, 24),
-                0xD => Case::new(32, 32),
-                0xF => Case::new(20, 21),
+                0x8 => Case::new(26, 27),             // BFTST: <5B + 12
+                0x9 | 0xB => Case::new(30, 30),       // BFEXT: <5B + 12
+                0xA | 0xC | 0xE => Case::new(34, 34), // real: 44.32 clk loop
+                0xD => Case::new(42, 42),             // BFFFO: <5B + 12
+                0xF => Case::new(34, 34),             // BFINS: <5B + 12
+                _ => return None,
+            }
+        } else {
+            match selector {
+                0x8 => Case::new(14, 15),             // real: 24.12 clk loop
+                0x9 | 0xB => Case::new(18, 18),       // real: 28.10 clk loop
+                0xA | 0xC | 0xE => Case::new(22, 22), // real: 28.10 clk loop
+                0xD => Case::new(30, 30),             // BFFFO: UM +8 over SET
+                0xF => Case::new(22, 22),             // real: 28.10 clk loop
                 _ => return None,
             }
         };
@@ -771,7 +800,7 @@ impl CpuCore {
             0x6 => Some(group_6(self, op, fetch_cached)),
             0x7 => Some(Case::new(2, 3).pick(fetch_cached)),
             0x8 | 0x9 | 0xB | 0xC | 0xD => dyadic(op, fetch_cached),
-            0xE => group_e(op, fetch_cached),
+            0xE => group_e(self, op, fetch_cached),
             _ => None,
         };
         cycles.unwrap_or_else(|| legacy_fallback(raw))
@@ -893,6 +922,86 @@ mod tests {
         assert_eq!(cpu.cycles_020(10, true), 6 + TAKEN_BRANCH_REFILL);
         cpu.change_of_flow = false;
         assert_eq!(cpu.cycles_020(10, true), 4);
+    }
+
+    fn bitfield_timed(op: u16, cached: bool, wide_span: bool) -> i32 {
+        let mut cpu = CpuCore::new();
+        cpu.ir = u32::from(op);
+        cpu.bitfield_mem_wide_span = wide_span;
+        cpu.cycles_020(12, cached)
+    }
+
+    #[test]
+    fn bitfield_register_rows_hold_the_measured_internal_cost() {
+        // Register forms perform no operand access, so the row is the whole
+        // instruction. Real A1200: a BFSET Dn{0:1} + DBcc loop is 20.02
+        // clocks (bfprobe row 4), against 14 here plus the taken DBcc.
+        for cached in [true, false] {
+            assert_eq!(bitfield_timed(0xEEC0, cached, false), 14); // BFSET Dn
+            assert_eq!(bitfield_timed(0xEAC0, cached, false), 14); // BFCHG Dn
+            assert_eq!(bitfield_timed(0xECC0, cached, false), 14); // BFCLR Dn
+        }
+        assert_eq!(bitfield_timed(0xE8C0, true, false), 6); // BFTST Dn
+        assert_eq!(bitfield_timed(0xE8C0, false, false), 7);
+        assert_eq!(bitfield_timed(0xE9C0, true, false), 8); // BFEXTU Dn
+        assert_eq!(bitfield_timed(0xEBC0, true, false), 8); // BFEXTS Dn
+        assert_eq!(bitfield_timed(0xEDC0, true, false), 18); // BFFFO Dn
+        assert_eq!(bitfield_timed(0xEFC0, true, false), 10); // BFINS Dn
+
+        // The span flag is a memory-operand property and must not reach the
+        // register rows, whatever the previous memory bit-field left behind.
+        assert_eq!(bitfield_timed(0xEEC0, true, true), 14);
+    }
+
+    #[test]
+    fn bitfield_memory_rows_within_four_bytes_hold_the_measured_cost() {
+        // (A0) adds the mode-2 word EA, Case(2, 3). Real A1200 loops:
+        // BFSET/BFINS/BFEXTU 28.10 clocks, BFTST 24.12 (bfprobe rows 2, 11,
+        // 10, 9). The remainder below is what the core charges on top of the
+        // one operand cycle the host bills.
+        assert_eq!(bitfield_timed(0xEED0, true, false), 24); // BFSET (A0)
+        assert_eq!(bitfield_timed(0xEED0, false, false), 25);
+        assert_eq!(bitfield_timed(0xEAD0, true, false), 24); // BFCHG (A0)
+        assert_eq!(bitfield_timed(0xECD0, true, false), 24); // BFCLR (A0)
+        assert_eq!(bitfield_timed(0xEFD0, true, false), 24); // BFINS (A0)
+        assert_eq!(bitfield_timed(0xEFD0, false, false), 25);
+        assert_eq!(bitfield_timed(0xE8D0, true, false), 16); // BFTST (A0)
+        assert_eq!(bitfield_timed(0xE8D0, false, false), 18);
+        assert_eq!(bitfield_timed(0xE9D0, true, false), 20); // BFEXTU (A0)
+        assert_eq!(bitfield_timed(0xE9D0, false, false), 21);
+        assert_eq!(bitfield_timed(0xEBD0, true, false), 20); // BFEXTS (A0)
+        assert_eq!(bitfield_timed(0xEDD0, true, false), 32); // BFFFO (A0)
+        assert_eq!(bitfield_timed(0xEDD0, false, false), 33);
+    }
+
+    #[test]
+    fn bitfield_five_byte_span_costs_one_operand_cycle_more() {
+        // Real A1200: the five-byte BFSET loop is 44.32 clocks against 28.10
+        // for a span within four bytes (bfprobe rows 7 and 2). The extra
+        // operand cycle the span needs is billed by the host; the internal
+        // remainder rises by 12 across every form.
+        assert_eq!(bitfield_timed(0xEED0, true, true), 36); // BFSET (A0)
+        assert_eq!(bitfield_timed(0xEED0, false, true), 37);
+        assert_eq!(bitfield_timed(0xEAD0, true, true), 36); // BFCHG (A0)
+        assert_eq!(bitfield_timed(0xECD0, true, true), 36); // BFCLR (A0)
+        assert_eq!(bitfield_timed(0xEFD0, true, true), 36); // BFINS (A0)
+        assert_eq!(bitfield_timed(0xE8D0, true, true), 28); // BFTST (A0)
+        assert_eq!(bitfield_timed(0xE8D0, false, true), 30);
+        assert_eq!(bitfield_timed(0xE9D0, true, true), 32); // BFEXTU (A0)
+        assert_eq!(bitfield_timed(0xEBD0, true, true), 32); // BFEXTS (A0)
+        assert_eq!(bitfield_timed(0xEDD0, true, true), 44); // BFFFO (A0)
+
+        // Every form pays exactly one operand cycle's worth more than its
+        // within-four-bytes row, which is the shape the UM publishes.
+        for op in [
+            0xEED0u16, 0xEAD0, 0xECD0, 0xEFD0, 0xE8D0, 0xE9D0, 0xEBD0, 0xEDD0,
+        ] {
+            assert_eq!(
+                bitfield_timed(op, true, true) - bitfield_timed(op, true, false),
+                12,
+                "opcode {op:04X} five-byte delta"
+            );
+        }
     }
 
     #[test]

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -710,10 +710,9 @@ fn group_e(cpu: &CpuCore, op: u16, cached: bool) -> Option<i32> {
         // The rows are independent of the operand's transfer width: the
         // A1200 moves any span up to four bytes across its 32-bit chip
         // bus in one cycle, so they hold whether the executor asks for a
-        // byte, a word or a long. The one exception is a three-byte span,
-        // which the executor composes from a word and a byte for want of
-        // a three-byte AddressBus transfer; a cycle-billing host charges
-        // that span one access more than the silicon does.
+        // byte, a word, three bytes or a long. Every span is one access,
+        // three bytes included (AddressBus::try_read_three_bytes), so a
+        // host that bills per access bills one operand cycle for all four.
         //
         // BFFFO and the five-byte rows of the non-BFSET forms keep the
         // MC68020UM relative deltas and are not yet hardware-measured.

--- a/tests/bitfield_memory_access_tests.rs
+++ b/tests/bitfield_memory_access_tests.rs
@@ -1,0 +1,247 @@
+//! Memory-form bit-field instructions access exactly the bytes their field
+//! spans, at the transfer size that span needs (MC68020UM 5.3.1), and never
+//! touch a neighbouring byte. A field within four bytes is one operand cycle
+//! and a five-byte span two (8.2.14); a real A1200 measures spans of one,
+//! two, three and four bytes at identical cost with only the five-byte span
+//! adding an access (Copperline timing-test/bfprobe.asm).
+//!
+//! Widening the operand to a long would read and write up to three bytes
+//! outside the field, which is observable on memory-mapped registers and
+//! moves the fault boundary past the end of a mapped region. These tests pin
+//! the touched byte set, not just the access count, so that cannot come back.
+
+use m68k::{AddressBus, CpuCore, CpuType, LinearMemoryBus};
+
+/// Wraps LinearMemoryBus and records every data access as (address, size).
+/// Instruction fetches bypass the log so only operand traffic is recorded.
+struct CountingBus {
+    inner: LinearMemoryBus,
+    reads: Vec<(u32, u32)>,
+    writes: Vec<(u32, u32)>,
+}
+
+impl CountingBus {
+    fn new() -> Self {
+        Self {
+            inner: LinearMemoryBus::new(0x10000),
+            reads: Vec::new(),
+            writes: Vec::new(),
+        }
+    }
+
+    /// Every byte address the log says was read or written, in order and
+    /// without duplicates.
+    fn bytes_touched(&self) -> Vec<u32> {
+        let mut out: Vec<u32> = self
+            .reads
+            .iter()
+            .chain(self.writes.iter())
+            .flat_map(|&(addr, size)| (0..size).map(move |i| addr + i))
+            .collect();
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+}
+
+impl AddressBus for CountingBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.reads.push((address, 1));
+        self.inner.read_byte(address)
+    }
+    fn read_word(&mut self, address: u32) -> u16 {
+        self.reads.push((address, 2));
+        self.inner.read_word(address)
+    }
+    fn read_long(&mut self, address: u32) -> u32 {
+        self.reads.push((address, 4));
+        self.inner.read_long(address)
+    }
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.writes.push((address, 1));
+        self.inner.write_byte(address, value)
+    }
+    fn write_word(&mut self, address: u32, value: u16) {
+        self.writes.push((address, 2));
+        self.inner.write_word(address, value)
+    }
+    fn write_long(&mut self, address: u32, value: u32) {
+        self.writes.push((address, 4));
+        self.inner.write_long(address, value)
+    }
+    // Opcode and extension words are not operand traffic.
+    fn read_immediate_word(&mut self, address: u32) -> u16 {
+        self.inner.read_word(address)
+    }
+    fn read_immediate_long(&mut self, address: u32) -> u32 {
+        self.inner.read_long(address)
+    }
+}
+
+const CODE: u32 = 0x1000;
+const DATA: u32 = 0x4000;
+/// Written either side of every field so a stray access shows up as a value
+/// change as well as a log entry.
+const SENTINEL: u8 = 0xA5;
+
+/// Assemble one bit-field opcode + extension at CODE and run it on a 68020
+/// with A0 = DATA, D1 = the dynamic offset, and the data bytes preloaded.
+/// DATA-8 .. DATA+16 is filled with sentinels first.
+fn run_bitfield(opcode: u16, ext: u16, d1: u32, data: &[(u32, u8)]) -> (CpuCore, CountingBus) {
+    let mut bus = CountingBus::new();
+    for addr in (DATA - 8)..(DATA + 16) {
+        bus.inner.load(addr, &[SENTINEL]);
+    }
+    bus.inner.load(CODE, &opcode.to_be_bytes());
+    bus.inner.load(CODE + 2, &ext.to_be_bytes());
+    bus.inner.load(CODE + 4, &0x4E71u16.to_be_bytes()); // NOP
+    for &(addr, value) in data {
+        bus.inner.load(addr, &[value]);
+    }
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68020);
+    cpu.pc = CODE;
+    cpu.set_sr(0x2700);
+    cpu.set_a(7, 0x8000);
+    cpu.set_a(0, DATA);
+    cpu.set_d(1, d1);
+    bus.reads.clear();
+    bus.writes.clear();
+    cpu.step(&mut bus);
+    (cpu, bus)
+}
+
+/// The byte addresses a field starting at `start` and spanning `len` bytes
+/// may legitimately touch, and nothing else.
+fn span(start: u32, len: u32) -> Vec<u32> {
+    (start..start + len).collect()
+}
+
+#[test]
+fn one_byte_span_is_a_single_byte_transfer() {
+    // BFSET (A0){D1:1} with D1 = 3: bit 3 (msb-first) of DATA.
+    let (_, mut bus) = run_bitfield(0xEED0, 0x0841, 3, &[(DATA, 0x00)]);
+    assert_eq!(bus.reads, vec![(DATA, 1)]);
+    assert_eq!(bus.writes, vec![(DATA, 1)]);
+    assert_eq!(bus.bytes_touched(), span(DATA, 1));
+    assert_eq!(bus.inner.read_byte(DATA), 0x10);
+    // A long operand would have read and rewritten these three.
+    for i in 1..4 {
+        assert_eq!(bus.inner.read_byte(DATA + i), SENTINEL, "byte +{i}");
+    }
+}
+
+#[test]
+fn two_byte_span_is_a_single_word_transfer() {
+    // BFSET (A0){4:8}: bits 4..11 span DATA and DATA+1.
+    let (_, mut bus) = run_bitfield(0xEED0, 0x0108, 0, &[(DATA, 0x00), (DATA + 1, 0x00)]);
+    assert_eq!(bus.reads, vec![(DATA, 2)]);
+    assert_eq!(bus.writes, vec![(DATA, 2)]);
+    assert_eq!(bus.bytes_touched(), span(DATA, 2));
+    assert_eq!(bus.inner.read_byte(DATA), 0x0F);
+    assert_eq!(bus.inner.read_byte(DATA + 1), 0xF0);
+    assert_eq!(bus.inner.read_byte(DATA + 2), SENTINEL);
+    assert_eq!(bus.inner.read_byte(DATA + 3), SENTINEL);
+}
+
+#[test]
+fn three_byte_span_never_reaches_the_fourth_byte() {
+    // BFEXTU (A0){4:16},D3: bits 4..19 span DATA..DATA+2. AddressBus has no
+    // three-byte transfer, so this composes a word and a byte - the right
+    // bytes and only those. Rounding up to a long would touch DATA+3.
+    let (cpu, mut bus) = run_bitfield(
+        0xE9D0,
+        0x3110,
+        0,
+        &[(DATA, 0x0A), (DATA + 1, 0xBC), (DATA + 2, 0xD0)],
+    );
+    assert_eq!(bus.reads, vec![(DATA, 2), (DATA + 2, 1)]);
+    assert!(bus.writes.is_empty());
+    assert_eq!(bus.bytes_touched(), span(DATA, 3));
+    assert_eq!(cpu.d(3), 0xABCD);
+    assert_eq!(bus.inner.read_byte(DATA + 3), SENTINEL);
+}
+
+#[test]
+fn three_byte_modify_span_writes_back_only_its_three_bytes() {
+    // BFSET (A0){4:16}: the modify form of the same span.
+    let (_, mut bus) = run_bitfield(0xEED0, 0x0110, 0, &[]);
+    assert_eq!(bus.reads, vec![(DATA, 2), (DATA + 2, 1)]);
+    assert_eq!(bus.writes, vec![(DATA, 2), (DATA + 2, 1)]);
+    assert_eq!(bus.bytes_touched(), span(DATA, 3));
+    assert_eq!(bus.inner.read_byte(DATA + 3), SENTINEL);
+}
+
+#[test]
+fn four_byte_span_is_a_single_long_transfer() {
+    // BFSET (A0){0:32}: the field is exactly the four bytes.
+    let (_, mut bus) = run_bitfield(0xEED0, 0x0000, 0, &[]);
+    assert_eq!(bus.reads, vec![(DATA, 4)]);
+    assert_eq!(bus.writes, vec![(DATA, 4)]);
+    assert_eq!(bus.bytes_touched(), span(DATA, 4));
+    assert_eq!(bus.inner.read_byte(DATA + 4), SENTINEL);
+}
+
+#[test]
+fn five_byte_span_adds_one_byte_access_and_no_more() {
+    // BFSET (A0){7:32}: bits 7..38 need the long plus the fifth byte, which
+    // is the second operand cycle the MC68020UM bills the wide span.
+    let (_, mut bus) = run_bitfield(0xEED0, 0x01C0, 0, &[]);
+    assert_eq!(bus.reads, vec![(DATA, 4), (DATA + 4, 1)]);
+    assert_eq!(bus.writes, vec![(DATA, 4), (DATA + 4, 1)]);
+    assert_eq!(bus.bytes_touched(), span(DATA, 5));
+    assert_eq!(bus.inner.read_byte(DATA + 5), SENTINEL);
+}
+
+#[test]
+fn negative_dynamic_offset_reaches_back_exactly_one_byte() {
+    // BFSET (A0){D1:1} with D1 = -1: the last bit of the byte before A0.
+    let (_, mut bus) = run_bitfield(0xEED0, 0x0841, -1i32 as u32, &[(DATA - 1, 0x00)]);
+    assert_eq!(bus.reads, vec![(DATA - 1, 1)]);
+    assert_eq!(bus.writes, vec![(DATA - 1, 1)]);
+    assert_eq!(bus.bytes_touched(), span(DATA - 1, 1));
+    assert_eq!(bus.inner.read_byte(DATA - 1), 0x01);
+    assert_eq!(bus.inner.read_byte(DATA - 2), SENTINEL);
+    assert_eq!(bus.inner.read_byte(DATA), SENTINEL);
+}
+
+#[test]
+fn read_only_forms_read_their_span_and_write_nothing() {
+    // BFTST (A0){6:4}: bits 6..9 span two bytes; field = 0b1011.
+    let (cpu, bus) = run_bitfield(0xE8D0, 0x0184, 0, &[(DATA, 0x02), (DATA + 1, 0xC0)]);
+    assert_eq!(bus.reads, vec![(DATA, 2)]);
+    assert!(bus.writes.is_empty());
+    assert_eq!(bus.bytes_touched(), span(DATA, 2));
+    // N set (msb of field), Z clear.
+    let sr = cpu.get_sr();
+    assert_ne!(sr & 0x0008, 0, "N should be set");
+    assert_eq!(sr & 0x0004, 0, "Z should be clear");
+}
+
+#[test]
+fn no_memory_form_touches_a_byte_outside_its_field() {
+    // Every form, at every span, against the field the extension word names.
+    // (opcode, extension, span in bytes)
+    let cases: [(u16, u16, u32); 12] = [
+        (0xE8D0, 0x0041, 1), // BFTST   (A0){1:1}
+        (0xE9D0, 0x3110, 3), // BFEXTU  (A0){4:16},D3
+        (0xEAD0, 0x0108, 2), // BFCHG   (A0){4:8}
+        (0xEBD0, 0x3110, 3), // BFEXTS  (A0){4:16},D3
+        (0xECD0, 0x0000, 4), // BFCLR   (A0){0:32}
+        (0xEDD0, 0x3184, 2), // BFFFO   (A0){6:4},D3
+        (0xEED0, 0x01C0, 5), // BFSET   (A0){7:32}
+        (0xEFD0, 0x3041, 1), // BFINS   D3,(A0){1:1}
+        (0xE8D0, 0x0000, 4), // BFTST   (A0){0:32}
+        (0xEAD0, 0x01C0, 5), // BFCHG   (A0){7:32}
+        (0xECD0, 0x0110, 3), // BFCLR   (A0){4:16}
+        (0xEFD0, 0x3108, 2), // BFINS   D3,(A0){4:8}
+    ];
+    for (opcode, ext, len) in cases {
+        let (_, bus) = run_bitfield(opcode, ext, 0, &[]);
+        assert_eq!(
+            bus.bytes_touched(),
+            span(DATA, len),
+            "opcode {opcode:04X} ext {ext:04X}"
+        );
+    }
+}

--- a/tests/bitfield_memory_access_tests.rs
+++ b/tests/bitfield_memory_access_tests.rs
@@ -1,15 +1,17 @@
 //! Memory-form bit-field instructions access exactly the bytes their field
-//! spans, at the transfer size that span needs (MC68020UM 5.3.1), and never
-//! touch a neighbouring byte. A field within four bytes is one operand cycle
-//! and a five-byte span two (8.2.14); a real A1200 measures spans of one,
-//! two, three and four bytes at identical cost with only the five-byte span
-//! adding an access (Copperline timing-test/bfprobe.asm).
+//! spans, in one transfer of the size that span needs - byte, word, three
+//! bytes or long (MC68020UM 5.3.1) - and never touch a neighbouring byte. A
+//! field within four bytes is one operand cycle and a five-byte span two
+//! (8.2.14); a real A1200 measures spans of one, two, three and four bytes at
+//! identical cost with only the five-byte span adding an access (Copperline
+//! timing-test/bfprobe.asm).
 //!
 //! Widening the operand to a long would read and write up to three bytes
 //! outside the field, which is observable on memory-mapped registers and
 //! moves the fault boundary past the end of a mapped region. These tests pin
 //! the touched byte set, not just the access count, so that cannot come back.
 
+use m68k::core::memory::BusFault;
 use m68k::{AddressBus, CpuCore, CpuType, LinearMemoryBus};
 
 /// Wraps LinearMemoryBus and records every data access as (address, size).
@@ -68,6 +70,27 @@ impl AddressBus for CountingBus {
     fn write_long(&mut self, address: u32, value: u32) {
         self.writes.push((address, 4));
         self.inner.write_long(address, value)
+    }
+    // A host that bills bus cycles overrides both variants of the three-byte
+    // hook: the core calls the fallible one, and the infallible one is what
+    // any direct bus user sees.
+    fn read_three_bytes(&mut self, address: u32) -> u32 {
+        self.reads.push((address, 3));
+        let hi = self.inner.read_word(address) as u32;
+        let lo = self.inner.read_byte(address.wrapping_add(2)) as u32;
+        (hi << 8) | lo
+    }
+    fn write_three_bytes(&mut self, address: u32, value: u32) {
+        self.writes.push((address, 3));
+        self.inner.write_word(address, (value >> 8) as u16);
+        self.inner.write_byte(address.wrapping_add(2), value as u8);
+    }
+    fn try_read_three_bytes(&mut self, address: u32) -> Result<u32, BusFault> {
+        Ok(self.read_three_bytes(address))
+    }
+    fn try_write_three_bytes(&mut self, address: u32, value: u32) -> Result<(), BusFault> {
+        self.write_three_bytes(address, value);
+        Ok(())
     }
     // Opcode and extension words are not operand traffic.
     fn read_immediate_word(&mut self, address: u32) -> u16 {
@@ -145,17 +168,18 @@ fn two_byte_span_is_a_single_word_transfer() {
 }
 
 #[test]
-fn three_byte_span_never_reaches_the_fourth_byte() {
-    // BFEXTU (A0){4:16},D3: bits 4..19 span DATA..DATA+2. AddressBus has no
-    // three-byte transfer, so this composes a word and a byte - the right
-    // bytes and only those. Rounding up to a long would touch DATA+3.
+fn three_byte_span_is_a_single_three_byte_transfer() {
+    // BFEXTU (A0){4:16},D3: bits 4..19 span DATA..DATA+2. The real A1200
+    // charges this span the same single operand cycle as one, two and four
+    // bytes, so it must be one access - not a word plus a byte. Rounding up
+    // to a long instead would touch DATA+3.
     let (cpu, mut bus) = run_bitfield(
         0xE9D0,
         0x3110,
         0,
         &[(DATA, 0x0A), (DATA + 1, 0xBC), (DATA + 2, 0xD0)],
     );
-    assert_eq!(bus.reads, vec![(DATA, 2), (DATA + 2, 1)]);
+    assert_eq!(bus.reads, vec![(DATA, 3)]);
     assert!(bus.writes.is_empty());
     assert_eq!(bus.bytes_touched(), span(DATA, 3));
     assert_eq!(cpu.d(3), 0xABCD);
@@ -163,12 +187,76 @@ fn three_byte_span_never_reaches_the_fourth_byte() {
 }
 
 #[test]
-fn three_byte_modify_span_writes_back_only_its_three_bytes() {
-    // BFSET (A0){4:16}: the modify form of the same span.
+fn three_byte_modify_span_is_one_transfer_each_way() {
+    // BFSET (A0){4:16}: the modify form of the same span, one read-modify-
+    // write of three bytes.
     let (_, mut bus) = run_bitfield(0xEED0, 0x0110, 0, &[]);
-    assert_eq!(bus.reads, vec![(DATA, 2), (DATA + 2, 1)]);
-    assert_eq!(bus.writes, vec![(DATA, 2), (DATA + 2, 1)]);
+    assert_eq!(bus.reads, vec![(DATA, 3)]);
+    assert_eq!(bus.writes, vec![(DATA, 3)]);
     assert_eq!(bus.bytes_touched(), span(DATA, 3));
+    assert_eq!(bus.inner.read_byte(DATA + 3), SENTINEL);
+}
+
+#[test]
+fn a_bus_without_the_three_byte_hook_still_gets_exactly_its_three_bytes() {
+    // The hook is a default method, so a bus written before it existed keeps
+    // working: the composed word plus byte reads the same bytes and no
+    // others, and costs that bus one extra access rather than correctness.
+    struct DefaultHooksBus {
+        inner: LinearMemoryBus,
+        reads: Vec<(u32, u32)>,
+    }
+    impl AddressBus for DefaultHooksBus {
+        fn read_byte(&mut self, address: u32) -> u8 {
+            self.reads.push((address, 1));
+            self.inner.read_byte(address)
+        }
+        fn read_word(&mut self, address: u32) -> u16 {
+            self.reads.push((address, 2));
+            self.inner.read_word(address)
+        }
+        fn read_long(&mut self, address: u32) -> u32 {
+            self.reads.push((address, 4));
+            self.inner.read_long(address)
+        }
+        fn write_byte(&mut self, address: u32, value: u8) {
+            self.inner.write_byte(address, value)
+        }
+        fn write_word(&mut self, address: u32, value: u16) {
+            self.inner.write_word(address, value)
+        }
+        fn write_long(&mut self, address: u32, value: u32) {
+            self.inner.write_long(address, value)
+        }
+        fn read_immediate_word(&mut self, address: u32) -> u16 {
+            self.inner.read_word(address)
+        }
+        fn read_immediate_long(&mut self, address: u32) -> u32 {
+            self.inner.read_long(address)
+        }
+    }
+
+    let mut bus = DefaultHooksBus {
+        inner: LinearMemoryBus::new(0x10000),
+        reads: Vec::new(),
+    };
+    for addr in DATA..(DATA + 8) {
+        bus.inner.load(addr, &[SENTINEL]);
+    }
+    bus.inner.load(CODE, &0xE9D0u16.to_be_bytes()); // BFEXTU (A0){4:16},D3
+    bus.inner.load(CODE + 2, &0x3110u16.to_be_bytes());
+    bus.inner.load(DATA, &[0x0A, 0xBC, 0xD0]);
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68020);
+    cpu.pc = CODE;
+    cpu.set_sr(0x2700);
+    cpu.set_a(7, 0x8000);
+    cpu.set_a(0, DATA);
+    bus.reads.clear();
+    cpu.step(&mut bus);
+
+    assert_eq!(bus.reads, vec![(DATA, 2), (DATA + 2, 1)]);
+    assert_eq!(cpu.d(3), 0xABCD);
     assert_eq!(bus.inner.read_byte(DATA + 3), SENTINEL);
 }
 


### PR DESCRIPTION
## Summary

The memory forms of the 68020 bit-field instructions (BFTST/BFEXTU/BFEXTS/BFCHG/BFCLR/BFSET/BFFFO/BFINS) had two defects that surface on cycle-billing hosts:

1. **Access pattern**: `bf_extract_mem_window_msb0` always read a five-byte window, so a one-bit `BFSET (An){Dn:1}` issued five byte reads plus one write where a real 68020 performs a single read-modify-write.

2. **68020 timing**: `timing_020`'s `group_e` billed the memory forms with MC68020UM section 8.2.14 totals that *include* the operand read and write cycles, while the host separately bills every bus access the executor performs - double-charging the bus portion. The register-form rows are the UM cache-case values verbatim (they perform no accesses), so the memory rows now follow the same internal-only convention.

Both are fixed, and the timing is calibrated against a real A1200 rather than against the manual alone.

## What the hardware measured

A stock A1200 ran a 14-row bit-field probe (Copperline `timing-test/bfprobe.asm`: 8192-iteration loops referenced to the CIA E-clock, with the anchor rows reproducing the established rdprobe/fwdprobe columns exactly). It is the first hardware measurement of the 020 bit-field class we know of.

- A field within four bytes is **one operand cycle** whatever it spans: spans of one, two, three and four bytes all measure 28.10 clocks for a `BFSET (An){0:1}` + `DBcc` loop. A five-byte span costs one operand cycle more (44.32).
- BFTST 24.12, BFEXTU and BFINS 28.10, register-form BFSET 20.02, the dynamic offset free, and the DBcc alignment clock absorbed by the operand access.

## What it did not measure, and what the model does about it

The review is right that this does not establish a long-width transfer, and checking it properly rather than arguing the point is what the data supports: the A1200 moves any span up to four bytes across its **32-bit** chip bus in a single cycle, and every probe row's field starts at a longword-aligned address. A byte, a word and a long are therefore indistinguishable on that machine. Separating them would need a 16-bit chip port (an OCS/ECS host with an 020) or a bus-signal capture.

So the executor transfers **exactly the width the field spans** - byte, word, three bytes, or long, plus one byte for a five-byte span. No byte outside the field is read or written, which removes the adjacent-MMIO exposure and the moved fault boundary of the earlier commit.

The timing rows are unaffected by the width choice, for the same reason the measurement cannot see it.

## The three-byte transfer

A three-byte span used to compose a word and a byte, which reads the right bytes but bills a cycle-counting host two operand transactions where the hardware charges one. `AddressBus` now has the transfer:

- `read_three_bytes`/`write_three_bytes` and their fallible variants, all **default methods** composing a word and a byte, so no existing bus needs to change.
- The fallible defaults compose the *fallible* word and byte accesses rather than delegating to the infallible ones, so a bus that reports faults keeps reporting them on whichever half fails. A host that bills bus cycles overrides both variants; the trait documents that and the regression bus does it.
- `CpuCore::read_24`/`write_24` mirror `read_32`/`write_32`, including the MMU page-straddle split and a fault size of 3. The 68020/68030 SSW reports that as SIZ 11, its three-byte encoding; the 68040 SZ and 68060 FSLW have no three-byte value (11 is a line transfer) and still report long.

With a host implementing the hook, the probe's three-byte row moves from `2D11` to `2CD1` - the same value as the one-, two- and four-byte spans and the dynamic form, which is exactly what the A1200 measures for all of them.

Note that this makes the PR additive to the public API. It is titled `fix:` because it fixes a defect; retitle it before merging if you would rather release-please cut a minor bump.

## Verification

- `tests/bitfield_memory_access_tests.rs` pins the **set of byte addresses touched**, not just the access count, for every form at every span from one to five bytes, with sentinel bytes either side of each field. The long-width shape fails them. The three-byte read and read-modify-write assert a single size-3 transaction each way, and a separate test pins the composed fallback for a bus that predates the hook.
- Timing regressions in the `timing_020` test module cover the register, within-four-bytes and five-byte rows, cached and uncached, plus an assertion that a five-byte span costs exactly one operand cycle more than a within-four-bytes span across every form.
- Full crate suite green (62 test targets), `cargo clippy --all-targets` and `cargo fmt --check` clean, Musashi `test_m68020_bitfield` unchanged.
- Against the real A1200 column a cycle-billing host lands every row within 0.62% (worst is the five-byte span), with the anchors and the register form tick-exact.
- SANITY Roots II AGA (CopperlineHQ/Copperline#371, the demo that motivated this): 60 frames across the DIE dissolve are **byte-for-byte identical** with and without the three-byte hook, and identical to the earlier long-width shape, so the real-world fix survives every step of the safer model.

### Known remaining gaps

BFFFO and the five-byte rows of the non-BFSET forms keep the MC68020UM relative deltas and are not yet hardware-measured.
