### PR TITLE
feat: add instruction-boundary cycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ fn emulate(cpu: &mut CpuCore, bus: &mut impl AddressBus) {
 | **`step_with_hle_handler()`** | One instruction | Same precise path as `step()` | Offers traps to `HleHandler`; unhandled traps take the hardware exception |
 | **`execute()`** | CPU cycles | Precise path; whole instructions may overshoot the requested cycles | Takes traps as hardware exceptions and returns consumed cycles |
 | **`run_for_cycles()`** | CPU cycles | Precise path with actual cycle and instruction totals | Surfaces traps, STOP, and bus-requested instruction boundaries separately |
+| **`run_for_cycles_with_hook()`** | CPU cycles | Same precise path, with host synchronization after each normally completed instruction | The hook can continue or request an instruction-boundary return |
 | **`run_batch()`** | Instructions | Throughput path using decoded-op caching, optional direct RAM, and portable or `jit`-enabled native hot-loop traces | Surfaces traps, STOP, watched PCs, or budget exhaustion |
 
 Use **`step()`** for debugger-style control. Use **`run_for_cycles()`** when a
@@ -209,6 +210,32 @@ The 68000 and 68010 may already have instruction words in their hardware
 prefetch queue at this boundary. If the host work changes instruction-visible
 memory or mapping and those queued words must not be used, call
 `cpu.invalidate_prefetch()` before resuming.
+
+Use **`run_for_cycles_with_hook()`** when devices or IRQ lines must be updated
+between instructions rather than after an aggregate batch:
+
+```rust
+use m68k::CycleBatchControl;
+
+let result = cpu.run_for_cycles_with_hook(&mut bus, 512, |cpu, bus, cycles| {
+    bus.advance_devices(cycles);
+    cpu.set_irq(bus.interrupt_level());
+
+    if bus.monitor_requested() {
+        CycleBatchControl::Return
+    } else {
+        CycleBatchControl::Continue
+    }
+});
+```
+
+The hook receives the cycles for the just-completed instruction and can inspect
+`cpu.ppc` and `cpu.pc`. Its CPU and bus updates are applied before another
+instruction is fetched. A hook-requested return uses
+`CycleBatchExit::BoundaryRequested`, includes the completed instruction exactly
+once, and resumes at the following instruction. Interrupt-entry cycles are
+included in `result.cycles` but are not reported as instruction cycles to the
+hook. The original `run_for_cycles()` path has no runtime hook check.
 
 Use **`step_with_hle_handler()`** when patching selected guest OS calls while
 allowing every unhandled trap to follow hardware behavior. Use
@@ -305,7 +332,7 @@ m68k/
 | `LinearMemoryBus` / `FastMem` | Ready-made flat memory and optional direct-RAM window |
 | `HleHandler` | Trap interception callbacks |
 | `StepResult` | Single-instruction result |
-| `CycleBatchResult` / `CycleBatchExit` | Precise cycle-scheduled execution result |
+| `CycleBatchResult` / `CycleBatchExit` / `CycleBatchControl` | Precise cycle-scheduled execution result and hook control |
 | `BatchResult` / `BatchExit` | High-throughput instruction-batch result |
 | `CpuCore::is_stopped()` | STOP state check |
 | `CpuCore::is_halted()` | Double-fault halt check |

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -7,7 +7,9 @@ use super::decode::{dispatch_instruction, needs_rollback_snapshot};
 use super::memory::AddressBus;
 use super::op_cache::BatchInnerExit;
 use super::trace_jit;
-use super::types::{BatchExit, BatchResult, CycleBatchExit, CycleBatchResult, StepResult};
+use super::types::{
+    BatchExit, BatchResult, CycleBatchControl, CycleBatchExit, CycleBatchResult, StepResult,
+};
 
 /// Stop level constants.
 pub const STOP_LEVEL_STOP: u32 = 1;
@@ -207,6 +209,62 @@ impl CpuCore {
         bus: &mut B,
         cycle_budget: i32,
     ) -> CycleBatchResult {
+        self.run_for_cycles_inner::<B, _, false>(bus, cycle_budget, &mut |_, _, _| {
+            CycleBatchControl::Continue
+        })
+    }
+
+    /// Execute complete instructions with host synchronization after each
+    /// normally completed instruction.
+    ///
+    /// The hook receives the CPU, bus, and cycles consumed by the just-completed
+    /// instruction. [`CpuCore::ppc`](Self::ppc) identifies that instruction;
+    /// [`CpuCore::pc`](Self::pc) identifies the next instruction or an exception
+    /// handler selected while the instruction completed. CPU and bus changes
+    /// made by the hook are visible before another instruction is fetched.
+    ///
+    /// Returning [`CycleBatchControl::Return`] exits with
+    /// [`CycleBatchExit::BoundaryRequested`]. The completed instruction and its
+    /// cycles remain included in the result, and no further interrupt entry or
+    /// instruction executes. Returning [`CycleBatchControl::Continue`] allows a
+    /// newly serviceable interrupt to be taken before the next instruction.
+    /// Interrupt-entry cycles are included in the batch total but are not passed
+    /// to the hook as instruction cycles.
+    ///
+    /// The hook is not called for surfaced traps, STOP, interrupt entry, or an
+    /// already-stopped CPU. Bus boundary requests and STOP retain their existing
+    /// precedence over budget exhaustion. A bus request raised by an instruction
+    /// or the hook is honored before a newly raised interrupt is serviced.
+    ///
+    /// The hook must not call CPU execution methods or modify the runner's cycle
+    /// bookkeeping fields; doing so would invalidate the returned totals.
+    ///
+    /// Use [`run_for_cycles`](Self::run_for_cycles) when synchronization is not
+    /// required; its hook branch is disabled at compile time.
+    pub fn run_for_cycles_with_hook<B, F>(
+        &mut self,
+        bus: &mut B,
+        cycle_budget: i32,
+        mut hook: F,
+    ) -> CycleBatchResult
+    where
+        B: AddressBus,
+        F: FnMut(&mut CpuCore, &mut B, i32) -> CycleBatchControl,
+    {
+        self.run_for_cycles_inner::<B, F, true>(bus, cycle_budget, &mut hook)
+    }
+
+    #[inline]
+    fn run_for_cycles_inner<B, F, const CALL_HOOK: bool>(
+        &mut self,
+        bus: &mut B,
+        cycle_budget: i32,
+        hook: &mut F,
+    ) -> CycleBatchResult
+    where
+        B: AddressBus,
+        F: FnMut(&mut CpuCore, &mut B, i32) -> CycleBatchControl,
+    {
         self.set_precise_bus(true);
         self.initial_cycles = cycle_budget;
 
@@ -268,7 +326,31 @@ impl CpuCore {
                             exit: CycleBatchExit::Stopped,
                         };
                     }
-                    if bus.take_boundary_request() {
+
+                    let hook_control = if CALL_HOOK {
+                        hook(self, bus, cycles)
+                    } else {
+                        CycleBatchControl::Continue
+                    };
+
+                    // Preserve the bus boundary before performing additional
+                    // CPU work requested by a hook update. This also consumes a
+                    // request raised from inside the hook.
+                    if bus.take_boundary_request() || hook_control == CycleBatchControl::Return {
+                        return CycleBatchResult {
+                            cycles: self.initial_cycles - self.cycles_remaining,
+                            instructions,
+                            exit: CycleBatchExit::BoundaryRequested,
+                        };
+                    }
+
+                    // step() has already serviced any interrupt pending at its
+                    // ordinary end-of-instruction sample. A hook can create a
+                    // new serviceable interrupt, so sample again before fetch.
+                    if CALL_HOOK
+                        && self.check_and_service_interrupts(bus)
+                        && bus.take_boundary_request()
+                    {
                         return CycleBatchResult {
                             cycles: self.initial_cycles - self.cycles_remaining,
                             instructions,

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -180,9 +180,10 @@ pub trait AddressBus {
     /// Take a pending request to return from cycle-scheduled execution at
     /// the next completed instruction or interrupt-entry boundary.
     ///
-    /// [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) calls this
-    /// after an instruction completes normally or an entry interrupt is
-    /// serviced, and before it fetches or executes another instruction.
+    /// [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) and
+    /// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook)
+    /// call this after an instruction completes normally or an entry interrupt
+    /// is serviced, and before fetching or executing another instruction.
     /// Returning `true` makes the runner exit with
     /// [`CycleBatchExit::BoundaryRequested`](crate::CycleBatchExit::BoundaryRequested).
     /// Completed work is included in the result: an instruction contributes

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -300,8 +300,19 @@ pub struct BatchResult {
     pub exit: BatchExit,
 }
 
-/// Reason a [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) call
-/// returned.
+/// Control returned by an instruction-boundary hook passed to
+/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CycleBatchControl {
+    /// Continue execution after applying the hook's CPU and bus updates.
+    Continue,
+    /// Return from the runner before another instruction is fetched.
+    Return,
+}
+
+/// Reason a [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) or
+/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook)
+/// call returned.
 ///
 /// Trap variants have exactly the same CPU/PC state as [`StepResult`]: the
 /// trapping opcode has been fetched and `pc` points past it, but no hardware
@@ -311,8 +322,8 @@ pub enum CycleBatchExit {
     /// The requested cycle budget was met or crossed at an instruction or
     /// interrupt boundary.
     BudgetExhausted,
-    /// The address bus requested a return after a completed instruction or
-    /// entry interrupt.
+    /// The address bus or instruction-boundary hook requested a return after
+    /// a completed instruction, or the bus requested one after an entry interrupt.
     ///
     /// Completed work is included in the result. Interrupt entry contributes
     /// cycles but no retired instruction. This exit takes precedence when the
@@ -348,7 +359,8 @@ pub enum CycleBatchExit {
     },
 }
 
-/// Result of [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles).
+/// Result of [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) or
+/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CycleBatchResult {
     /// Actual CPU cycles consumed. This may exceed the requested budget

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,10 @@
 //! [`CpuCore::step`] and [`CpuCore::execute`] preserve transaction-level bus
 //! ordering and expose internal-clock gaps through [`AddressBus::sync`].
 //! [`CpuCore::run_for_cycles`] retains cycle accounting with lower dispatch
-//! overhead, while [`CpuCore::run_batch`] is an instruction-budgeted
-//! throughput path that can use [`FastMem`].
+//! overhead. [`CpuCore::run_for_cycles_with_hook`] additionally lets a host
+//! synchronize devices and IRQ state between instructions, while
+//! [`CpuCore::run_batch`] is an instruction-budgeted throughput path that can
+//! use [`FastMem`].
 //!
 //! # Cargo features
 //!
@@ -61,6 +63,6 @@ pub use core::cpu::{
 };
 pub use core::memory::{AddressBus, FastMem, LinearMemoryBus};
 pub use core::types::{
-    BatchExit, BatchResult, CpuType, CycleBatchExit, CycleBatchResult, HleHandler, NoOpHleHandler,
-    Size, StepResult,
+    BatchExit, BatchResult, CpuType, CycleBatchControl, CycleBatchExit, CycleBatchResult,
+    HleHandler, NoOpHleHandler, Size, StepResult,
 };

--- a/tests/run_for_cycles_tests.rs
+++ b/tests/run_for_cycles_tests.rs
@@ -1,4 +1,6 @@
-use m68k::{AddressBus, CpuCore, CpuType, CycleBatchExit, LinearMemoryBus, StepResult};
+use m68k::{
+    AddressBus, CpuCore, CpuType, CycleBatchControl, CycleBatchExit, LinearMemoryBus, StepResult,
+};
 
 fn cpu_at(cpu_type: CpuType, pc: u32) -> CpuCore {
     let mut cpu = CpuCore::new();
@@ -173,6 +175,105 @@ fn stop_is_distinct_and_the_stop_instruction_is_counted() {
     assert_eq!(result.exit, CycleBatchExit::Stopped);
 }
 
+#[test]
+fn hook_return_precedes_budget_and_resume_starts_at_next_instruction() {
+    let mut bus = bus_with(&[
+        (0x1000, 0x4E71), // NOP
+        (0x1002, 0x4E71), // NOP
+        (0x1004, 0x4E71), // NOP
+    ]);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    let mut observations = Vec::new();
+
+    let result = cpu.run_for_cycles_with_hook(&mut bus, 1, |cpu, _bus, cycles| {
+        observations.push((cpu.ppc, cpu.pc, cycles));
+        CycleBatchControl::Return
+    });
+
+    assert_eq!(observations, vec![(0x1000, 0x1002, 4)]);
+    assert_eq!(result.cycles, 4);
+    assert_eq!(result.instructions, 1);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.pc, 0x1002);
+
+    let resumed = cpu.run_for_cycles(&mut bus, 1);
+    assert_eq!(resumed.cycles, 4);
+    assert_eq!(resumed.instructions, 1);
+    assert_eq!(resumed.exit, CycleBatchExit::BudgetExhausted);
+    assert_eq!(cpu.pc, 0x1004);
+}
+
+#[test]
+fn always_continue_hook_matches_the_original_runner() {
+    let words = [
+        (0x1000, 0x5280), // ADDQ.L #1,D0
+        (0x1002, 0x60FC), // BRA.S $1000
+    ];
+    let mut plain_bus = bus_with(&words);
+    let mut hooked_bus = bus_with(&words);
+    let mut plain_cpu = cpu_at(CpuType::M68000, 0x1000);
+    let mut hooked_cpu = cpu_at(CpuType::M68000, 0x1000);
+    let mut hook_calls = 0;
+
+    let plain = plain_cpu.run_for_cycles(&mut plain_bus, 50);
+    let hooked = hooked_cpu.run_for_cycles_with_hook(&mut hooked_bus, 50, |_, _, cycles| {
+        assert!(cycles > 0);
+        hook_calls += 1;
+        CycleBatchControl::Continue
+    });
+
+    assert_eq!(hooked, plain);
+    assert_eq!(hook_calls, hooked.instructions);
+    assert_cpu_state_eq(&hooked_cpu, &plain_cpu);
+}
+
+#[test]
+fn hook_reports_data_dependent_instruction_cycles_individually() {
+    let mut bus = bus_with(&[
+        (0x1000, 0xC0C1), // MULU.W D1,D0
+        (0x1002, 0xC0C1), // MULU.W D1,D0
+        (0x1004, 0x4E71),
+    ]);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_d(0, 2);
+    cpu.set_d(1, 1);
+    let mut observed_cycles = Vec::new();
+
+    let result = cpu.run_for_cycles_with_hook(&mut bus, 1_000, |cpu, _, cycles| {
+        observed_cycles.push(cycles);
+        if observed_cycles.len() == 1 {
+            // 68000 MULU timing depends on the number of set bits in the source.
+            cpu.set_d(1, 0xFFFF);
+            CycleBatchControl::Continue
+        } else {
+            CycleBatchControl::Return
+        }
+    });
+
+    assert_eq!(observed_cycles.len(), 2);
+    assert!(observed_cycles[1] > observed_cycles[0]);
+    assert_eq!(result.cycles, observed_cycles.iter().sum());
+    assert_eq!(result.instructions, 2);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+}
+
+#[test]
+fn stop_retains_its_exit_without_invoking_the_hook() {
+    let mut bus = bus_with(&[(0x1000, 0x4E72), (0x1002, 0x2700)]);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    let mut hook_calls = 0;
+
+    let result = cpu.run_for_cycles_with_hook(&mut bus, 100, |_, _, _| {
+        hook_calls += 1;
+        CycleBatchControl::Return
+    });
+
+    assert_eq!(hook_calls, 0);
+    assert_eq!(result.cycles, 4);
+    assert_eq!(result.instructions, 1);
+    assert_eq!(result.exit, CycleBatchExit::Stopped);
+}
+
 #[derive(Clone)]
 struct EventBus {
     memory: Vec<u8>,
@@ -271,6 +372,118 @@ impl AddressBus for EventBus {
     fn reset_devices(&mut self) {
         self.resets += 1;
     }
+}
+
+#[test]
+fn hook_updates_bus_state_before_the_next_instruction() {
+    let mut bus = EventBus::new();
+    bus.load_word(0x1000, 0x4E71); // NOP
+    bus.load_word(0x1002, 0x1210); // MOVE.B (A0),D1
+    bus.load_word(0x1004, 0x4E71); // NOP
+    bus.write_byte(0x4000, 0x11);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_a(0, 0x4000);
+    let mut observations = Vec::new();
+
+    let result = cpu.run_for_cycles_with_hook(&mut bus, 100, |cpu, bus, cycles| {
+        observations.push((cpu.ppc, cycles));
+        if cpu.ppc == 0x1000 {
+            bus.write_byte(0x4000, 0x7B);
+            CycleBatchControl::Continue
+        } else {
+            CycleBatchControl::Return
+        }
+    });
+
+    assert_eq!(observations, vec![(0x1000, 4), (0x1002, 8)]);
+    assert_eq!(result.cycles, 12);
+    assert_eq!(result.instructions, 2);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.d(1) & 0xFF, 0x7B);
+    assert_eq!(cpu.pc, 0x1004);
+}
+
+#[test]
+fn irq_raised_by_hook_is_taken_before_the_next_ordinary_instruction() {
+    let mut bus = EventBus::new();
+    bus.load_word(0x1000, 0x4E71); // NOP
+    bus.load_word(0x1002, 0x7201); // MOVEQ #1,D1 (must not execute first)
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x7007); // handler: MOVEQ #7,D0
+    bus.load_word(0x2002, 0x4E71);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    let mut observations = Vec::new();
+
+    let result = cpu.run_for_cycles_with_hook(&mut bus, 100, |cpu, _bus, cycles| {
+        observations.push((cpu.ppc, cycles));
+        if cpu.ppc == 0x1000 {
+            cpu.set_irq(3);
+            CycleBatchControl::Continue
+        } else {
+            CycleBatchControl::Return
+        }
+    });
+
+    assert_eq!(observations, vec![(0x1000, 4), (0x2000, 4)]);
+    assert_eq!(result.cycles, 52); // NOP + level-3 entry + handler MOVEQ
+    assert_eq!(result.instructions, 2);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.d(0), 7);
+    assert_eq!(cpu.d(1), 0);
+    assert_eq!(cpu.pc, 0x2002);
+}
+
+#[test]
+fn bus_boundary_precedes_an_irq_newly_raised_by_the_hook() {
+    let mut bus = EventBus::new();
+    bus.load_word(0x1000, 0x3080); // MOVE.W D0,(A0)
+    bus.load_word(0x1002, 0x4E71);
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x4E71);
+    bus.boundary_write_address = Some(0x4000);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    cpu.set_a(0, 0x4000);
+
+    let result = cpu.run_for_cycles_with_hook(&mut bus, 100, |cpu, _, _| {
+        cpu.set_irq(3);
+        CycleBatchControl::Continue
+    });
+
+    assert_eq!(result.cycles, 8);
+    assert_eq!(result.instructions, 1);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.pc, 0x1002);
+
+    let resumed = cpu.run_for_cycles(&mut bus, 1);
+    assert_eq!(resumed.cycles, 44);
+    assert_eq!(resumed.instructions, 0);
+    assert_eq!(resumed.exit, CycleBatchExit::BudgetExhausted);
+    assert_eq!(cpu.pc, 0x2000);
+}
+
+#[test]
+fn entry_interrupt_boundary_does_not_invoke_instruction_hook() {
+    let mut bus = EventBus::new();
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x4E71);
+    bus.boundary_on_interrupt_acknowledge = true;
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    cpu.set_irq(3);
+    let mut hook_calls = 0;
+
+    let result = cpu.run_for_cycles_with_hook(&mut bus, 100, |_, _, _| {
+        hook_calls += 1;
+        CycleBatchControl::Continue
+    });
+
+    assert_eq!(hook_calls, 0);
+    assert_eq!(result.cycles, 44);
+    assert_eq!(result.instructions, 0);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.pc, 0x2000);
 }
 
 #[test]


### PR DESCRIPTION
Closes #58

## Summary
- add `run_for_cycles_with_hook` for per-instruction host device and IRQ synchronization
- let hooks continue or return at the completed boundary without changing the existing cycle result shape
- preserve STOP, trap, interrupt-entry, bus-boundary, and no-hook runner behavior
- document the public contract and add focused ordering, resume, timing, and parity coverage

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo test --locked`
- `cargo test --all-features --locked`