### PR TITLE
perf: JIT displacement PEA pushes

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1038,6 +1038,72 @@ fn bench_indexed_immediate_compare() {
     );
 }
 
+/// Measure a JIT-compiled loop that pushes an address with `PEA (d16,A5)`
+/// and pops it back with a postincrement load, keeping the stack balanced
+/// across iterations while exercising the checked predecrement store. This
+/// models a compiler materializing the address of an A5-relative global as
+/// a by-reference argument; the popping load stands in for the callee
+/// consuming the pushed pointer:
+///
+/// ```c
+/// int32_t count = 0;                  /* MOVEQ #0,D0, once  */
+/// for (;;) {
+///     ++count;                        /* ADDQ.L #1,D0    */
+///     int32_t *arg = &globals->field; /* PEA $40(A5)     */
+///     sink = arg;                     /* MOVE.L (A7)+,D3 */
+///     ++iterations;                   /* ADDQ.L #1,D1    */
+/// }
+/// ```
+///
+/// The instruction budget is one initializer plus a whole number of
+/// five-instruction iterations, so the run ends at the loop head and the
+/// final counter, pointer, and stack values are exact.
+fn bench_pea_displacement_loop() {
+    const CODE_BASE: u32 = 0x6E00;
+    const ITERATIONS: u32 = 20_000_000;
+    const INSTRS: u32 = 1 + ITERATIONS * 5;
+    let words = [
+        0x7000, // MOVEQ #0,D0
+        0x5280, // loop: ADDQ.L #1,D0
+        0x486D, 0x0040, // PEA $40(A5)
+        0x261F, // MOVE.L (A7)+,D3
+        0x5281, // ADDQ.L #1,D1
+        0x60F4, // BRA.S loop
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(5, 0x4200);
+        cpu.set_a(7, 0x8000);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(cpu.d(0), ITERATIONS, "count increments once per iteration");
+    assert_eq!(cpu.d(1), ITERATIONS, "iterations increment once per pass");
+    assert_eq!(cpu.d(3), 0x4240, "the popped value is the pushed address");
+    assert_eq!(cpu.a(7), 0x8000, "the stack is balanced at the loop head");
+    println!(
+        "batch     pea displacement loop   {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 /// Measure decoded generic memory operations without allowing a backward
 /// branch to turn the workload into a native JIT loop. Each pass walks the
 /// same straight-line code, retaining the decoded-op cache while resetting
@@ -1161,6 +1227,10 @@ fn main() {
     }
     if only.as_deref() == Some("indexed-immediate-compare") {
         bench_indexed_immediate_compare();
+        return;
+    }
+    if only.as_deref() == Some("pea-displacement") {
+        bench_pea_displacement_loop();
         return;
     }
     if only.as_deref() == Some("immediate-shifts") {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -372,6 +372,14 @@ pub(crate) enum JitTraceOp {
         reg: u8,
         displacement: i16,
     },
+    /// `PEA (d16,An)`: push the effective address through the checked
+    /// window. The address is computed from the pre-decrement stack pointer
+    /// state, no condition code changes, and every check precedes the store
+    /// and the A7 update so a bail commits nothing.
+    PeaDisp {
+        reg: u8,
+        displacement: i16,
+    },
     /// ADDQ/SUBQ through a checked address-register-relative memory EA.
     MemAddqSubq {
         data: u32,
@@ -1176,6 +1184,7 @@ impl TraceJit {
                     | JitTraceOp::AddrCmpMemToReg { .. }
                     | JitTraceOp::AddRegToMem { .. }
                     | JitTraceOp::AnDispUnary { .. }
+                    | JitTraceOp::PeaDisp { .. }
                     | JitTraceOp::MemAddqSubq { .. }
                     | JitTraceOp::AnDispBit { .. }
                     | JitTraceOp::IndirectJsr { .. }
@@ -1417,6 +1426,10 @@ impl TraceJit {
                     JitTraceOp::AnDispUnary { .. } | JitTraceOp::AnDispBit { .. } => {
                         let env = mem_env.as_ref().expect("AnDisp implies a window env");
                         emit_an_disp_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
+                    JitTraceOp::PeaDisp { .. } => {
+                        let env = mem_env.as_ref().expect("PeaDisp implies a window env");
+                        emit_pea_disp(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
                     _ => emit_jit_op(&mut builder, cpu_ptr, *op, aligned_only),
                 };
@@ -1839,6 +1852,9 @@ impl JitTraceOp {
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::MemAddqSubq { .. } | Self::AnDispUnary { .. } | Self::AnDispBit { .. } => 24,
+            // MC68000 PEA (d16,An): twelve-cycle push plus the four-cycle
+            // displacement extension fetch.
+            Self::PeaDisp { .. } => 16,
         }
     }
 
@@ -2223,6 +2239,19 @@ fn decode_an_disp_trace_op<B: AddressBus>(
                 JitTraceOp::AnDispUnary {
                     op: JitUnaryOp::Clr,
                     size,
+                    reg,
+                    displacement: displacement as i16,
+                },
+            )
+        }
+        DecodedMemOp::Pea {
+            ea: FastEa::AnDisp(reg),
+        } => {
+            let displacement = read_ext(2, bus)?;
+            (
+                Some(displacement),
+                None,
+                JitTraceOp::PeaDisp {
                     reg,
                     displacement: displacement as i16,
                 },
@@ -2634,6 +2663,9 @@ fn execute_portable_op(
     if matches!(op.op, JitTraceOp::MemAddqSubq { .. }) {
         return execute_portable_mem_addq_subq(cpu, op, code_start, code_end);
     }
+    if matches!(op.op, JitTraceOp::PeaDisp { .. }) {
+        return execute_portable_pea_disp(cpu, op, code_start, code_end);
+    }
     if matches!(
         op.op,
         JitTraceOp::AnDispUnary { .. } | JitTraceOp::AnDispBit { .. }
@@ -2743,6 +2775,36 @@ fn execute_portable_mem_addq_subq(
             size,
             ea,
             is_sub,
+        },
+    ) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
+#[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
+fn execute_portable_pea_disp(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    code_start: u32,
+    code_end: u32,
+) -> Option<i32> {
+    let JitTraceOp::PeaDisp { reg, .. } = trace.op else {
+        return None;
+    };
+    let sp = cpu.dar[15].wrapping_sub(4);
+    let masked = sp & cpu.address_mask;
+    if masked < code_end && masked.wrapping_add(4) > code_start {
+        return None;
+    }
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::Pea {
+            ea: FastEa::AnDisp(reg),
         },
     ) {
         Some(trace.op.max_cycles())
@@ -3621,6 +3683,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::AnDispUnary { .. } | JitTraceOp::AnDispBit { .. } => {
             unreachable!("AnDisp ops are handled by execute_portable_an_disp")
         }
+        JitTraceOp::PeaDisp { .. } => {
+            unreachable!("PeaDisp is handled by execute_portable_pea_disp")
+        }
     }
 }
 
@@ -4170,6 +4235,9 @@ fn emit_jit_op(
         }
         JitTraceOp::AnDispUnary { .. } | JitTraceOp::AnDispBit { .. } => {
             unreachable!("AnDisp ops are emitted by emit_an_disp_mem")
+        }
+        JitTraceOp::PeaDisp { .. } => {
+            unreachable!("PeaDisp is emitted by emit_pea_disp")
         }
         JitTraceOp::IndirectJsr { .. } => {
             unreachable!("IndirectJsr is emitted by emit_indirect_jsr")
@@ -4867,6 +4935,45 @@ fn emit_an_disp_mem(
         }
         _ => unreachable!(),
     }
+    cycles_const(builder, trace.op.max_cycles())
+}
+
+/// Emit `PEA (d16,An)`: the pushed address is computed from the
+/// pre-decrement register state, then the decremented stack slot passes the
+/// alignment/window/code-overlap checks before the store and the A7 update,
+/// so a failed check bails with nothing committed. PEA changes no condition
+/// codes.
+#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+fn emit_pea_disp(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::PeaDisp { reg, displacement } = trace.op else {
+        unreachable!("expected PEA displacement trace")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+    let address = builder.ins().iadd_imm(base, displacement as i64);
+    let sp = if reg == 7 {
+        base
+    } else {
+        load_reg(builder, cpu, JitDirectReg::Addr(7))
+    };
+    let new_sp = builder.ins().iadd_imm(sp, -4);
+    let (off, masked) = checked_window_off(builder, env, bail, new_sp, Size::Long);
+    guard_store_not_code(builder, env, bail, masked, Size::Long);
+    window_store(builder, env, off, Size::Long, address);
+    store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -6809,6 +6916,187 @@ mod portable_tests {
         assert_eq!(shape.prefix_ops, 1);
         assert_eq!(shape.prefix[0].pc, 0x0100);
         assert_eq!(shape.prefix[0].opcode, 0x4840);
+    }
+
+    #[test]
+    fn pea_displacement_decode_and_portable_execution_push_without_flags() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0100..0x0102].copy_from_slice(&0x486Du16.to_be_bytes());
+        mem[0x0102..0x0104].copy_from_slice(&0x0040u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(5, 0x0300);
+        cpu.set_a(7, 0x0800);
+        cpu.set_ccr(0x1F);
+
+        let mut decode_bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        decode_bus.write_word(0x0100, 0x486D);
+        decode_bus.write_word(0x0102, 0x0040);
+        let trace = decode_trace_op(&cpu, &mut decode_bus, 0x0100, CpuType::M68040)
+            .expect("PEA (d16,An) should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::PeaDisp {
+                reg: 5,
+                displacement: 0x40,
+            }
+        ));
+        assert_eq!(trace.extension, Some(0x0040));
+        assert_eq!(trace.extension2, None);
+        assert_eq!(
+            execute_portable_op(&mut cpu, trace, 0x0100, 0x0104),
+            Some(16)
+        );
+        assert_eq!(cpu.dar[15], 0x07FC);
+        assert_eq!(&mem[0x07FC..0x0800], &0x0340u32.to_be_bytes());
+        assert_eq!(cpu.get_ccr(), 0x1F, "PEA changes no condition codes");
+        assert_eq!(cpu.pc, 0x0104);
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_pea_displacement_matches_portable_and_bails_atomically() {
+        let pea = TraceBuildOp {
+            opcode: 0x486D,
+            extension: Some(0x0040),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::PeaDisp {
+                reg: 5,
+                displacement: 0x40,
+            },
+        };
+        let branch = TraceBuildOp {
+            opcode: 0x60FA,
+            extension: None,
+            extension2: None,
+            pc: 0x0104,
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -6,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+
+        let prepare = |mem: &mut [u8], opcode: u16, ext: u16| {
+            mem[0x0100..0x0102].copy_from_slice(&opcode.to_be_bytes());
+            mem[0x0102..0x0104].copy_from_slice(&ext.to_be_bytes());
+            mem[0x0104..0x0106].copy_from_slice(&0x60FAu16.to_be_bytes());
+            let mut cpu = cpu();
+            attach_window(&mut cpu, mem);
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_a(5, 0x0300);
+            cpu.set_a(7, 0x0800);
+            cpu.set_ccr(0x15);
+            cpu
+        };
+
+        let mut expected_mem = vec![0u8; 0x1000];
+        let mut expected = prepare(&mut expected_mem, 0x486D, 0x0040);
+        let expected_packed = execute_portable_trace(&mut expected, &[pea, branch], 0x0100, 0x0106);
+
+        let mut actual_mem = vec![0u8; 0x1000];
+        let mut actual = prepare(&mut actual_mem, 0x486D, 0x0040);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(
+                &actual,
+                0x0100,
+                CpuType::M68040,
+                vec![pea, branch],
+                Some(0x0100),
+            )
+            .expect("PEA displacement loop should compile");
+        let actual_packed = unsafe { compiled.call_native(&mut actual, 1) };
+        assert_eq!(actual_packed, expected_packed);
+        assert_eq!(actual.pc, expected.pc);
+        assert_eq!(actual.dar, expected.dar);
+        assert_eq!(actual.get_ccr(), expected.get_ccr());
+        assert_eq!(actual_mem, expected_mem);
+        assert_eq!(&actual_mem[0x07FC..0x0800], &0x0340u32.to_be_bytes());
+
+        // PEA (d16,A7) pushes an address computed from the pre-decrement
+        // stack pointer.
+        let pea_sp = TraceBuildOp {
+            opcode: 0x486F,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::PeaDisp {
+                reg: 7,
+                displacement: 0x10,
+            },
+        };
+        let mut sp_expected_mem = vec![0u8; 0x1000];
+        let mut sp_expected = prepare(&mut sp_expected_mem, 0x486F, 0x0010);
+        let sp_expected_packed =
+            execute_portable_trace(&mut sp_expected, &[pea_sp, branch], 0x0100, 0x0106);
+        let mut sp_actual_mem = vec![0u8; 0x1000];
+        let mut sp_actual = prepare(&mut sp_actual_mem, 0x486F, 0x0010);
+        let mut sp_jit = TraceJit::new();
+        let sp_compiled = sp_jit
+            .compile_decoded_ops(
+                &sp_actual,
+                0x0100,
+                CpuType::M68040,
+                vec![pea_sp, branch],
+                Some(0x0100),
+            )
+            .expect("PEA (d16,A7) loop should compile");
+        let sp_actual_packed = unsafe { sp_compiled.call_native(&mut sp_actual, 1) };
+        assert_eq!(sp_actual_packed, sp_expected_packed);
+        assert_eq!(sp_actual.dar, sp_expected.dar);
+        assert_eq!(sp_actual_mem, sp_expected_mem);
+        assert_eq!(&sp_actual_mem[0x07FC..0x0800], &0x0810u32.to_be_bytes());
+
+        let mut untouched_mem = vec![0u8; 0x1000];
+        prepare(&mut untouched_mem, 0x486D, 0x0040);
+
+        // A stack slot outside the window reaches the side exit with
+        // nothing committed.
+        let mut bail_mem = vec![0u8; 0x1000];
+        let mut bailed = prepare(&mut bail_mem, 0x486D, 0x0040);
+        bailed.set_a(7, 0x0002);
+        let mut bail_jit = TraceJit::new();
+        let bail_compiled = bail_jit
+            .compile_decoded_ops(
+                &bailed,
+                0x0100,
+                CpuType::M68040,
+                vec![pea, branch],
+                Some(0x0100),
+            )
+            .expect("PEA displacement loop should compile");
+        let before = bailed.dar;
+        let packed = unsafe { bail_compiled.call_native(&mut bailed, 1) };
+        assert_eq!(packed, 0, "bail retires no instructions or cycles");
+        assert_eq!(bailed.pc, 0x0100);
+        assert_eq!(bailed.dar, before);
+        assert_eq!(bailed.get_ccr(), 0x15);
+        assert_eq!(bail_mem, untouched_mem, "nothing was stored");
+
+        // A stack slot overlapping the trace's own code hits the
+        // store-overlap guard before anything commits.
+        let mut smc_mem = vec![0u8; 0x1000];
+        let mut smc = prepare(&mut smc_mem, 0x486D, 0x0040);
+        smc.set_a(7, 0x0106);
+        let mut smc_jit = TraceJit::new();
+        let smc_compiled = smc_jit
+            .compile_decoded_ops(
+                &smc,
+                0x0100,
+                CpuType::M68040,
+                vec![pea, branch],
+                Some(0x0100),
+            )
+            .expect("PEA displacement loop should compile");
+        let before = smc.dar;
+        let packed = unsafe { smc_compiled.call_native(&mut smc, 1) };
+        assert_eq!(packed, 0, "store-overlap guard retires nothing");
+        assert_eq!(smc.dar, before);
+        assert_eq!(smc_mem, untouched_mem);
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]


### PR DESCRIPTION
## Summary

Admit `PEA (d16,An)` as a trace operation: the first predecrement store in
the trace JIT. The pushed value is the effective address computed from the
pre-decrement register state (correct even for `PEA (d16,A7)`), no
condition code changes, and the decremented stack slot passes the
alignment, window, and store-overlap checks before the store and the A7
update, so a failed check bails to full dispatch with nothing committed.

This follows the merged #68/#69/#72 and applies directly to master at
v0.7.2.

The source remains generic and contains no application-specific matching.

## Generated-code shape

`PEA (d16,A5)` is how classic Mac compilers pass an A5-relative global by
reference:

```c
DoSomething(&globals->field);   /* PEA $40(A5); ...; JSR/BSR */
```

The focused benchmark models the push with the popping load standing in
for the callee consuming the pointer:

```c
for (;;) {
    ++count;                        /* ADDQ.L #1,D0    */
    int32_t *arg = &globals->field; /* PEA $40(A5)     */
    sink = arg;                     /* MOVE.L (A7)+,D3 */
    ++iterations;                   /* ADDQ.L #1,D1    */
}
```

## Why this operation

With indexed CMPI.W admitted (#72), `PEA (d16,An)` is the largest
remaining trace-recording blocker in the stationary EV Override profile
(663.8 million guest instructions, `trace-profile` build with the
exact-path reporter): `486D`/`486E` blocked six trace heads — 903,738
rejected recordings and 16.6 million projected trace operations — with the
two hottest heads carrying 21-operation recorded prefixes, the longest
blocked prefixes in the profile.

Admitting the push lets recording continue past it; how much of that
projection is realized depends on what follows the push in each loop and
is measured with the same reporter below.

In the matching session with this change (482.0 million guest
instructions), `486D`/`486E` block nothing, and session-wide rejected
recordings fell from 93.8% to 87.0% of backward hits. The realized
breakdown is honest rather than triumphant: one of the six formerly
blocked heads compiled — a thirteen-operation trace retiring 2.0 million
guest instructions over 247,655 native calls, averaging only 8.1
operations per call — while the other five extended their recorded
prefixes past the push and now stop at the next operation in the same
argument-setup sequence, `CLR.L -(SP)` and `MOVE.W #imm,-(SP)`, which
this change promotes to the profile's top remaining blockers (7.5 and
1.0 million projected operations). The push family is a chain: each
admitted member moves the boundary toward the terminating `BSR.L`. This
PR contributes the predecrement-store machinery the rest of that chain
reuses.

## Correctness and safety

- Decode only the measured `(d16,An)` control form; all other PEA shapes
  keep their existing dispatch.
- Compute the pushed address from the pre-decrement register state, which
  keeps `PEA (d16,A7)` pushing the original stack pointer's address.
- Capture the displacement extension word for trace validation.
- Check alignment, window bounds, and store overlap with the trace's own
  code before the store; the store and the A7 update are the only state
  changes and both happen after every check.
- Change no condition codes.
- Account sixteen cycles: the MC68000's twelve-cycle push plus the
  four-cycle displacement extension fetch.
- Provide both portable-trace and native-JIT execution; the native tests
  cover portable equivalence, the `(d16,A7)` self-reference, an
  out-of-window bail, and a store-overlap bail, each retiring nothing.

## Performance

Focused benchmark: `pea-displacement`, a stack-balanced push/pop loop.
The instruction budget is one initializer plus exactly twenty million
five-instruction iterations, so the run ends at the loop head and the
benchmark asserts the final counters, the popped pointer value, and the
balanced stack.

Five alternating runs against a baseline worktree at v0.7.2 master that
carries an identical copy of the benchmark but none of this
implementation, M guest instructions/s:

| Run | v0.7.2 base | this PR |
|---:|---:|---:|
| 1 | 71.8 | 521.9 |
| 2 | 68.3 | 499.0 |
| 3 | 71.8 | 546.7 |
| 4 | 73.3 | 575.2 |
| 5 | 76.4 | 542.7 |
| **Median** | **71.8** | **542.7** |

That is a **7.56x** focused-loop speedup over the actual PR base.

Whole-application `sample` ladder (two consecutive 30-second 1 ms
captures per session; a four-session block in the same stationary scene:
baseline, this PR, a follow-up candidate, then the baseline again as a
drift control): this PR measured **21.96%** of main-thread observations
in the emulation-runner subtree versus **26.60%** for the baseline
sampled before it and **26.66%** for the identical baseline sampled at
the block's end — a **17.5% reduction**, against a measured drift
envelope of 0.06 points between the two baseline sessions. The
trap-dispatch share moved proportionally (the work mix was constant
across all four sessions), and an earlier independent pair reproduced
the same direction and magnitude. One stated caveat: the runner metric
is CPU share, not CPU per guest instruction, so in an elastic scene a
throughput gain can partially mask itself; on that reading this figure
is conservative.

## Validation

- `cargo test --all-features` and `cargo test` — full suite, 62 test
  binaries each, with both fixture submodules initialized
- `cargo test --all-features --lib pea_displacement` — decode, portable
  push/flag/PC behavior, native-versus-portable parity including
  `(d16,A7)`, atomic out-of-window and store-overlap bails
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features` / `--features jit` /
  `--features trace-profile`
- `cargo check --target wasm32-unknown-unknown --no-default-features`

<!-- Drafted by Claude Fable 5, 2026-08-05. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ28utnrHwacwzpZnVUbUx
