### PR TITLE
perf: JIT brief-indexed memory-source ALU operations

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -923,6 +923,69 @@ fn bench_displacement_address_compare() {
     );
 }
 
+/// Measure a read-only compare through a compiler-shaped brief indexed
+/// address in the middle of an otherwise traceable record loop. Keeping the
+/// surrounding work in the benchmark measures the trace boundary rather than
+/// letting native-call overhead dominate a two-instruction self-loop:
+///
+/// ```c
+/// do {
+///     uint32_t accumulator = seed3 + seed4 + seed5;
+///     if (*(int16_t *)((uint8_t *)records + (int16_t)offset + 4) == value) {
+///         ++accumulator;
+///     }
+/// } while (running);
+/// ```
+fn bench_indexed_value_compare() {
+    const CODE_BASE: u32 = 0x6E00;
+    const INSTRS: u32 = 100_000_000;
+    let words = [
+        0x7600, // MOVEQ #0,D3
+        0x7801, // MOVEQ #1,D4
+        0x7A02, // MOVEQ #2,D5
+        0x7C03, // MOVEQ #3,D6
+        0x7E04, // MOVEQ #4,D7
+        0x2003, // MOVE.L D3,D0
+        0xD084, // ADD.L D4,D0
+        0xD085, // ADD.L D5,D0
+        0xB270, 0x2004, // CMP.W 4(A0,D2.W),D1
+        0x6602, // BNE.S skip increment (recorded not taken)
+        0x5280, // ADDQ.L #1,D0
+        0x60E6, // BRA.S loop
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    bus.write_word_at(0x4206, 0x1234);
+
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(0, 0x4200);
+        cpu.set_a(7, 0xF000);
+        cpu.set_d(1, 0x1234);
+        cpu.set_d(2, 2);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "batch     indexed value compare   {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 /// Measure decoded generic memory operations without allowing a backward
 /// branch to turn the workload into a native JIT loop. Each pass walks the
 /// same straight-line code, retaining the decoded-op cache while resetting
@@ -1038,6 +1101,10 @@ fn main() {
     }
     if only.as_deref() == Some("displacement-address-compare") {
         bench_displacement_address_compare();
+        return;
+    }
+    if only.as_deref() == Some("indexed-value-compare") {
+        bench_indexed_value_compare();
         return;
     }
     if only.as_deref() == Some("immediate-shifts") {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -332,6 +332,71 @@ fn bench_memory_sub_trace() {
     bench_batch_loop_at("batch", "SUB.W d16(A5),D4 p10", &words, 200_000_000, 0x7A00);
 }
 
+/// Measure a compiler-shaped unsigned fixed-point state update. Dividing the
+/// fixed-point values by 256 becomes `LSR.L #8`; updating a field in place
+/// becomes `ADD.L D0,d16(A1)`.
+///
+/// ```c
+/// struct State {
+///     uint8_t *base;
+///     uint32_t step;
+///     uint32_t accumulator;
+///     uint16_t *cursor;
+/// };
+///
+/// state->accumulator += state->step >> 8;
+/// state->cursor = (uint16_t *)(state->base
+///                           + 2 * (state->accumulator >> 8));
+/// ```
+fn bench_fixed_point_state_update() {
+    const CODE_BASE: u32 = 0x7C00;
+    const STATE_BASE: u32 = 0x4000;
+    const INSTRS: u32 = 100_000_000;
+    let words = [
+        0x2029, 0x0010, // MOVE.L 16(A1),D0
+        0xE088, // LSR.L #8,D0
+        0xD1A9, 0x0018, // ADD.L D0,24(A1)
+        0x2029, 0x0018, // MOVE.L 24(A1),D0
+        0xE088, // LSR.L #8,D0
+        0xD080, // ADD.L D0,D0
+        0x2069, 0x0008, // MOVEA.L 8(A1),A0
+        0xD1C0, // ADDA.L D0,A0
+        0x2348, 0x0020, // MOVE.L A0,32(A1)
+        0x60E2, // BRA.S loop
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    bus.write_long(STATE_BASE + 0x08, 0x5000);
+    bus.write_long(STATE_BASE + 0x10, 0x0200);
+    bus.write_long(STATE_BASE + 0x18, 0x0100);
+
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(1, STATE_BASE);
+        cpu.set_a(7, 0xF000);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "batch     fixed-point update      {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 #[derive(Clone, Copy)]
 enum IndirectJsrMix {
     Register,
@@ -985,6 +1050,10 @@ fn main() {
     }
     if only.as_deref() == Some("memory-sub") {
         bench_memory_sub_trace();
+        return;
+    }
+    if only.as_deref() == Some("fixed-point-update") {
+        bench_fixed_point_state_update();
         return;
     }
     if only.as_deref() == Some("indirect-jsr") {

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -425,11 +425,11 @@ impl DecodedSimpleOp {
                 }
                 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
                 {
-                    // Native traces lower the immediate-count shift forms
-                    // exercised by measured hot regions. Keep other variants
-                    // on the decoded interpreter until their flag handling is
-                    // lowered and measured independently.
-                    if !count_is_register && matches!((op, direction), (0, 0) | (1, 1)) {
+                    // Native traces lower the measured immediate-count right
+                    // arithmetic/logical and left logical forms. Keep other
+                    // variants on the decoded interpreter until their flag
+                    // handling is lowered and measured independently.
+                    if !count_is_register && matches!((op, direction), (0, 0) | (1, 0) | (1, 1)) {
                         Some(JitTraceOp::ShiftReg {
                             reg,
                             size,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -350,7 +350,7 @@ pub(crate) enum JitTraceOp {
         src: JitEa,
         dst: u8,
     },
-    /// ADD.W/L Dn,<ea> store/accumulate operations through measured writable
+    /// ADD.W/L Dn,`<ea>` store/accumulate operations through measured writable
     /// address-register-relative forms.
     AddRegToMem {
         size: Size,
@@ -4471,7 +4471,7 @@ fn emit_addr_cmp_mem_to_reg(
     cycles_const(builder, trace.op.max_cycles())
 }
 
-/// Emit ADD.W/L Dn,<ea>. The window, alignment, and self-modification guards
+/// Emit ADD.W/L Dn,`<ea>`. The window, alignment, and self-modification guards
 /// all run before memory, address-register, or flag state is changed.
 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
 fn emit_add_reg_to_mem(

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -329,7 +329,8 @@ pub(crate) enum JitTraceOp {
         cycles: i32,
     },
     /// Read-only ALU operation from fast memory to a data register. The
-    /// decoder admits measured CMP/ADD/SUB `(An)`/`d16(An)` sources.
+    /// decoder admits measured CMP/ADD/SUB `(An)`/`d16(An)`/`d8(An,Xn)`
+    /// sources.
     AluMemToReg {
         op: JitBinaryOp,
         size: Size,
@@ -2359,9 +2360,9 @@ fn decode_add_reg_to_mem_trace_op<B: AddressBus>(
     })
 }
 
-/// CMP/ADD/SUB `<ea>,Dn` for indirect and displacement source forms. The
-/// access itself is emitted against the fastmem window; the extension word
-/// is captured for validation and displacement baking.
+/// CMP/ADD/SUB `<ea>,Dn` for indirect, displacement, and brief-indexed source
+/// forms. The access itself is emitted against the fastmem window; extension
+/// words are captured for validation and decoded once while recording.
 fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
     cpu: &CpuCore,
     bus: &mut B,
@@ -2384,6 +2385,13 @@ fn decode_alu_mem_to_reg_trace_op<B: AddressBus>(
         FastEa::AnDisp(reg) => {
             let displacement = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
             (JitEa::Disp(reg, displacement as i16), Some(displacement))
+        }
+        FastEa::AnIndex(reg) => {
+            let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (
+                decode_jit_ea(6, u16::from(reg), extension, cpu_type)?,
+                Some(extension),
+            )
         }
         _ => return None,
     };
@@ -2745,6 +2753,7 @@ fn execute_portable_alu_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) -> Op
     let src = match src {
         JitEa::Ind(reg) => FastEa::AnInd(reg),
         JitEa::Disp(reg, _) => FastEa::AnDisp(reg),
+        JitEa::Index { base, .. } => FastEa::AnIndex(base),
         _ => return None,
     };
     let old_pc = cpu.pc;
@@ -4364,15 +4373,36 @@ fn emit_alu_mem_to_reg(
         at,
     });
 
-    let base_reg = match src {
-        JitEa::Ind(reg) | JitEa::Disp(reg, _) => reg,
-        _ => unreachable!("ALU trace decoder only admits (An) and d16(An)"),
-    };
-    let base = load_reg(builder, cpu, JitDirectReg::Addr(base_reg));
     let addr = match src {
-        JitEa::Ind(_) => base,
-        JitEa::Disp(_, displacement) => builder.ins().iadd_imm(base, displacement as i64),
-        _ => unreachable!(),
+        JitEa::Ind(reg) => load_reg(builder, cpu, JitDirectReg::Addr(reg)),
+        JitEa::Disp(reg, displacement) => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+            builder.ins().iadd_imm(base, displacement as i64)
+        }
+        JitEa::Index {
+            base,
+            index,
+            index_long,
+            scale,
+            displacement,
+        } => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
+            let raw_index = load_reg(builder, cpu, index);
+            let index = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index = if scale == 0 {
+                index
+            } else {
+                builder.ins().ishl_imm(index, i64::from(scale))
+            };
+            let address = builder.ins().iadd(base, index);
+            builder.ins().iadd_imm(address, displacement as i64)
+        }
+        _ => unreachable!("ALU trace decoder admitted an unsupported EA"),
     };
     let (off, _) = checked_window_off(builder, env, bail, addr, size);
     let src_value = window_load(builder, env, off, size);
@@ -6102,6 +6132,26 @@ mod portable_tests {
             }
         ));
 
+        mem.write_word(0x0100, 0xB270); // CMP.W $04(A0,D2.W),D1
+        mem.write_word(0x0102, 0x2004);
+        let indexed = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68040).unwrap();
+        assert_eq!(indexed.extension, Some(0x2004));
+        assert!(matches!(
+            indexed.op,
+            JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                },
+                dst: 1,
+            }
+        ));
+
         mem.write_word(0x0100, 0xB7E9); // CMPA.L $0010(A1),A3
         mem.write_word(0x0102, 0x0010);
         let address_compare = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68040).unwrap();
@@ -6289,6 +6339,122 @@ mod portable_tests {
         assert!(execute_portable_op(&mut cpu, op, 0x0100, 0x0102).is_some());
         assert_eq!(cpu.d(1), 0x1234_567F, "CMP does not write its destination");
         assert_eq!(cpu.get_ccr(), 0x1B, "X/N/V/C set and Z clear");
+    }
+
+    #[test]
+    fn portable_cmp_indexed_sets_flags_without_changing_registers() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0x2004u16.to_be_bytes());
+        mem[0x0206..0x0208].copy_from_slice(&0x8000u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(0, 0x0200);
+        cpu.set_d(1, 0x1234_7FFF);
+        cpu.set_d(2, 2);
+        cpu.set_ccr(0x10); // X set; CMP must preserve it.
+
+        let op = TraceBuildOp {
+            opcode: 0xB270,
+            extension: Some(0x2004),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                },
+                dst: 1,
+            },
+        };
+        assert_eq!(execute_portable_op(&mut cpu, op, 0x0100, 0x0104), Some(24));
+        assert_eq!(cpu.a(0), 0x0200);
+        assert_eq!(cpu.d(1), 0x1234_7FFF);
+        assert_eq!(cpu.d(2), 2);
+        assert_eq!(cpu.pc, 0x0104);
+        assert_eq!(cpu.get_ccr(), 0x1B, "X/N/V/C set and Z clear");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_cmp_indexed_matches_portable_and_bails_atomically() {
+        let cmp = TraceBuildOp {
+            opcode: 0xB270,
+            extension: Some(0x2004),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                },
+                dst: 1,
+            },
+        };
+        let branch = TraceBuildOp {
+            opcode: 0x60FA,
+            extension: None,
+            extension2: None,
+            pc: 0x0104,
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -6,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+        let ops = vec![cmp, branch];
+
+        let prepare = |mem: &mut [u8]| {
+            mem[0x0102..0x0104].copy_from_slice(&0x2004u16.to_be_bytes());
+            mem[0x0206..0x0208].copy_from_slice(&0x8000u16.to_be_bytes());
+            let mut cpu = cpu();
+            attach_window(&mut cpu, mem);
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_a(0, 0x0200);
+            cpu.set_d(1, 0x1234_7FFF);
+            cpu.set_d(2, 2);
+            cpu.set_ccr(0x10);
+            cpu
+        };
+
+        let mut expected_mem = vec![0u8; 0x1000];
+        let mut expected = prepare(&mut expected_mem);
+        let expected_packed = execute_portable_trace(&mut expected, &ops, 0x0100, 0x0106);
+
+        let mut actual_mem = vec![0u8; 0x1000];
+        let mut actual = prepare(&mut actual_mem);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&actual, 0x0100, CpuType::M68040, ops, Some(0x0100))
+            .expect("indexed CMP loop should compile");
+        let actual_packed = unsafe { compiled.call_native(&mut actual, 1) };
+        assert_eq!(actual_packed, expected_packed);
+        assert_eq!(actual.pc, expected.pc);
+        assert_eq!(actual.dar, expected.dar);
+        assert_eq!(actual.get_ccr(), expected.get_ccr());
+
+        actual.pc = 0x0100;
+        actual.set_a(0, 0x0FFE); // indexed word read falls outside the window
+        actual.set_d(1, 0x1234_7FFF);
+        actual.set_d(2, 2);
+        actual.set_ccr(0x10);
+        let before = actual.dar;
+        let packed = unsafe { compiled.call_native(&mut actual, 1) };
+        assert_eq!(packed, 0, "bail retires no instructions or cycles");
+        assert_eq!(actual.pc, 0x0100);
+        assert_eq!(actual.dar, before);
+        assert_eq!(actual.get_ccr(), 0x10);
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -349,11 +349,12 @@ pub(crate) enum JitTraceOp {
         src: JitEa,
         dst: u8,
     },
