### PR TITLE
feat: expose interrupt-entry cycle boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ fn emulate(cpu: &mut CpuCore, bus: &mut impl AddressBus) {
 | **`execute()`** | CPU cycles | Precise path; whole instructions may overshoot the requested cycles | Takes traps as hardware exceptions and returns consumed cycles |
 | **`run_for_cycles()`** | CPU cycles | Precise path with actual cycle and instruction totals | Surfaces traps, STOP, and bus-requested instruction boundaries separately |
 | **`run_for_cycles_with_hook()`** | CPU cycles | Same precise path, with host synchronization after each normally completed instruction | The hook can continue or request an instruction-boundary return |
+| **`run_for_cycles_with_boundary_hook()`** | CPU cycles | Same precise path, with separate instruction and interrupt-entry events | The hook can synchronize or return before the first handler instruction |
 | **`run_batch()`** | Instructions | Throughput path using decoded-op caching, optional direct RAM, and portable or `jit`-enabled native hot-loop traces | Surfaces traps, STOP, watched PCs, or budget exhaustion |
 
 Use **`step()`** for debugger-style control. Use **`run_for_cycles()`** when a
@@ -236,6 +237,27 @@ instruction is fetched. A hook-requested return uses
 once, and resumes at the following instruction. Interrupt-entry cycles are
 included in `result.cycles` but are not reported as instruction cycles to the
 hook. The original `run_for_cycles()` path has no runtime hook check.
+
+Use **`run_for_cycles_with_boundary_hook()`** when the host must also advance
+devices for interrupt-entry cycles before the first handler instruction:
+
+```rust
+use m68k::{CycleBatchControl, CycleBoundaryEvent};
+
+let result = cpu.run_for_cycles_with_boundary_hook(&mut bus, 512, |cpu, bus, event| {
+    let cycles = match event {
+        CycleBoundaryEvent::Instruction { cycles }
+        | CycleBoundaryEvent::InterruptEntry { cycles } => cycles,
+    };
+    bus.advance_devices(cycles);
+    cpu.set_irq(bus.interrupt_level());
+    CycleBatchControl::Continue
+});
+```
+
+Interrupt entry contributes no retired instruction. Returning from its event
+stops before the first handler instruction, and resuming executes that
+instruction normally.
 
 Use **`step_with_hle_handler()`** when patching selected guest OS calls while
 allowing every unhandled trap to follow hardware behavior. Use
@@ -332,7 +354,7 @@ m68k/
 | `LinearMemoryBus` / `FastMem` | Ready-made flat memory and optional direct-RAM window |
 | `HleHandler` | Trap interception callbacks |
 | `StepResult` | Single-instruction result |
-| `CycleBatchResult` / `CycleBatchExit` / `CycleBatchControl` | Precise cycle-scheduled execution result and hook control |
+| `CycleBatchResult` / `CycleBatchExit` / `CycleBatchControl` / `CycleBoundaryEvent` | Precise cycle-scheduled execution result, hook control, and boundary kind |
 | `BatchResult` / `BatchExit` | High-throughput instruction-batch result |
 | `CpuCore::is_stopped()` | STOP state check |
 | `CpuCore::is_halted()` | Double-fault halt check |

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -8,7 +8,8 @@ use super::memory::AddressBus;
 use super::op_cache::BatchInnerExit;
 use super::trace_jit;
 use super::types::{
-    BatchExit, BatchResult, CycleBatchControl, CycleBatchExit, CycleBatchResult, StepResult,
+    BatchExit, BatchResult, CycleBatchControl, CycleBatchExit, CycleBatchResult,
+    CycleBoundaryEvent, StepResult,
 };
 
 /// Stop level constants.
@@ -209,7 +210,7 @@ impl CpuCore {
         bus: &mut B,
         cycle_budget: i32,
     ) -> CycleBatchResult {
-        self.run_for_cycles_inner::<B, _, false>(bus, cycle_budget, &mut |_, _, _| {
+        self.run_for_cycles_inner::<B, _, false, false>(bus, cycle_budget, &mut |_, _, _| {
             CycleBatchControl::Continue
         })
     }
@@ -251,11 +252,80 @@ impl CpuCore {
         B: AddressBus,
         F: FnMut(&mut CpuCore, &mut B, i32) -> CycleBatchControl,
     {
-        self.run_for_cycles_inner::<B, F, true>(bus, cycle_budget, &mut hook)
+        self.run_for_cycles_inner::<B, _, true, false>(bus, cycle_budget, &mut |cpu, bus, event| {
+            match event {
+                CycleBoundaryEvent::Instruction { cycles } => hook(cpu, bus, cycles),
+                CycleBoundaryEvent::InterruptEntry { .. } => {
+                    unreachable!("the instruction hook does not receive interrupt entry")
+                }
+            }
+        })
+    }
+
+    /// Execute complete instructions with host synchronization after every
+    /// instruction and interrupt-entry boundary.
+    ///
+    /// The hook receives [`CycleBoundaryEvent::Instruction`] after an
+    /// instruction retires and [`CycleBoundaryEvent::InterruptEntry`] after
+    /// interrupt entry completes. An interrupt-entry event occurs before the
+    /// first handler instruction is fetched or executed, contributes cycles
+    /// but no retired instruction, and can request a return. CPU and bus
+    /// changes made for either event are visible before execution continues.
+    ///
+    /// A bus boundary request raised during interrupt entry remains pending
+    /// while the hook runs and forces [`CycleBatchExit::BoundaryRequested`]
+    /// afterward. Use [`run_for_cycles_with_hook`](Self::run_for_cycles_with_hook)
+    /// when only retired instructions need synchronization, or
+    /// [`run_for_cycles`](Self::run_for_cycles) when no synchronization hook is
+    /// required.
+    pub fn run_for_cycles_with_boundary_hook<B, F>(
+        &mut self,
+        bus: &mut B,
+        cycle_budget: i32,
+        mut hook: F,
+    ) -> CycleBatchResult
+    where
+        B: AddressBus,
+        F: FnMut(&mut CpuCore, &mut B, CycleBoundaryEvent) -> CycleBatchControl,
+    {
+        self.run_for_cycles_inner::<B, F, true, true>(bus, cycle_budget, &mut hook)
     }
 
     #[inline]
-    fn run_for_cycles_inner<B, F, const CALL_HOOK: bool>(
+    fn service_interrupt_boundary<B, F, const CALL_INTERRUPT_HOOK: bool>(
+        &mut self,
+        bus: &mut B,
+        hook: &mut F,
+    ) -> Option<CycleBatchControl>
+    where
+        B: AddressBus,
+        F: FnMut(&mut CpuCore, &mut B, CycleBoundaryEvent) -> CycleBatchControl,
+    {
+        let before_interrupt = self.cycles_remaining;
+        if !self.check_and_service_interrupts(bus) {
+            return None;
+        }
+        let entry_cycles = before_interrupt - self.cycles_remaining;
+        Some(if CALL_INTERRUPT_HOOK {
+            hook(
+                self,
+                bus,
+                CycleBoundaryEvent::InterruptEntry {
+                    cycles: entry_cycles,
+                },
+            )
+        } else {
+            CycleBatchControl::Continue
+        })
+    }
+
+    #[inline]
+    fn run_for_cycles_inner<
+        B,
+        F,
+        const CALL_INSTRUCTION_HOOK: bool,
+        const CALL_INTERRUPT_HOOK: bool,
+    >(
         &mut self,
         bus: &mut B,
         cycle_budget: i32,
@@ -263,7 +333,7 @@ impl CpuCore {
     ) -> CycleBatchResult
     where
         B: AddressBus,
-        F: FnMut(&mut CpuCore, &mut B, i32) -> CycleBatchControl,
+        F: FnMut(&mut CpuCore, &mut B, CycleBoundaryEvent) -> CycleBatchControl,
     {
         self.set_precise_bus(true);
         self.initial_cycles = cycle_budget;
@@ -287,8 +357,10 @@ impl CpuCore {
 
         // Interrupts are instruction-boundary events. Service one before the
         // first fetch, including when it wakes a stopped CPU.
-        let serviced_entry_interrupt = self.check_and_service_interrupts(bus);
-        if serviced_entry_interrupt && bus.take_boundary_request() {
+        if let Some(hook_control) =
+            self.service_interrupt_boundary::<B, F, CALL_INTERRUPT_HOOK>(bus, hook)
+            && (bus.take_boundary_request() || hook_control == CycleBatchControl::Return)
+        {
             return CycleBatchResult {
                 cycles: self.initial_cycles - self.cycles_remaining,
                 instructions: 0,
@@ -313,13 +385,45 @@ impl CpuCore {
                 };
             }
 
-            match self.step(bus) {
+            // Hook-enabled runners must expose the instruction boundary before
+            // servicing an interrupt made pending by that instruction or its
+            // hook. `step()` normally services the current level on return, so
+            // defer it locally and restore it before invoking the hook.
+            let deferred_irq = if CALL_INSTRUCTION_HOOK {
+                std::mem::take(&mut self.int_level)
+            } else {
+                0
+            };
+            let step_result = self.step(bus);
+            if CALL_INSTRUCTION_HOOK {
+                self.int_level = deferred_irq;
+            }
+
+            match step_result {
                 StepResult::Ok { cycles } => {
                     self.cycles_remaining -= cycles;
                     instructions += 1;
                     // STOP is an observable exit even when its own cycles
-                    // simultaneously exhaust the budget.
+                    // simultaneously exhaust the budget. If STOP itself
+                    // unmasked a pending interrupt, service that entry first
+                    // without turning STOP into an ordinary instruction-hook
+                    // event.
                     if self.stopped != 0 {
+                        if CALL_INSTRUCTION_HOOK
+                            && let Some(interrupt_control) = self
+                                .service_interrupt_boundary::<B, F, CALL_INTERRUPT_HOOK>(bus, hook)
+                        {
+                            if bus.take_boundary_request()
+                                || interrupt_control == CycleBatchControl::Return
+                            {
+                                return CycleBatchResult {
+                                    cycles: self.initial_cycles - self.cycles_remaining,
+                                    instructions,
+                                    exit: CycleBatchExit::BoundaryRequested,
+                                };
+                            }
+                            continue;
+                        }
                         return CycleBatchResult {
                             cycles: self.initial_cycles - self.cycles_remaining,
                             instructions,
@@ -327,8 +431,8 @@ impl CpuCore {
                         };
                     }
 
-                    let hook_control = if CALL_HOOK {
-                        hook(self, bus, cycles)
+                    let hook_control = if CALL_INSTRUCTION_HOOK {
+                        hook(self, bus, CycleBoundaryEvent::Instruction { cycles })
                     } else {
                         CycleBatchControl::Continue
                     };
@@ -344,12 +448,14 @@ impl CpuCore {
                         };
                     }
 
-                    // step() has already serviced any interrupt pending at its
-                    // ordinary end-of-instruction sample. A hook can create a
-                    // new serviceable interrupt, so sample again before fetch.
-                    if CALL_HOOK
-                        && self.check_and_service_interrupts(bus)
-                        && bus.take_boundary_request()
+                    // Service the level restored above, including an interrupt
+                    // newly raised by the instruction hook, before the next
+                    // fetch.
+                    if CALL_INSTRUCTION_HOOK
+                        && let Some(interrupt_control) =
+                            self.service_interrupt_boundary::<B, F, CALL_INTERRUPT_HOOK>(bus, hook)
+                        && (bus.take_boundary_request()
+                            || interrupt_control == CycleBatchControl::Return)
                     {
                         return CycleBatchResult {
                             cycles: self.initial_cycles - self.cycles_remaining,

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -182,6 +182,8 @@ pub trait AddressBus {
     ///
     /// [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) and
     /// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook)
+    /// and
+    /// [`CpuCore::run_for_cycles_with_boundary_hook`](crate::CpuCore::run_for_cycles_with_boundary_hook)
     /// call this after an instruction completes normally or an entry interrupt
     /// is serviced, and before fetching or executing another instruction.
     /// Returning `true` makes the runner exit with

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -300,8 +300,27 @@ pub struct BatchResult {
     pub exit: BatchExit,
 }
 
-/// Control returned by an instruction-boundary hook passed to
-/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook).
+/// Boundary reported by
+/// [`CpuCore::run_for_cycles_with_boundary_hook`](crate::CpuCore::run_for_cycles_with_boundary_hook).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CycleBoundaryEvent {
+    /// A normally completed instruction retired.
+    Instruction {
+        /// Cycles consumed by the instruction, including any internally
+        /// taken synchronous exception.
+        cycles: i32,
+    },
+    /// Interrupt entry completed without retiring an instruction.
+    InterruptEntry {
+        /// Cycles consumed by interrupt entry.
+        cycles: i32,
+    },
+}
+
+/// Control returned by a cycle-boundary hook passed to
+/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook)
+/// or
+/// [`CpuCore::run_for_cycles_with_boundary_hook`](crate::CpuCore::run_for_cycles_with_boundary_hook).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CycleBatchControl {
     /// Continue execution after applying the hook's CPU and bus updates.
@@ -310,8 +329,10 @@ pub enum CycleBatchControl {
     Return,
 }
 
-/// Reason a [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) or
-/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook)
+/// Reason a [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles),
+/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook),
+/// or
+/// [`CpuCore::run_for_cycles_with_boundary_hook`](crate::CpuCore::run_for_cycles_with_boundary_hook)
 /// call returned.
 ///
 /// Trap variants have exactly the same CPU/PC state as [`StepResult`]: the
@@ -322,8 +343,8 @@ pub enum CycleBatchExit {
     /// The requested cycle budget was met or crossed at an instruction or
     /// interrupt boundary.
     BudgetExhausted,
-    /// The address bus or instruction-boundary hook requested a return after
-    /// a completed instruction, or the bus requested one after an entry interrupt.
+    /// The address bus or a cycle-boundary hook requested a return after a
+    /// completed instruction or interrupt entry.
     ///
     /// Completed work is included in the result. Interrupt entry contributes
     /// cycles but no retired instruction. This exit takes precedence when the
@@ -360,7 +381,7 @@ pub enum CycleBatchExit {
 }
 
 /// Result of [`CpuCore::run_for_cycles`](crate::CpuCore::run_for_cycles) or
-/// [`CpuCore::run_for_cycles_with_hook`](crate::CpuCore::run_for_cycles_with_hook).
+/// one of its hook-enabled variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CycleBatchResult {
     /// Actual CPU cycles consumed. This may exceed the requested budget

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@
 //! ordering and expose internal-clock gaps through [`AddressBus::sync`].
 //! [`CpuCore::run_for_cycles`] retains cycle accounting with lower dispatch
 //! overhead. [`CpuCore::run_for_cycles_with_hook`] additionally lets a host
-//! synchronize devices and IRQ state between instructions, while
+//! synchronize devices and IRQ state between instructions, and
+//! [`CpuCore::run_for_cycles_with_boundary_hook`] also reports interrupt
+//! entry, while
 //! [`CpuCore::run_batch`] is an instruction-budgeted throughput path that can
 //! use [`FastMem`].
 //!
@@ -64,5 +66,5 @@ pub use core::cpu::{
 pub use core::memory::{AddressBus, FastMem, LinearMemoryBus};
 pub use core::types::{
     BatchExit, BatchResult, CpuType, CycleBatchControl, CycleBatchExit, CycleBatchResult,
-    HleHandler, NoOpHleHandler, Size, StepResult,
+    CycleBoundaryEvent, HleHandler, NoOpHleHandler, Size, StepResult,
 };

--- a/tests/run_for_cycles_tests.rs
+++ b/tests/run_for_cycles_tests.rs
@@ -1,5 +1,6 @@
 use m68k::{
-    AddressBus, CpuCore, CpuType, CycleBatchControl, CycleBatchExit, LinearMemoryBus, StepResult,
+    AddressBus, CpuCore, CpuType, CycleBatchControl, CycleBatchExit, CycleBoundaryEvent,
+    LinearMemoryBus, StepResult,
 };
 
 fn cpu_at(cpu_type: CpuType, pc: u32) -> CpuCore {
@@ -480,6 +481,179 @@ fn entry_interrupt_boundary_does_not_invoke_instruction_hook() {
     });
 
     assert_eq!(hook_calls, 0);
+    assert_eq!(result.cycles, 44);
+    assert_eq!(result.instructions, 0);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.pc, 0x2000);
+}
+
+#[test]
+fn boundary_hook_reports_entry_interrupt_and_resumes_at_handler() {
+    let mut bus = EventBus::new();
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x7001); // handler: MOVEQ #1,D0
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    cpu.set_irq(3);
+    let mut observations = Vec::new();
+
+    let result = cpu.run_for_cycles_with_boundary_hook(&mut bus, 100, |cpu, _, event| {
+        observations.push((event, cpu.pc, cpu.d(0)));
+        CycleBatchControl::Return
+    });
+
+    assert_eq!(
+        observations,
+        vec![(CycleBoundaryEvent::InterruptEntry { cycles: 44 }, 0x2000, 0,)]
+    );
+    assert_eq!(result.cycles, 44);
+    assert_eq!(result.instructions, 0);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+
+    let resumed = cpu.run_for_cycles(&mut bus, 1);
+    assert_eq!(resumed.cycles, 4);
+    assert_eq!(resumed.instructions, 1);
+    assert_eq!(cpu.d(0), 1);
+    assert_eq!(cpu.pc, 0x2002);
+}
+
+#[test]
+fn hook_created_irq_reports_entry_before_the_handler_instruction() {
+    let mut bus = EventBus::new();
+    bus.load_word(0x1000, 0x4E71); // NOP
+    bus.load_word(0x1002, 0x7201); // MOVEQ #1,D1 (must not execute)
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x1210); // handler: MOVE.B (A0),D1
+    bus.load_word(0x2002, 0x4E71);
+    bus.write_byte(0x4000, 0x11);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    cpu.set_a(0, 0x4000);
+    let mut observations = Vec::new();
+
+    let result = cpu.run_for_cycles_with_boundary_hook(&mut bus, 100, |cpu, bus, event| {
+        observations.push((event, cpu.ppc, cpu.pc));
+        match event {
+            CycleBoundaryEvent::Instruction { .. } if cpu.ppc == 0x1000 => {
+                cpu.set_irq(3);
+                CycleBatchControl::Continue
+            }
+            CycleBoundaryEvent::InterruptEntry { .. } => {
+                bus.write_byte(0x4000, 0x7B);
+                CycleBatchControl::Continue
+            }
+            CycleBoundaryEvent::Instruction { .. } => CycleBatchControl::Return,
+        }
+    });
+
+    assert_eq!(
+        observations,
+        vec![
+            (
+                CycleBoundaryEvent::Instruction { cycles: 4 },
+                0x1000,
+                0x1002,
+            ),
+            (
+                CycleBoundaryEvent::InterruptEntry { cycles: 44 },
+                0x1000,
+                0x2000,
+            ),
+            (
+                CycleBoundaryEvent::Instruction { cycles: 8 },
+                0x2000,
+                0x2002,
+            ),
+        ]
+    );
+    assert_eq!(result.cycles, 56);
+    assert_eq!(result.instructions, 2);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.d(1) & 0xFF, 0x7B);
+    assert_eq!(cpu.pc, 0x2002);
+}
+
+#[test]
+fn instruction_boundary_precedes_an_irq_unmasked_by_that_instruction() {
+    let mut bus = EventBus::new();
+    bus.load_word(0x1000, 0x46FC); // MOVE.W #$2000,SR
+    bus.load_word(0x1002, 0x2000); // lower interrupt mask from 3 to 0
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x4E71);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2300); // level 3 remains masked on batch entry
+    cpu.set_irq(3);
+    let mut observations = Vec::new();
+
+    let result = cpu.run_for_cycles_with_boundary_hook(&mut bus, 100, |cpu, _, event| {
+        observations.push((event, cpu.pc));
+        match event {
+            CycleBoundaryEvent::Instruction { .. } => CycleBatchControl::Continue,
+            CycleBoundaryEvent::InterruptEntry { .. } => CycleBatchControl::Return,
+        }
+    });
+
+    assert_eq!(observations.len(), 2);
+    assert!(matches!(
+        observations[0],
+        (CycleBoundaryEvent::Instruction { .. }, 0x1004)
+    ));
+    assert_eq!(
+        observations[1],
+        (CycleBoundaryEvent::InterruptEntry { cycles: 44 }, 0x2000)
+    );
+    assert_eq!(result.instructions, 1);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert_eq!(cpu.pc, 0x2000);
+}
+
+#[test]
+fn stop_that_unmasks_an_irq_reports_only_the_interrupt_boundary() {
+    let mut bus = EventBus::new();
+    bus.load_word(0x1000, 0x4E72); // STOP #$2000
+    bus.load_word(0x1002, 0x2000);
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x4E71);
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2300); // level 3 remains masked on batch entry
+    cpu.set_irq(3);
+    let mut events = Vec::new();
+
+    let result = cpu.run_for_cycles_with_boundary_hook(&mut bus, 100, |_, _, event| {
+        events.push(event);
+        CycleBatchControl::Return
+    });
+
+    assert_eq!(
+        events,
+        vec![CycleBoundaryEvent::InterruptEntry { cycles: 44 }]
+    );
+    assert_eq!(result.instructions, 1);
+    assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);
+    assert!(!cpu.is_stopped());
+    assert_eq!(cpu.pc, 0x2000);
+}
+
+#[test]
+fn entry_bus_request_still_returns_after_the_boundary_event() {
+    let mut bus = EventBus::new();
+    bus.load_long(0x6C, 0x2000); // level-3 autovector
+    bus.load_word(0x2000, 0x4E71);
+    bus.boundary_on_interrupt_acknowledge = true;
+    let mut cpu = cpu_at(CpuType::M68000, 0x1000);
+    cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+    cpu.set_irq(3);
+    let mut events = Vec::new();
+
+    let result = cpu.run_for_cycles_with_boundary_hook(&mut bus, 100, |_, _, event| {
+        events.push(event);
+        CycleBatchControl::Continue
+    });
+
+    assert_eq!(
+        events,
+        vec![CycleBoundaryEvent::InterruptEntry { cycles: 44 }]
+    );
     assert_eq!(result.cycles, 44);
     assert_eq!(result.instructions, 0);
     assert_eq!(result.exit, CycleBatchExit::BoundaryRequested);


### PR DESCRIPTION
## Problem

run_for_cycles_with_hook() reports retired-instruction cycles, but interrupt-entry cycles are only visible in the aggregate result after the batch returns. A host therefore cannot advance timers, DMA, or IRQ state after entry and before the first handler instruction.

## Design

- Add CycleBoundaryEvent with Instruction and InterruptEntry variants, plus run_for_cycles_with_boundary_hook().
- Preserve run_for_cycles_with_hook() and the no-hook fast path; const-generic branches keep hook work compiled out when unused.
- Defer hook-enabled interrupt service until after the instruction event, then emit exact entry cycles before handler execution.
- Preserve zero retirement for interrupt entry, Return/resume semantics, bus-boundary precedence, and STOP behavior.

## Evidence

Regression coverage verifies entry-cycle count, event ordering, host updates before handler execution, hook-created and instruction-unmasked IRQs, STOP-unmasked IRQs, bus-boundary precedence, and resume executing the handler once.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked
- cargo package --locked

Closes #64
