### PR TITLE
perf: continue trace recording through full dispatch

### DIFF
--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -488,6 +488,10 @@ impl CpuCore {
             self.cycles_remaining = i32::MAX / 2;
 
             if retired >= max_instructions {
+                // A full-dispatch instruction may have just extended a path
+                // recording before exhausting this outer batch's budget.
+                // The caller may mutate guest state before the next batch.
+                trace_jit::stop_recording(self);
                 return BatchResult {
                     instructions: retired,
                     exit: BatchExit::BudgetExhausted,
@@ -571,6 +575,10 @@ impl CpuCore {
                 }
             };
             if let Some(exit) = exit {
+                // The caller may emulate a surfaced trap and resume at an
+                // unrelated guest PC. Never let an in-progress path recording
+                // cross that host-controlled execution boundary.
+                trace_jit::stop_recording(self);
                 return BatchResult {
                     instructions: retired,
                     exit,
@@ -582,9 +590,21 @@ impl CpuCore {
             // frame and jumped to the handler; skip trace/interrupt checks
             // for the faulting instruction (mirrors `execute`).
             if self.run_mode == RUN_MODE_BERR_AERR_RESET {
+                // The fault handler is not the sequential continuation of the
+                // instruction being recorded. Discard the partial path before
+                // execution resumes at the exception vector.
+                trace_jit::stop_recording(self);
                 self.run_mode = RUN_MODE_NORMAL;
                 probe_on_entry = true;
             } else {
+                // A complex opcode leaves the decoded fast path and executes
+                // through the full dispatcher above. Offer that successfully
+                // executed instruction to an in-progress trace just as the
+                // decoded paths do. The trace decoder remains the authority
+                // on whether the exact opcode/extension form is safe to
+                // replay; an unsupported operation simply ends recording.
+                trace_jit::record_executed(self, bus, self.ppc, self.pc);
+
                 // Mirrors `execute`: only backward branches can reach a
                 // trace head, so straight-line dispatches re-enter the
                 // fast loop without a trace-cache probe.
@@ -601,6 +621,7 @@ impl CpuCore {
             }
 
             if self.stopped != 0 {
+                trace_jit::stop_recording(self);
                 return BatchResult {
                     instructions: retired,
                     exit: BatchExit::Stopped,
@@ -608,6 +629,9 @@ impl CpuCore {
             }
 
             if !watch_pcs.is_empty() && watch_pcs.contains(&self.pc) {
+                // Match the decoded fast path: a watched-PC return is a host
+                // boundary, so a partial recording cannot survive it.
+                trace_jit::stop_recording(self);
                 return BatchResult {
                     instructions: retired,
                     exit: BatchExit::WatchedPc { pc: self.pc },

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1124,10 +1124,6 @@ impl CpuCore {
                     }
                 }
                 CachedOp::Complex => {
-                    #[cfg(not(feature = "trace-profile"))]
-                    trace_jit::stop_recording(self);
-                    #[cfg(feature = "trace-profile")]
-                    trace_jit::stop_recording_at_blocker(self, self.ppc, opcode);
                     return BatchInnerExit::Miss(opcode);
                 }
             }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -1539,27 +1539,6 @@ pub(crate) fn stop_recording(cpu: &mut CpuCore) {
     }
 }
 
-/// End a recording because the decoded fast loop reached an opcode that it
-/// cannot execute. Profiling builds retain the stranded prefix and blocker;
-/// ordinary builds are identical to `stop_recording`.
-#[cfg(feature = "trace-profile")]
-pub(crate) fn stop_recording_at_blocker(cpu: &mut CpuCore, pc: u32, opcode: u16) {
-    if cpu.trace_recording {
-        TRACE_JIT.with_borrow_mut(|jit| {
-            if let Some(recording) = jit.recording.as_ref() {
-                super::trace_profile::note_blocker(
-                    recording.start_pc,
-                    recording.cpu_type,
-                    recording.ops.len(),
-                    pc,
-                    opcode,
-                );
-            }
-            jit.finish_recording(cpu, pc);
-        });
-    }
-}
-
 /// Note that execution just took a backward branch to `cpu.pc` (a potential
 /// trace head) and return whether the caller should probe the trace cache.
 ///

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -472,7 +472,7 @@ fn cpu_type_from_repr(value: u32) -> CpuType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AddressBus, CpuCore, LinearMemoryBus};
+    use crate::{AddressBus, BatchExit, CpuCore, LinearMemoryBus};
 
     #[test]
     fn report_ranks_stranded_dispatches_not_raw_hits() {
@@ -549,6 +549,98 @@ mod tests {
         #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
         assert!(row.native_calls > 0);
         assert!(row.jit_retired > 0);
+    }
+
+    #[test]
+    fn full_dispatch_instruction_can_complete_a_recorded_loop() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        bus.write_word(0, 0x4C98); // MOVEM.W (A0)+,D1 (full dispatcher)
+        bus.write_word(2, 0x0002);
+        bus.write_word(4, 0x60FA); // BRA.S $0000
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(0, 0x0100);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 120, &[]);
+        assert_eq!(result.instructions, 120);
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("MOVEM loop head was profiled");
+        assert_eq!(row.compiled_ops, 2);
+        assert_eq!(row.blocker_pc, None);
+        assert!(row.jit_retired > 0);
+    }
+
+    fn warm_full_dispatch_recording(cpu: &mut CpuCore, bus: &mut LinearMemoryBus) {
+        bus.write_word(0, 0x4C98); // MOVEM.W (A0)+,D1 (full dispatcher)
+        bus.write_word(2, 0x0002);
+        bus.write_word(4, 0x60FA); // BRA.S $0000
+
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(0, 0x0100);
+        cpu.pc = 0;
+        let result = cpu.run_batch(bus, 4, &[]);
+        assert_eq!(result.exit, BatchExit::BudgetExhausted);
+        assert_eq!(result.instructions, 4);
+        assert_eq!(cpu.pc, 0);
+        assert!(!cpu.trace_recording);
+    }
+
+    #[test]
+    fn budget_exit_ends_recording_after_full_dispatch_instruction() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        let mut cpu = CpuCore::new();
+        warm_full_dispatch_recording(&mut cpu, &mut bus);
+
+        let result = cpu.run_batch(&mut bus, 1, &[]);
+
+        assert_eq!(result.exit, BatchExit::BudgetExhausted);
+        assert_eq!(result.instructions, 1);
+        assert_eq!(cpu.pc, 4);
+        assert!(!cpu.trace_recording);
+    }
+
+    #[test]
+    fn watched_exit_ends_recording_after_full_dispatch_instruction() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        let mut cpu = CpuCore::new();
+        warm_full_dispatch_recording(&mut cpu, &mut bus);
+
+        let result = cpu.run_batch(&mut bus, 10, &[4]);
+
+        assert_eq!(result.exit, BatchExit::WatchedPc { pc: 4 });
+        assert_eq!(result.instructions, 1);
+        assert_eq!(cpu.pc, 4);
+        assert!(!cpu.trace_recording);
+    }
+
+    #[test]
+    fn surfaced_trap_ends_full_dispatch_recording() {
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        bus.write_word(0, 0x5280); // ADDQ.L #1,D0
+        bus.write_word(2, 0x0C80); // CMPI.L #3,D0
+        bus.write_word(4, 0x0000);
+        bus.write_word(6, 0x0003);
+        bus.write_word(8, 0x66F6); // BNE.S $0000 (taken twice)
+        bus.write_word(10, 0xA123); // surfaced A-line trap
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0;
+        let result = cpu.run_batch(&mut bus, 100, &[]);
+
+        assert_eq!(result.exit, BatchExit::AlineTrap { opcode: 0xA123 });
+        assert_eq!(cpu.d(0), 3);
+        assert!(!cpu.trace_recording);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The decoded opcode cache uses `CachedOp::Complex` to mean “execute this instruction through the complete dispatcher.” The trace recorder previously treated that dispatch classification as a hard trace boundary before the instruction ran.

Those are different questions. Some instructions intentionally use the complete dispatcher while the trace decoder and native/portable trace executors already know how to replay their exact form. Stopping at the cache miss made that existing trace support unreachable from real execution paths.

This change:

- lets the complete dispatcher execute the instruction once;
- offers a successfully executed instruction to the trace decoder afterward;
- leaves the trace decoder responsible for accepting or rejecting the exact opcode and extension form; and
- still discards a partial recording before surfaced traps, address/bus-error handler handoffs, or other host-controlled execution boundaries.

The implementation is deliberately general: it does not special-case an opcode or an application.

## Execution model

Before:

```text
decoded cache sees Complex
    -> discard recording
    -> execute through full dispatcher
```

After:

```text
decoded cache sees Complex
    -> execute through full dispatcher
    -> if execution stays in the guest instruction stream:
           ask the existing trace decoder to reconstruct the executed form
           accept it only if that decoder already proves it replayable
       else:
           discard the partial recording
```

This does not make the complete dispatcher itself part of native trace execution. It only repairs the recording handoff so already-supported instructions can be included in a later compiled trace.

## Why this is safe

- An unsupported or unreadable form still makes `decode_trace_op` finish/reject the recording exactly as before.
- Surfaced `BatchExit` values stop recording before control returns to the embedding runtime, which may emulate a trap and resume at an unrelated guest PC.
- Address and bus exceptions stop recording before the CPU resumes at the exception vector.
- The change does not weaken fast-memory checks, self-modifying-code guards, CPU-model checks, or the atomic fallback behavior of individual trace operations.

Regression tests cover both sides of the handoff:

- a `MOVEM.W (A0)+,D1` loop, which uses the complete dispatcher but already has trace support, now compiles and retires natively;
- a surfaced A-line trap terminates an in-progress recording instead of allowing it to cross the host boundary.

## Performance role and measurements

This is an enabling change, not a standalone opcode optimization. A focused compiler-shaped loop confirmed that the repaired handoff produces the expected 10-operation native trace, but alternating throughput runs were neutral/noisy:

- baseline: 47.3–52.5 M instructions/s
- candidate: 46.3–58.3 M instructions/s

That result is expected: once compiled, the benchmark’s inner work was already cheap, so changing how the trace is first recorded does not materially change its steady-state native code.

The practical benefit appears when a hot loop contains an operation that the trace executor can lower but the decoded cache sends through the complete dispatcher. Without this handoff, later opcode-coverage PRs can contain correct native implementations and focused benchmarks yet remain unreachable in the downstream application. The full dependent stack used for EV Override is available here for reviewer testing:

https://github.com/rlanday/m68k-rs/tree/perf/ev-override-integration-stack

That branch contains this handoff together with #59 and the subsequent measured trace-coverage changes. The individual PRs remain separate review units; the integration branch is only a convenient non-circular test target.

## Tests

- `cargo test --features trace-profile --lib` (134 passed)
- `cargo clippy --lib --all-features -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --no-default-features`

`cargo test --all-features` additionally requires the optional Musashi fixture submodule, whose binary fixtures are not present in this worktree. The fixture-independent library test suite above is clean.