-    /// ADD.W/L Dn,(An)+ store/accumulate operations.
-    AddRegToPostInc {
+    /// ADD.W/L Dn,<ea> store/accumulate operations through measured writable
+    /// address-register-relative forms.
+    AddRegToMem {
         size: Size,
         src: u8,
-        dst: u8,
+        dst: JitEa,
     },
     /// Displacement-memory forms that require extension words, represented
     /// explicitly rather than through the register-only trace operations.
@@ -1129,7 +1130,7 @@ impl TraceJit {
                     | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::TstMem { .. }
                     | JitTraceOp::AddrCmpMemToReg { .. }
-                    | JitTraceOp::AddRegToPostInc { .. }
+                    | JitTraceOp::AddRegToMem { .. }
                     | JitTraceOp::AnDispUnary { .. }
                     | JitTraceOp::MemAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
@@ -1353,18 +1354,9 @@ impl TraceJit {
                             bail_at,
                         )
                     }
-                    JitTraceOp::AddRegToPostInc { .. } => {
-                        let env = mem_env
-                            .as_ref()
-                            .expect("AddRegToPostInc implies a window env");
-                        emit_add_reg_to_postinc(
-                            &mut builder,
-                            cpu_ptr,
-                            *op,
-                            env,
-                            &mut bails,
-                            bail_at,
-                        )
+                    JitTraceOp::AddRegToMem { .. } => {
+                        let env = mem_env.as_ref().expect("AddRegToMem implies a window env");
+                        emit_add_reg_to_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
                     JitTraceOp::IndirectJsr { reg } => {
                         let env = mem_env.as_ref().expect("IndirectJsr implies a window env");
@@ -1786,13 +1778,12 @@ impl JitTraceOp {
                 }
             }
             Self::AddrCmpMemToReg { .. } => 24,
-            Self::AddRegToPostInc { size, .. } => {
-                if size == Size::Long {
-                    20
-                } else {
-                    12
-                }
-            }
+            Self::AddRegToMem { size, dst, .. } => match (size, dst) {
+                (Size::Long, JitEa::Disp(_, _)) => 24,
+                (Size::Long, _) => 20,
+                (_, JitEa::Disp(_, _)) => 16,
+                _ => 12,
+            },
             Self::IndirectJsr { .. } => 16,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
@@ -1855,7 +1846,7 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_addr_cmp_mem_to_reg_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
-    if let Some(op) = decode_add_reg_to_postinc_trace_op(pc, opcode, cpu_type) {
+    if let Some(op) = decode_add_reg_to_mem_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_movem_word_postinc_trace_op(cpu, bus, pc, opcode) {
@@ -2332,7 +2323,9 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
-fn decode_add_reg_to_postinc_trace_op(
+fn decode_add_reg_to_mem_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
     pc: u32,
     opcode: u16,
     cpu_type: CpuType,
@@ -2341,7 +2334,7 @@ fn decode_add_reg_to_postinc_trace_op(
         op: BinaryOp::Add,
         size,
         src,
-        dst: FastEa::AnPostInc(dst),
+        dst,
     } = DecodedMemOp::decode(cpu_type, opcode)?
     else {
         return None;
@@ -2349,12 +2342,20 @@ fn decode_add_reg_to_postinc_trace_op(
     if !matches!(size, Size::Word | Size::Long) {
         return None;
     }
+    let (dst, extension) = match dst {
+        FastEa::AnPostInc(reg) => (JitEa::PostInc(reg), None),
+        FastEa::AnDisp(reg) => {
+            let displacement = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (JitEa::Disp(reg, displacement as i16), Some(displacement))
+        }
+        _ => return None,
+    };
     Some(TraceBuildOp {
         opcode,
-        extension: None,
+        extension,
         extension2: None,
         pc,
-        op: JitTraceOp::AddRegToPostInc { size, src, dst },
+        op: JitTraceOp::AddRegToMem { size, src, dst },
     })
 }
 
@@ -2533,8 +2534,8 @@ fn execute_portable_op(
     if matches!(op.op, JitTraceOp::AddrCmpMemToReg { .. }) {
         return execute_portable_addr_cmp_mem_to_reg(cpu, op);
     }
-    if matches!(op.op, JitTraceOp::AddRegToPostInc { .. }) {
-        return execute_portable_add_reg_to_postinc(cpu, op, code_start, code_end);
+    if matches!(op.op, JitTraceOp::AddRegToMem { .. }) {
+        return execute_portable_add_reg_to_mem(cpu, op, code_start, code_end);
     }
     if matches!(op.op, JitTraceOp::MemAddqSubq { .. }) {
         return execute_portable_mem_addq_subq(cpu, op, code_start, code_end);
@@ -2804,16 +2805,23 @@ fn execute_portable_addr_cmp_mem_to_reg(cpu: &mut CpuCore, trace: TraceBuildOp) 
 }
 
 #[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
-fn execute_portable_add_reg_to_postinc(
+fn execute_portable_add_reg_to_mem(
     cpu: &mut CpuCore,
     trace: TraceBuildOp,
     code_start: u32,
     code_end: u32,
 ) -> Option<i32> {
-    let JitTraceOp::AddRegToPostInc { size, src, dst } = trace.op else {
+    let JitTraceOp::AddRegToMem { size, src, dst } = trace.op else {
         return None;
     };
-    let raw = cpu.dar[8 + dst as usize];
+    let (reg, raw) = match dst {
+        JitEa::PostInc(reg) => (reg, cpu.dar[8 + reg as usize]),
+        JitEa::Disp(reg, displacement) => (
+            reg,
+            cpu.dar[8 + reg as usize].wrapping_add(displacement as i32 as u32),
+        ),
+        _ => return None,
+    };
     let masked = raw & cpu.address_mask;
     if masked < code_end && masked.wrapping_add(size.bytes()) > code_start {
         return None;
@@ -2826,7 +2834,11 @@ fn execute_portable_add_reg_to_postinc(
             op: BinaryOp::Add,
             size,
             src,
-            dst: FastEa::AnPostInc(dst),
+            dst: match dst {
+                JitEa::PostInc(_) => FastEa::AnPostInc(reg),
+                JitEa::Disp(_, _) => FastEa::AnDisp(reg),
+                _ => unreachable!(),
+            },
         },
     ) {
         Some(trace.op.max_cycles())
@@ -3476,8 +3488,8 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is handled by execute_portable_addr_cmp_mem_to_reg")
         }
-        JitTraceOp::AddRegToPostInc { .. } => {
-            unreachable!("AddRegToPostInc is handled by execute_portable_add_reg_to_postinc")
+        JitTraceOp::AddRegToMem { .. } => {
+            unreachable!("AddRegToMem is handled by execute_portable_add_reg_to_mem")
         }
         JitTraceOp::MemAddqSubq { .. } => {
             unreachable!("MemAddqSubq is handled by execute_portable_mem_addq_subq")
@@ -3944,7 +3956,9 @@ fn emit_jit_op(
             direction,
             op,
         } => {
-            debug_assert!(!count_is_register && matches!((op, direction), (0, 0) | (1, 1)));
+            debug_assert!(
+                !count_is_register && matches!((op, direction), (0, 0) | (1, 0) | (1, 1))
+            );
             let shift = if count_or_reg == 0 {
                 8
             } else {
@@ -3963,6 +3977,16 @@ fn emit_jit_op(
                     let shifted_out = if shift >= bits {
                         let msb = iconst_u32(builder, size_msb(size));
                         builder.ins().band(value, msb)
+                    } else {
+                        let bit = iconst_u32(builder, 1u32 << (shift - 1));
+                        builder.ins().band(value, bit)
+                    };
+                    (result, shifted_out)
+                }
+                (1, 0) => {
+                    let result = builder.ins().ushr_imm(value, i64::from(shift));
+                    let shifted_out = if shift > bits {
+                        iconst_u32(builder, 0)
                     } else {
                         let bit = iconst_u32(builder, 1u32 << (shift - 1));
                         builder.ins().band(value, bit)
@@ -4011,8 +4035,8 @@ fn emit_jit_op(
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is emitted by emit_addr_cmp_mem_to_reg")
         }
-        JitTraceOp::AddRegToPostInc { .. } => {
-            unreachable!("AddRegToPostInc is emitted by emit_add_reg_to_postinc")
+        JitTraceOp::AddRegToMem { .. } => {
+            unreachable!("AddRegToMem is emitted by emit_add_reg_to_mem")
         }
         JitTraceOp::MemAddqSubq { .. } => {
             unreachable!("MemAddqSubq is emitted by emit_mem_addq_subq")
@@ -4417,10 +4441,10 @@ fn emit_addr_cmp_mem_to_reg(
     cycles_const(builder, trace.op.max_cycles())
 }
 
-/// Emit ADD.W/L Dn,(An)+. The window, alignment, and self-modification
-/// guards all run before memory, address-register, or flag state is changed.
+/// Emit ADD.W/L Dn,<ea>. The window, alignment, and self-modification guards
+/// all run before memory, address-register, or flag state is changed.
 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
-fn emit_add_reg_to_postinc(
+fn emit_add_reg_to_mem(
     builder: &mut FunctionBuilder<'_>,
     cpu: Value,
     trace: TraceBuildOp,
@@ -4428,8 +4452,8 @@ fn emit_add_reg_to_postinc(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::AddRegToPostInc { size, src, dst } = trace.op else {
-        unreachable!("expected register-to-postincrement ADD trace")
+    let JitTraceOp::AddRegToMem { size, src, dst } = trace.op else {
+        unreachable!("expected register-to-memory ADD trace")
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -4438,7 +4462,20 @@ fn emit_add_reg_to_postinc(
         at,
     });
 
-    let addr = load_reg(builder, cpu, JitDirectReg::Addr(dst));
+    let (reg, addr, next) = match dst {
+        JitEa::PostInc(reg) => {
+            let addr = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+            let next = builder
+                .ins()
+                .iadd_imm(addr, i64::from(jit_ea_step(size, reg)));
+            (reg, addr, Some(next))
+        }
+        JitEa::Disp(reg, displacement) => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+            (reg, builder.ins().iadd_imm(base, displacement as i64), None)
+        }
+        _ => unreachable!("unsupported register-to-memory ADD destination"),
+    };
     let (off, masked) = checked_window_off(builder, env, bail, addr, size);
     guard_store_not_code(builder, env, bail, masked, size);
     let dst_value = window_load(builder, env, off, size);
@@ -4447,10 +4484,9 @@ fn emit_add_reg_to_postinc(
     let result = builder.ins().iadd(dst_value, src_value);
 
     window_store(builder, env, off, size, result);
-    let next = builder
-        .ins()
-        .iadd_imm(addr, i64::from(jit_ea_step(size, dst)));
-    store_reg(builder, cpu, JitDirectReg::Addr(dst), next);
+    if let Some(next) = next {
+        store_reg(builder, cpu, JitDirectReg::Addr(reg), next);
+    }
     set_add_flags(builder, cpu, src_value, dst_value, result, size);
     cycles_const(builder, trace.op.max_cycles())
 }
@@ -6136,6 +6172,40 @@ mod portable_tests {
     }
 
     #[test]
+    fn decodes_fixed_point_update_operations() {
+        let cpu = cpu();
+        let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
+
+        mem.write_word(0x0100, 0xE088); // LSR.L #8,D0
+        let shift = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68040).unwrap();
+        assert_eq!(shift.extension, None);
+        assert!(matches!(
+            shift.op,
+            JitTraceOp::ShiftReg {
+                reg: 0,
+                size: Size::Long,
+                count_or_reg: 0,
+                count_is_register: false,
+                direction: 0,
+                op: 1,
+            }
+        ));
+
+        mem.write_word(0x0100, 0xD1A9); // ADD.L D0,$0018(A1)
+        mem.write_word(0x0102, 0x0018);
+        let add = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68040).unwrap();
+        assert_eq!(add.extension, Some(0x0018));
+        assert!(matches!(
+            add.op,
+            JitTraceOp::AddRegToMem {
+                size: Size::Long,
+                src: 0,
+                dst: JitEa::Disp(1, 0x0018),
+            }
+        ));
+    }
+
+    #[test]
     fn decodes_indirect_jsr_trace_boundary() {
         let cpu = cpu();
         let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
@@ -7406,6 +7476,282 @@ mod portable_tests {
                 assert_eq!(actual.ir, 0x60FC);
             }
         }
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_immediate_lsr_matches_interpreter() {
+        let cases = [
+            (Size::Byte, 1u8, 0xA5A5_5581u32),
+            (Size::Byte, 7, 0xA5A5_557Fu32),
+            (Size::Byte, 0, 0xA5A5_5580u32), // encoded zero means eight
+            (Size::Word, 1, 0xA5A5_8001u32),
+            (Size::Word, 4, 0xA5A5_7FF0u32),
+            (Size::Word, 0, 0xA5A5_8100u32),
+            (Size::Long, 1, 0x8000_0001u32),
+            (Size::Long, 5, 0x7FFF_FFE0u32),
+            (Size::Long, 0, 0x8100_0080u32),
+        ];
+
+        for cpu_type in [CpuType::M68000, CpuType::M68040] {
+            for (size, encoded_count, initial) in cases {
+                let shift = if encoded_count == 0 {
+                    8
+                } else {
+                    u32::from(encoded_count)
+                };
+                let size_code = match size {
+                    Size::Byte => 0,
+                    Size::Word => 1,
+                    Size::Long => 2,
+                };
+                let opcode = 0xE008 | (u16::from(encoded_count) << 9) | (size_code << 6);
+                let ops = vec![
+                    TraceBuildOp {
+                        opcode,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0100,
+                        op: JitTraceOp::ShiftReg {
+                            reg: 0,
+                            size,
+                            count_or_reg: encoded_count,
+                            count_is_register: false,
+                            direction: 0,
+                            op: 1,
+                        },
+                    },
+                    TraceBuildOp {
+                        opcode: 0x60FC,
+                        extension: None,
+                        extension2: None,
+                        pc: 0x0102,
+                        op: JitTraceOp::Branch {
+                            condition: 0,
+                            displacement: -4,
+                            length: 2,
+                            expected_taken: None,
+                        },
+                    },
+                ];
+
+                let mut expected = cpu();
+                expected.set_cpu_type(cpu_type);
+                expected.set_d(0, initial);
+                expected.set_ccr(0x1F);
+                let (result, shift_cycles) = expected.exec_lsr(size, shift, initial & size.mask());
+                expected.set_d(0, (initial & !size.mask()) | result);
+
+                let mut actual = cpu();
+                actual.set_cpu_type(cpu_type);
+                actual.set_d(0, initial);
+                actual.set_ccr(0x1F);
+                let mut jit = TraceJit::new();
+                let compiled = jit
+                    .compile_decoded_ops(&actual, 0x0100, cpu_type, ops, Some(0x0100))
+                    .expect("native LSR loop should compile");
+                let packed = unsafe { compiled.call_native(&mut actual, 1) };
+
+                assert_eq!((packed >> 32) as u32, 2, "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    packed as u32 as i32,
+                    shift_cycles + 10,
+                    "{cpu_type:?} {size:?} #{shift} cycles"
+                );
+                assert_eq!(actual.d(0), expected.d(0), "{cpu_type:?} {size:?} #{shift}");
+                assert_eq!(
+                    actual.get_ccr(),
+                    expected.get_ccr(),
+                    "{cpu_type:?} {size:?} #{shift} flags"
+                );
+                assert_eq!(actual.pc, 0x0100);
+                assert_eq!(actual.ppc, 0x0102);
+                assert_eq!(actual.ir, 0x60FC);
+            }
+        }
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_fixed_point_update_loop_matches_portable_and_bails_atomically() {
+        // A compiler can use this fixed-point state update to avoid division:
+        //
+        //   state->accumulator += state->step >> 8;
+        //   state->cursor = state->base + 2 * (state->accumulator >> 8);
+        //
+        // The trace includes both newly admitted operations: LSR.L #8,D0 and
+        // ADD.L D0,d16(A1). The remaining instructions were already admitted.
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x2029, // MOVE.L $0010(A1),D0
+                extension: Some(0x0010),
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Long,
+                    src: JitEa::Disp(1, 0x0010),
+                    dst: JitEa::Data(0),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0xE088, // LSR.L #8,D0
+                extension: None,
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::ShiftReg {
+                    reg: 0,
+                    size: Size::Long,
+                    count_or_reg: 0,
+                    count_is_register: false,
+                    direction: 0,
+                    op: 1,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0xD1A9, // ADD.L D0,$0018(A1)
+                extension: Some(0x0018),
+                extension2: None,
+                pc: 0x0106,
+                op: JitTraceOp::AddRegToMem {
+                    size: Size::Long,
+                    src: 0,
+                    dst: JitEa::Disp(1, 0x0018),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x2029, // MOVE.L $0018(A1),D0
+                extension: Some(0x0018),
+                extension2: None,
+                pc: 0x010A,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Long,
+                    src: JitEa::Disp(1, 0x0018),
+                    dst: JitEa::Data(0),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0xE088, // LSR.L #8,D0
+                extension: None,
+                extension2: None,
+                pc: 0x010E,
+                op: JitTraceOp::ShiftReg {
+                    reg: 0,
+                    size: Size::Long,
+                    count_or_reg: 0,
+                    count_is_register: false,
+                    direction: 0,
+                    op: 1,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0xD080, // ADD.L D0,D0
+                extension: None,
+                extension2: None,
+                pc: 0x0110,
+                op: JitTraceOp::BinaryDataReg {
+                    op: JitBinaryOp::Add,
+                    src: JitDirectReg::Data(0),
+                    dst: 0,
+                    size: Size::Long,
+                    cycles: 6,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x2069, // MOVEA.L $0008(A1),A0
+                extension: Some(0x0008),
+                extension2: None,
+                pc: 0x0112,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Long,
+                    src: JitEa::Disp(1, 0x0008),
+                    dst: JitEa::Addr(0),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0xD1C0, // ADDA.L D0,A0
+                extension: None,
+                extension2: None,
+                pc: 0x0116,
+                op: JitTraceOp::AddrDataReg {
+                    op: JitAddrOp::Adda,
+                    src: JitDirectReg::Data(0),
+                    dst: 0,
+                    size: Size::Long,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x2348, // MOVE.L A0,$0020(A1)
+                extension: Some(0x0020),
+                extension2: None,
+                pc: 0x0118,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Long,
+                    src: JitEa::Addr(0),
+                    dst: JitEa::Disp(1, 0x0020),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x60E2, // BRA.S $0100
+                extension: None,
+                extension2: None,
+                pc: 0x011C,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -30,
+                    length: 2,
+                    expected_taken: None,
+                },
+            },
+        ];
+
+        let prepare = || {
+            let mut cpu = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            for op in &ops {
+                let pc = op.pc as usize;
+                mem[pc..pc + 2].copy_from_slice(&op.opcode.to_be_bytes());
+                if let Some(extension) = op.extension {
+                    mem[pc + 2..pc + 4].copy_from_slice(&extension.to_be_bytes());
+                }
+            }
+            attach_window(&mut cpu, &mut mem);
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_a(1, 0x0300);
+            mem[0x0308..0x030C].copy_from_slice(&0x0000_0500u32.to_be_bytes());
+            mem[0x0310..0x0314].copy_from_slice(&0x0000_0200u32.to_be_bytes());
+            mem[0x0318..0x031C].copy_from_slice(&0x0000_0100u32.to_be_bytes());
+            (cpu, mem)
+        };
+
+        let (mut expected, expected_mem) = prepare();
+        let expected_packed = execute_portable_trace(&mut expected, &ops, 0x0100, 0x011E);
+
+        let (mut actual, actual_mem) = prepare();
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&actual, 0x0100, CpuType::M68040, ops, Some(0x0100))
+            .expect("fixed-point update loop should compile");
+        let actual_packed = unsafe { compiled.call_native(&mut actual, 1) };
+
+        assert_eq!(actual_packed, expected_packed);
+        assert_eq!(&actual_mem[0x0318..0x031C], &expected_mem[0x0318..0x031C]);
+        assert_eq!(&actual_mem[0x0320..0x0324], &expected_mem[0x0320..0x0324]);
+        assert_eq!(&actual_mem[0x0318..0x031C], &0x0000_0102u32.to_be_bytes());
+        assert_eq!(&actual_mem[0x0320..0x0324], &0x0000_0502u32.to_be_bytes());
+        assert_eq!(actual.d(0), expected.d(0));
+        assert_eq!(actual.a(0), expected.a(0));
+        assert_eq!(actual.get_ccr(), expected.get_ccr());
+        assert_eq!(actual.pc, 0x0100);
+
+        actual.set_a(1, 0x00FF_FFE8); // accumulator address wraps outside the window
+        actual.set_d(0, 0xDEAD_BEEF);
+        actual.set_ccr(0x15);
+        actual.pc = 0x0100;
+        let packed = unsafe { compiled.call_native(&mut actual, 1) };
+        assert_eq!(packed, 0, "bail retires no instructions or cycles");
+        assert_eq!(actual.pc, 0x0100);
+        assert_eq!(actual.d(0), 0xDEAD_BEEF);
+        assert_eq!(actual.get_ccr(), 0x15);
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]


### PR DESCRIPTION
## Summary

Extend the trace JIT's existing read-only ALU memory-source path to admit brief-indexed sources (`d8(An,Xn)`) for the measured `CMP/ADD/SUB <ea>,Dn` forms.

This is a stacked follow-up to #68. The source
changes address a different instruction family and hot loop, but controlled
EV Override sampling found the whole-application improvement to be measurable
only when both are present. The performance section reports both the focused
benchmark against that exact base and the incremental application effect.

EV Override exposed a hot record scan containing `CMP.W 4(A0,D2.W),D1`. The rest of the loop was already traceable, so this single unsupported memory source repeatedly split a roughly 30-instruction dynamic trace.

The source remains generic and contains no application-specific matching.

## Generated-code shape

This is the kind of indexed record lookup a C or Pascal compiler emits:

```c
do {
    uint32_t accumulator = seed3 + seed4 + seed5;
    int16_t field = *(int16_t *)((uint8_t *)records + (int16_t)offset + 4);
    if (field == value) {
        ++accumulator;
    }
} while (running);
```

The relevant instruction is:

```asm
CMP.W  4(A0,D2.W),D1
```

The implementation decodes the brief-index extension once while recording, then emits native address calculation for word- or long-sized index registers, scale, and signed 8-bit displacement. The memory access still uses the existing fast-memory guards.

## Relationship to #59

#59 made a packed lookup-table generator traceable, including the indexed operations used by that specific loop. It did not admit an indexed source for the general `CMP/ADD/SUB <ea>,Dn` trace operation.

This PR reuses the same generic `JitEa::Index` representation for a different instruction family and a different hot loop. The `guarded-indexed-scan` benchmark from #59 is already fast on current master and does not improve here; the new `indexed-value-compare` benchmark isolates this remaining boundary.

Lemmings did not need this change because its profiled hot traces did not repeatedly execute the indexed memory-source compare form. In the EV Override profile, opcode `B270` executed about 1.06 million times, with the two hottest sites accounting for roughly 479,000 executions each. With this change the relevant trace retired about 14.4 million guest instructions over 480,000 native calls (about 30.1 instructions/call).

## Correctness and safety

- Sign-extend word index registers; preserve long index registers.
- Apply the brief extension's scale and signed displacement exactly once.
- Capture the extension word for trace validation.
- Preserve CMP's destination registers and X flag while setting N/Z/V/C normally.
- Use the existing checked fast-memory window.
- Bail atomically on an out-of-window access, retiring no instruction or cycles and changing no architectural state.
- Provide both portable-trace and native-JIT execution.

## Performance

Measured against the fixed-point state-update base (`1fd6549`) rather than
against `master`. The baseline worktree contains the identical committed
benchmark but none of this PR's implementation. Both trees used release builds
with the native JIT explicitly enabled:

```text
cargo build --release --bench microbench --features jit
microbench indexed-value-compare
```

Five alternating runs, M guest instructions/s:

| Run | fixed-point base | this PR |
|---:|---:|---:|
| 1 | 42.2 | 396.9 |
| 2 | 42.4 | 422.6 |
| 3 | 46.9 | 424.6 |
| 4 | 44.1 | 422.7 |
| 5 | 45.2 | 445.0 |
| **Median** | **44.1** | **422.7** |

That is a **9.59x** focused-loop speedup over the actual PR base.

For the application ablation, four Systemless release binaries used identical
host source, archive/save snapshots, and stationary EV Override gameplay. Two
consecutive 30-second `sample` runs per build were normalized against all
main-thread observations:

| Build | Active event loop | 68k runner |
|---|---:|---:|
| fixed-point base | 18.91% | 6.11% |
| fixed-point + this PR | 18.04% | 5.75% |

This PR therefore contributes an incremental **4.6% reduction in active
event-loop work** and **5.9% reduction in 68k-runner work** on top of its base.

The indexed-only build did not show an application-level improvement in this
stationary scene, even though the focused loop became much faster. That is why
this is a stacked follow-up: the measured whole-application benefit is the
combined trace coverage, not an unsupported claim that this one opcode family
alone lowers EV Override's total CPU use.

The already-merged #59 and full-dispatch recording work are present in both measurements and are not credited to this PR.

## Validation

- `cargo test --features trace-profile --lib` — 143 passed on the complete stack
- `cargo clippy --all-features --lib --benches -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- decode coverage for the brief-index extension
- portable CMP state/flag coverage
- native-versus-portable parity and atomic out-of-window bailout coverage

`cargo clippy --all-targets` additionally attempts to compile the repository's
Musashi integration tests; this checkout does not have their binary-fixture
submodule initialized, so that broader invocation stops on missing
`include_bytes!` inputs rather than on a Clippy diagnostic.
