### PR TITLE
feat: report exact trace recording paths

### DIFF
--- a/src/core/mem_ops.rs
+++ b/src/core/mem_ops.rs
@@ -1323,6 +1323,17 @@ fn store(cpu: &mut CpuCore, win: Win, loc: &Loc, size: Size, value: u32) {
 /// Returns `false` (with zero state changes) when the op must fall back to
 /// full dispatch: window misses, pre-68020 misaligned accesses, 68020+
 /// full-format extensions, or no window at all.
+/// Side-effect-free diagnostic read of a guest word through the attached
+/// fastmem window. Returns `None` when no window is attached or the address
+/// is outside it. The `AddressBus` is never involved, so callers cannot add
+/// host-visible bus transactions.
+#[cfg(feature = "trace-profile")]
+pub(crate) fn peek_window_word(cpu: &CpuCore, addr: u32) -> Option<u16> {
+    let win = Win::from_cpu(cpu)?;
+    let off = win.off(cpu.address(addr), 2)?;
+    Some(win.read(off, Size::Word) as u16)
+}
+
 pub(crate) fn execute_mem_op(cpu: &mut CpuCore, op: DecodedMemOp) -> bool {
     let Some(win) = Win::from_cpu(cpu) else {
         return false;

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -960,7 +960,16 @@ impl TraceJit {
         let cpu_type = recording.cpu_type;
         let adaptive_rerecords = recording.adaptive_rerecords;
         #[cfg(feature = "trace-profile")]
-        let recorded_ops = recording.ops.len();
+        let recorded_shape = recording
+            .ops
+            .iter()
+            .map(|op| super::trace_profile::TraceShapeOp {
+                pc: op.pc,
+                opcode: op.opcode,
+                extension: op.extension,
+                extension2: op.extension2,
+            })
+            .collect();
         self.slots[idx] =
             match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
                 Some(mut trace) => {
@@ -980,7 +989,7 @@ impl TraceJit {
             };
         #[cfg(feature = "trace-profile")]
         if matches!(self.slots[idx], TraceSlot::Compiled(_)) {
-            super::trace_profile::note_compiled(start_pc, cpu_type, recorded_ops);
+            super::trace_profile::note_compiled(start_pc, cpu_type, recorded_shape);
         }
     }
 
@@ -1004,13 +1013,37 @@ impl TraceJit {
 
         let Some(mut op) = decode_trace_op(cpu, bus, executed_pc, cpu_type) else {
             #[cfg(feature = "trace-profile")]
-            super::trace_profile::note_blocker(
-                start_pc,
-                cpu_type,
-                recording.ops.len(),
-                executed_pc,
-                cpu.ir as u16,
-            );
+            {
+                // Diagnostics read through the fastmem window only. The
+                // profiler must not add bus transactions: on buses where a
+                // read is host-visible (MMIO, watchpoints, fault counters),
+                // extra reads would change guest-observable behavior.
+                let memory_opcode = super::mem_ops::peek_window_word(cpu, executed_pc);
+                let next_word = super::mem_ops::peek_window_word(cpu, executed_pc.wrapping_add(2));
+                let next_word2 = super::mem_ops::peek_window_word(cpu, executed_pc.wrapping_add(4));
+                let prefix = recording
+                    .ops
+                    .iter()
+                    .map(|op| super::trace_profile::TraceShapeOp {
+                        pc: op.pc,
+                        opcode: op.opcode,
+                        extension: op.extension,
+                        extension2: op.extension2,
+                    })
+                    .collect();
+                super::trace_profile::note_blocker(
+                    start_pc,
+                    cpu_type,
+                    prefix,
+                    super::trace_profile::TraceBlocker {
+                        pc: executed_pc,
+                        executed_opcode: cpu.ir as u16,
+                        memory_opcode,
+                        next_word,
+                        next_word2,
+                    },
+                );
+            }
             self.finish_recording(cpu, executed_pc);
             return;
         };
@@ -6663,6 +6696,119 @@ mod portable_tests {
         assert_eq!(bailed.pc, 0x0100);
         assert_eq!(bailed.dar, before);
         assert_eq!(bailed.get_ccr(), 0x10);
+    }
+
+    /// Word-read counting bus for the profiling bus-access regression.
+    #[cfg(feature = "trace-profile")]
+    struct CountingBus {
+        memory: Vec<u8>,
+        word_reads: std::collections::BTreeMap<u32, u32>,
+    }
+
+    #[cfg(feature = "trace-profile")]
+    impl super::super::memory::AddressBus for CountingBus {
+        fn read_byte(&mut self, address: u32) -> u8 {
+            self.memory[address as usize & 0xFFF]
+        }
+
+        fn read_word(&mut self, address: u32) -> u16 {
+            *self.word_reads.entry(address).or_default() += 1;
+            let addr = address as usize & 0xFFF;
+            u16::from_be_bytes([self.memory[addr], self.memory[addr + 1]])
+        }
+
+        fn read_long(&mut self, address: u32) -> u32 {
+            let high = self.read_word(address);
+            let low = self.read_word(address.wrapping_add(2));
+            (u32::from(high) << 16) | u32::from(low)
+        }
+
+        fn write_byte(&mut self, address: u32, value: u8) {
+            self.memory[address as usize & 0xFFF] = value;
+        }
+
+        fn write_word(&mut self, address: u32, value: u16) {
+            let addr = address as usize & 0xFFF;
+            self.memory[addr..addr + 2].copy_from_slice(&value.to_be_bytes());
+        }
+
+        fn write_long(&mut self, address: u32, value: u32) {
+            let addr = address as usize & 0xFFF;
+            self.memory[addr..addr + 4].copy_from_slice(&value.to_be_bytes());
+        }
+    }
+
+    /// Recording-failure diagnostics must not add bus transactions: the one
+    /// bus read is the decoder's own opcode read, and the blocker's memory
+    /// opcode and following words come from the fastmem window alone.
+    #[cfg(feature = "trace-profile")]
+    #[test]
+    fn recording_failure_diagnostics_add_no_bus_reads() {
+        super::super::trace_profile::reset();
+
+        let swap = TraceBuildOp {
+            opcode: 0x4840,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::Swap { reg: 0 },
+        };
+
+        let run = |cpu: &mut CpuCore| {
+            let mut bus = CountingBus {
+                memory: vec![0u8; 0x1000],
+                word_reads: std::collections::BTreeMap::new(),
+            };
+            bus.memory[0x0102..0x0104].copy_from_slice(&0xC0FCu16.to_be_bytes());
+            bus.memory[0x0104..0x0106].copy_from_slice(&0x0005u16.to_be_bytes());
+            let mut jit = TraceJit::new();
+            jit.recording = Some(TraceRecording {
+                start_pc: 0x0100,
+                cpu_type: CpuType::M68040,
+                ops: vec![swap],
+                adaptive_rerecords: 0,
+            });
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.trace_recording = true;
+            cpu.ir = 0xC0FC;
+            jit.record_executed(cpu, &mut bus, 0x0102, 0x0106);
+            bus.word_reads
+        };
+
+        // Headless: no window is attached, so diagnostics are unavailable
+        // and the failure still costs exactly one decoder opcode read.
+        let mut headless = cpu();
+        let reads = run(&mut headless);
+        assert_eq!(reads.get(&0x0102), Some(&1), "one decoder opcode read");
+        assert_eq!(reads.len(), 1, "no other bus reads: {reads:?}");
+
+        // With a window attached, the diagnostics come from the window and
+        // the bus still sees exactly the one decoder opcode read.
+        super::super::trace_profile::reset();
+        let mut windowed = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0xC0FCu16.to_be_bytes());
+        mem[0x0104..0x0106].copy_from_slice(&0x0005u16.to_be_bytes());
+        mem[0x0106..0x0108].copy_from_slice(&0x60F8u16.to_be_bytes());
+        attach_window(&mut windowed, &mut mem);
+        let reads = run(&mut windowed);
+        assert_eq!(reads.get(&0x0102), Some(&1), "one decoder opcode read");
+        assert_eq!(reads.len(), 1, "diagnostics must use the window: {reads:?}");
+
+        let snapshot = super::super::trace_profile::snapshot();
+        let shape = snapshot
+            .failed_shapes
+            .iter()
+            .find(|row| row.start_pc == 0x0100)
+            .expect("the failure was recorded");
+        assert_eq!(shape.blocker_pc, 0x0102);
+        assert_eq!(shape.executed_opcode, 0xC0FC);
+        assert_eq!(shape.memory_opcode, Some(0xC0FC));
+        assert_eq!(shape.next_word, Some(0x0005));
+        assert_eq!(shape.next_word2, Some(0x60F8));
+        assert_eq!(shape.prefix_ops, 1);
+        assert_eq!(shape.prefix[0].pc, 0x0100);
+        assert_eq!(shape.prefix[0].opcode, 0x4840);
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -13,6 +13,7 @@ use std::hash::{BuildHasherDefault, Hasher};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Per-trace-head profiling counters.
+#[non_exhaustive]
 pub struct TraceProfileRow {
     /// Guest program counter at which the trace starts.
     pub start_pc: u32,
@@ -45,8 +46,93 @@ pub struct TraceProfileRow {
     pub adaptive_rerecords: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Why replay-time decoding could not append an executed instruction.
+pub enum TraceDecodeFailureReason {
+    /// The blocker's memory could not be read side-effect-free: no fastmem
+    /// window covers it, so the recorder cannot inspect it without adding
+    /// observable bus transactions.
+    OpcodeReadFailed,
+    /// The opcode executed by the CPU no longer matches guest memory.
+    OpcodeChanged,
+    /// Memory still contains the executed opcode, but its form is not
+    /// traceable or an operand-extension read failed.
+    UnsupportedFormOrOperandRead,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// One instruction captured in a successfully compiled trace path.
+#[non_exhaustive]
+pub struct TraceShapeOp {
+    /// Guest address at which the instruction executed.
+    pub pc: u32,
+    /// Primary opcode word.
+    pub opcode: u16,
+    /// First extension word captured by the trace decoder, if any.
+    pub extension: Option<u16>,
+    /// Second extension word captured by the trace decoder, if any.
+    pub extension2: Option<u16>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TraceBlocker {
+    pub(crate) pc: u32,
+    pub(crate) executed_opcode: u16,
+    pub(crate) memory_opcode: Option<u16>,
+    pub(crate) next_word: Option<u16>,
+    pub(crate) next_word2: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// One distinct failed recording path for a trace head.
+#[non_exhaustive]
+pub struct FailedTraceShapeProfileRow {
+    /// Guest program counter at which recording began.
+    pub start_pc: u32,
+    /// CPU model active while recording.
+    pub cpu_type: CpuType,
+    /// Successfully reconstructed operations before the failure.
+    pub prefix_ops: u32,
+    /// The exact reconstructed operations preceding the failure, in
+    /// execution order.
+    pub prefix: Vec<TraceShapeOp>,
+    /// Guest address of the instruction whose reconstruction failed.
+    pub blocker_pc: u32,
+    /// Opcode retained in the CPU's instruction register after execution.
+    pub executed_opcode: u16,
+    /// Opcode reread from the fastmem window while reconstructing the
+    /// trace, when the address is inside the window.
+    pub memory_opcode: Option<u16>,
+    /// First guest word after the blocker opcode, read through the fastmem
+    /// window when available. For an extensionless blocker this is the next
+    /// opcode, not an operand.
+    pub next_word: Option<u16>,
+    /// Second guest word after the blocker opcode, read through the fastmem
+    /// window when available.
+    pub next_word2: Option<u16>,
+    /// Coarse classification of the reconstruction failure.
+    pub reason: TraceDecodeFailureReason,
+    /// Number of recording attempts with this exact shape.
+    pub recordings: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// One distinct successfully compiled path for a trace head.
+#[non_exhaustive]
+pub struct CompiledTraceShapeProfileRow {
+    /// Guest program counter at which recording began.
+    pub start_pc: u32,
+    /// CPU model active while recording.
+    pub cpu_type: CpuType,
+    /// Executed instructions in dynamic path order.
+    pub ops: Vec<TraceShapeOp>,
+    /// Number of times this exact path was compiled.
+    pub recordings: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Execution count aggregated by decoded memory-operation opcode.
+#[non_exhaustive]
 pub struct DecodedMemProfileRow {
     /// Guest opcode word.
     pub opcode: u16,
@@ -56,6 +142,7 @@ pub struct DecodedMemProfileRow {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Execution count for one decoded memory-operation site.
+#[non_exhaustive]
 pub struct DecodedMemSiteProfileRow {
     /// Guest program counter of the operation.
     pub pc: u32,
@@ -77,6 +164,7 @@ impl TraceProfileRow {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 /// Snapshot of all trace and decoded-memory profiling counters.
+#[non_exhaustive]
 pub struct TraceProfileSnapshot {
     /// Per-trace-head counters.
     pub rows: Vec<TraceProfileRow>,
@@ -84,6 +172,17 @@ pub struct TraceProfileSnapshot {
     pub decoded_mem_ops: Vec<DecodedMemProfileRow>,
     /// Decoded memory counts split by guest PC and opcode.
     pub decoded_mem_sites: Vec<DecodedMemSiteProfileRow>,
+    /// Failed paths kept separately from successful recordings at the same
+    /// trace head. This prevents a historical blocker from being mistaken
+    /// for the boundary of the currently compiled path.
+    pub failed_shapes: Vec<FailedTraceShapeProfileRow>,
+    /// Successfully compiled dynamic paths, including their exact executed
+    /// guest instruction sequence.
+    pub compiled_shapes: Vec<CompiledTraceShapeProfileRow>,
+    /// Failure recordings dropped after the distinct failed-shape cap was
+    /// reached. Zero unless a pathological workload produced thousands of
+    /// distinct failed paths.
+    pub failed_shape_overflow: u64,
     /// Total observed backward branches.
     pub backward_hits: u64,
     /// Total rejected trace-entry opportunities.
@@ -116,6 +215,10 @@ impl TraceProfileSnapshot {
             out,
             "totals: backward_hits={} rejected_hits={} native_calls={} jit_retired={} avg_ops_per_native_call={average:.2}",
             self.backward_hits, self.rejected_hits, self.native_calls, self.jit_retired
+        );
+        let _ = writeln!(
+            out,
+            "note: head rows aggregate the process lifetime; failure and compiled columns may describe different recording paths. See the shape tables below."
         );
         let _ = writeln!(
             out,
@@ -176,6 +279,102 @@ impl TraceProfileSnapshot {
                 row.guarded_branch_exits,
                 row.adaptive_rerecords
             );
+        }
+
+        let mut failed_shapes = self.failed_shapes.clone();
+        failed_shapes.sort_unstable_by(|a, b| {
+            b.recordings
+                .cmp(&a.recordings)
+                .then_with(|| b.prefix_ops.cmp(&a.prefix_ops))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+        let _ = writeln!(out, "failed recording shapes");
+        if self.failed_shape_overflow > 0 {
+            let _ = writeln!(
+                out,
+                "note: {} failure recordings dropped past the {}-shape cap",
+                self.failed_shape_overflow, FAILED_SHAPE_CAP
+            );
+        }
+        let _ = writeln!(
+            out,
+            "rank  start_pc  records prefix blocker_pc ir   memory next1 next2 reason"
+        );
+        for (rank, shape) in failed_shapes.iter().take(40).enumerate() {
+            let memory = shape
+                .memory_opcode
+                .map_or_else(|| "----".to_owned(), |value| format!("{value:04X}"));
+            let next_word = shape
+                .next_word
+                .map_or_else(|| "----".to_owned(), |value| format!("{value:04X}"));
+            let next_word2 = shape
+                .next_word2
+                .map_or_else(|| "----".to_owned(), |value| format!("{value:04X}"));
+            let reason = match shape.reason {
+                TraceDecodeFailureReason::OpcodeReadFailed => "opcode-read-failed",
+                TraceDecodeFailureReason::OpcodeChanged => "opcode-changed",
+                TraceDecodeFailureReason::UnsupportedFormOrOperandRead => {
+                    "unsupported-form-or-operand-read"
+                }
+            };
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X} {:>8} {:>6}   {:08X} {:04X} {} {:>5} {:>5} {}",
+                rank + 1,
+                shape.start_pc,
+                shape.recordings,
+                shape.prefix_ops,
+                shape.blocker_pc,
+                shape.executed_opcode,
+                memory,
+                next_word,
+                next_word2,
+                reason
+            );
+            let _ = write!(out, "      prefix:");
+            if shape.prefix.is_empty() {
+                let _ = write!(out, " (none)");
+            }
+            for op in &shape.prefix {
+                let _ = write!(out, " {:08X}:{:04X}", op.pc, op.opcode);
+                if let Some(extension) = op.extension {
+                    let _ = write!(out, "/{extension:04X}");
+                }
+                if let Some(extension) = op.extension2 {
+                    let _ = write!(out, "/{extension:04X}");
+                }
+            }
+            let _ = writeln!(out);
+        }
+
+        let mut compiled_shapes = self.compiled_shapes.clone();
+        compiled_shapes.sort_unstable_by(|a, b| {
+            b.recordings
+                .cmp(&a.recordings)
+                .then_with(|| b.ops.len().cmp(&a.ops.len()))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+        let _ = writeln!(out, "compiled recording shapes");
+        for (rank, shape) in compiled_shapes.iter().take(40).enumerate() {
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X} records={} ops={}",
+                rank + 1,
+                shape.start_pc,
+                shape.recordings,
+                shape.ops.len()
+            );
+            let _ = write!(out, "      path:");
+            for op in &shape.ops {
+                let _ = write!(out, " {:08X}:{:04X}", op.pc, op.opcode);
+                if let Some(extension) = op.extension {
+                    let _ = write!(out, "/{extension:04X}");
+                }
+                if let Some(extension) = op.extension2 {
+                    let _ = write!(out, "/{extension:04X}");
+                }
+            }
+            let _ = writeln!(out);
         }
 
         let mut decoded_mem_ops = self.decoded_mem_ops.clone();
@@ -246,6 +445,26 @@ struct Row {
     adaptive_rerecords: u64,
 }
 
+/// Upper bound on distinct failed shapes kept per process. Each entry holds
+/// a full prefix sequence, so the map must not grow for the whole session;
+/// drops past the cap are counted and reported.
+const FAILED_SHAPE_CAP: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct FailedShapeKey {
+    start_pc: u32,
+    cpu_type: u32,
+    prefix: Vec<TraceShapeOp>,
+    blocker_pc: u32,
+    executed_opcode: u16,
+    memory_opcode: Option<u16>,
+    next_word: Option<u16>,
+    next_word2: Option<u16>,
+    reason: TraceDecodeFailureReason,
+}
+
+type CompiledShapeKey = (u32, u32, Vec<TraceShapeOp>);
+
 /// The site key is already a uniformly useful `(pc << 16) | opcode` integer,
 /// so hashing it again only adds overhead to this hot, feature-only profiler.
 #[derive(Default)]
@@ -274,6 +493,13 @@ type SiteCounts = HashMap<u64, u64, BuildHasherDefault<IdentityHasher>>;
 
 struct Profile {
     rows: BTreeMap<(u32, u32), Row>,
+    failed_shapes: BTreeMap<FailedShapeKey, u64>,
+    /// Failure recordings dropped after `FAILED_SHAPE_CAP` distinct shapes.
+    /// The prefix sequences make each entry meaningfully sized, so the map
+    /// is bounded for the process lifetime and the report states what was
+    /// dropped instead of growing without limit.
+    failed_shape_overflow: u64,
+    compiled_shapes: BTreeMap<CompiledShapeKey, u64>,
     decoded_mem_counts: Box<[u64]>,
     decoded_mem_site_counts: SiteCounts,
 }
@@ -282,8 +508,11 @@ impl Default for Profile {
     fn default() -> Self {
         Self {
             rows: BTreeMap::new(),
+            failed_shapes: BTreeMap::new(),
+            compiled_shapes: BTreeMap::new(),
             decoded_mem_counts: vec![0; super::op_cache::DECODE_TABLE_SIZE].into_boxed_slice(),
             decoded_mem_site_counts: SiteCounts::default(),
+            failed_shape_overflow: 0,
         }
     }
 }
@@ -338,6 +567,35 @@ impl Profile {
                 executions,
             })
             .collect();
+        let failed_shapes = self
+            .failed_shapes
+            .iter()
+            .map(|(key, &recordings)| FailedTraceShapeProfileRow {
+                start_pc: key.start_pc,
+                cpu_type: cpu_type_from_repr(key.cpu_type),
+                prefix_ops: key.prefix.len() as u32,
+                prefix: key.prefix.clone(),
+                blocker_pc: key.blocker_pc,
+                executed_opcode: key.executed_opcode,
+                memory_opcode: key.memory_opcode,
+                next_word: key.next_word,
+                next_word2: key.next_word2,
+                reason: key.reason,
+                recordings,
+            })
+            .collect();
+        let compiled_shapes = self
+            .compiled_shapes
+            .iter()
+            .map(
+                |((start_pc, cpu_type, ops), &recordings)| CompiledTraceShapeProfileRow {
+                    start_pc: *start_pc,
+                    cpu_type: cpu_type_from_repr(*cpu_type),
+                    ops: ops.clone(),
+                    recordings,
+                },
+            )
+            .collect();
         TraceProfileSnapshot {
             backward_hits: rows.iter().map(|row| row.backward_hits).sum(),
             rejected_hits: rows.iter().map(|row| row.rejected_hits).sum(),
@@ -346,6 +604,9 @@ impl Profile {
             rows,
             decoded_mem_ops,
             decoded_mem_sites,
+            failed_shapes,
+            compiled_shapes,
+            failed_shape_overflow: self.failed_shape_overflow,
         }
     }
 }
@@ -408,26 +669,57 @@ pub(crate) fn note_recording(pc: u32, cpu_type: CpuType) {
 pub(crate) fn note_blocker(
     start_pc: u32,
     cpu_type: CpuType,
-    prefix_ops: usize,
-    blocker_pc: u32,
-    blocker_opcode: u16,
+    prefix: Vec<TraceShapeOp>,
+    blocker: TraceBlocker,
 ) {
     PROFILE.with_borrow_mut(|profile| {
         let row = profile.0.row(start_pc, cpu_type);
         // Keep the longest observed prefix for this trace head. It is the
         // conservative amount of already-supported work stranded behind the
-        // blocker; path variation is visible through repeated recordings.
-        if prefix_ops as u32 >= row.prefix_ops {
-            row.prefix_ops = prefix_ops as u32;
-            row.blocker_pc = Some(blocker_pc);
-            row.blocker_opcode = Some(blocker_opcode);
+        // blocker; path variation is visible through the shape table.
+        if prefix.len() as u32 >= row.prefix_ops {
+            row.prefix_ops = prefix.len() as u32;
+            row.blocker_pc = Some(blocker.pc);
+            row.blocker_opcode = Some(blocker.executed_opcode);
         }
+        let reason = match blocker.memory_opcode {
+            None => TraceDecodeFailureReason::OpcodeReadFailed,
+            Some(opcode) if opcode != blocker.executed_opcode => {
+                TraceDecodeFailureReason::OpcodeChanged
+            }
+            Some(_) => TraceDecodeFailureReason::UnsupportedFormOrOperandRead,
+        };
+        let key = FailedShapeKey {
+            start_pc,
+            cpu_type: cpu_type as u32,
+            prefix,
+            blocker_pc: blocker.pc,
+            executed_opcode: blocker.executed_opcode,
+            memory_opcode: blocker.memory_opcode,
+            next_word: blocker.next_word,
+            next_word2: blocker.next_word2,
+            reason,
+        };
+        if profile.0.failed_shapes.len() >= FAILED_SHAPE_CAP
+            && !profile.0.failed_shapes.contains_key(&key)
+        {
+            profile.0.failed_shape_overflow = profile.0.failed_shape_overflow.saturating_add(1);
+            return;
+        }
+        let recordings = profile.0.failed_shapes.entry(key).or_default();
+        *recordings = recordings.saturating_add(1);
     });
 }
 
-pub(crate) fn note_compiled(pc: u32, cpu_type: CpuType, ops: usize) {
+pub(crate) fn note_compiled(pc: u32, cpu_type: CpuType, ops: Vec<TraceShapeOp>) {
     PROFILE.with_borrow_mut(|profile| {
-        profile.0.row(pc, cpu_type).compiled_ops = ops as u32;
+        profile.0.row(pc, cpu_type).compiled_ops = ops.len() as u32;
+        let recordings = profile
+            .0
+            .compiled_shapes
+            .entry((pc, cpu_type as u32, ops))
+            .or_default();
+        *recordings = recordings.saturating_add(1);
     });
 }
 
@@ -474,18 +766,167 @@ mod tests {
     use super::*;
     use crate::{AddressBus, BatchExit, CpuCore, LinearMemoryBus};
 
+    /// A `count`-op prefix of single-word instructions starting at `start`.
+    fn dummy_prefix(start: u32, count: u32) -> Vec<TraceShapeOp> {
+        (0..count)
+            .map(|index| TraceShapeOp {
+                pc: start + index * 2,
+                opcode: 0x7000 + index as u16,
+                extension: None,
+                extension2: None,
+            })
+            .collect()
+    }
+
     #[test]
     fn report_ranks_stranded_dispatches_not_raw_hits() {
         reset();
         note_backward_edge(0x100, CpuType::M68040, true);
-        note_blocker(0x100, CpuType::M68040, 2, 0x104, 0x4ead);
+        note_blocker(
+            0x100,
+            CpuType::M68040,
+            dummy_prefix(0x100, 2),
+            TraceBlocker {
+                pc: 0x104,
+                executed_opcode: 0x4ead,
+                memory_opcode: Some(0x4ead),
+                next_word: None,
+                next_word2: None,
+            },
+        );
         for _ in 0..3 {
             note_backward_edge(0x200, CpuType::M68040, true);
         }
-        note_blocker(0x200, CpuType::M68040, 1, 0x202, 0x486d);
+        note_blocker(
+            0x200,
+            CpuType::M68040,
+            dummy_prefix(0x200, 1),
+            TraceBlocker {
+                pc: 0x202,
+                executed_opcode: 0x486d,
+                memory_opcode: Some(0x486d),
+                next_word: None,
+                next_word2: None,
+            },
+        );
 
         let report = snapshot().report();
         assert!(report.find("00000200").unwrap() < report.find("00000100").unwrap());
+    }
+
+    #[test]
+    fn failed_shape_cap_counts_overflow() {
+        reset();
+        let blocker = TraceBlocker {
+            pc: 0x9000,
+            executed_opcode: 0x4c01,
+            memory_opcode: Some(0x4c01),
+            next_word: None,
+            next_word2: None,
+        };
+        for index in 0..(FAILED_SHAPE_CAP as u32 + 5) {
+            note_blocker(
+                0x100 + index * 2,
+                CpuType::M68040,
+                dummy_prefix(0x100, 1),
+                blocker,
+            );
+        }
+        let snapshot = snapshot();
+        assert_eq!(snapshot.failed_shapes.len(), FAILED_SHAPE_CAP);
+        assert_eq!(snapshot.failed_shape_overflow, 5);
+        assert!(
+            snapshot
+                .report()
+                .contains("5 failure recordings dropped past the 4096-shape cap")
+        );
+    }
+
+    #[test]
+    fn distinct_equal_length_prefixes_stay_distinct() {
+        reset();
+        let blocker = TraceBlocker {
+            pc: 0x108,
+            executed_opcode: 0x4c01,
+            memory_opcode: Some(0x4c01),
+            next_word: None,
+            next_word2: None,
+        };
+        let mut path_a = dummy_prefix(0x100, 4);
+        let mut path_b = dummy_prefix(0x100, 4);
+        // Same head, same length, same blocker; one interior operation
+        // differs, as when a guarded branch takes another recorded route.
+        path_a[2].opcode = 0x5280;
+        path_b[2].opcode = 0x5281;
+        note_blocker(0x100, CpuType::M68040, path_a.clone(), blocker);
+        note_blocker(0x100, CpuType::M68040, path_b.clone(), blocker);
+        note_blocker(0x100, CpuType::M68040, path_b, blocker);
+
+        let snapshot = snapshot();
+        let rows: Vec<_> = snapshot
+            .failed_shapes
+            .iter()
+            .filter(|row| row.start_pc == 0x100)
+            .collect();
+        assert_eq!(
+            rows.len(),
+            2,
+            "equal-length distinct prefixes must not merge"
+        );
+        assert!(rows.iter().all(|row| row.prefix_ops == 4));
+        let mut recordings: Vec<u64> = rows.iter().map(|row| row.recordings).collect();
+        recordings.sort_unstable();
+        assert_eq!(recordings, vec![1, 2]);
+        assert_ne!(rows[0].prefix, rows[1].prefix);
+
+        let report = snapshot.report();
+        assert!(report.contains("prefix: 00000100:7000 00000102:7001 00000104:5280 00000106:7003"));
+        assert!(report.contains("prefix: 00000100:7000 00000102:7001 00000104:5281 00000106:7003"));
+    }
+
+    #[test]
+    fn report_separates_failed_and_compiled_shapes_at_one_head() {
+        reset();
+        note_blocker(
+            0x100,
+            CpuType::M68040,
+            dummy_prefix(0x100, 20),
+            TraceBlocker {
+                pc: 0x140,
+                executed_opcode: 0x4c01,
+                memory_opcode: Some(0x4c01),
+                next_word: Some(0x0800),
+                next_word2: Some(0xee80),
+            },
+        );
+        note_compiled(
+            0x100,
+            CpuType::M68040,
+            vec![
+                TraceShapeOp {
+                    pc: 0x100,
+                    opcode: 0x7000,
+                    extension: None,
+                    extension2: None,
+                },
+                TraceShapeOp {
+                    pc: 0x102,
+                    opcode: 0x60fc,
+                    extension: None,
+                    extension2: None,
+                },
+            ],
+        );
+
+        let snapshot = snapshot();
+        assert_eq!(snapshot.failed_shapes.len(), 1);
+        assert_eq!(snapshot.compiled_shapes.len(), 1);
+        assert_eq!(snapshot.failed_shapes[0].prefix_ops, 20);
+        assert_eq!(snapshot.compiled_shapes[0].ops.len(), 2);
+        let report = snapshot.report();
+        assert!(report.contains("failure and compiled columns may describe different"));
+        assert!(report.contains("00000140 4C01 4C01  0800  EE80"));
+        assert!(report.contains("path: 00000100:7000 00000102:60FC"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make the optional trace opportunity profile report the exact dynamic paths that compiled and the exact paths that failed to record.

The existing head row is a process-lifetime aggregate. A trace head can first fail on one path and later compile on another, but the row can retain the earlier blocker label beside the later compiled-call counts. During EV Override profiling this made an earlier `4C01` failure appear to be the boundary of a successfully compiled trace whose executed path did not contain that instruction.

This PR keeps the aggregate table for ranking, labels its lifetime-aggregation limitation, and adds shape tables that answer the diagnostic question unambiguously.

## What is recorded

For every distinct failed recording shape:

- trace start PC and CPU model;
- the exact reconstructed prefix operations, in execution order — two
  equal-length paths that converge on the same blocker remain distinct
  rows, each printed with its own `prefix:` line;
- blocker PC;
- executed instruction-register opcode;
- the opcode and up to two following guest words as they appear in memory
  — labeled as following words, not extensions, because an extensionless
  blocker is followed by other opcodes.

All failure diagnostics are read through the attached fastmem window
only; the collection helper does not take an `AddressBus`, so enabling
profiling cannot add host-visible bus transactions (MMIO, watchpoints,
fault counters). When no window covers the blocker, the diagnostics are
recorded as unavailable rather than read from the bus. The distinct
failed-shape map is capped (4096 shapes) with a reported overflow count,
keeping the profiler's memory bounded for the process lifetime now that
each entry carries a prefix sequence.

Failures are classified as:

- opcode read failed;
- executed opcode no longer matches memory; or
- unsupported form / operand-extension read failed.

For every distinct compiled shape, the report records the exact dynamic sequence of PC, opcode, and captured extension words plus its compile count.

This separates path variation from self-modifying code and from genuinely unsupported instruction forms. It also prevents us from optimizing an opcode merely because an older aggregate blocker label happened to remain visible.

## Scope and overhead

All new collection is behind the existing `trace-profile` feature. Normal library/JIT builds do not allocate the shape maps or perform the extra diagnostic memory reads. This is instrumentation only; it does not change guest execution or claim a runtime speedup.

## Validation

- `cargo test --all-features` — full suite, 62 test binaries (166 lib
  tests), with both fixture submodules initialized, on v0.7.2
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --no-default-features` and
  `cargo check --features trace-profile`
- bus-access regression driving the recording-failure path directly with a
  word-read-counting bus: exactly one decoder opcode read and nothing
  else, asserted both with and without a window attached
- test proving two distinct equal-length prefixes at the same blocker stay
  separate rows with separate counts
- failed-shape cap and overflow-count coverage
- report test proving that a failed 20-op path and a compiled 2-op path at the same head remain distinct
- coverage for the exact following words and explanatory aggregate-table note

The profiler applies directly to current master (v0.7.2). It produced the
before/after recording-path evidence in #72 and #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ28utnrHwacwzpZnVUbUx
