### PR TITLE
perf(execute): add precise decoded dispatch for boundary-hook runs

### DIFF
--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -756,7 +756,20 @@ impl CpuCore {
     /// automatically in this mode. For HLE interception with automatic fallback
     /// to exceptions, use `step_with_hle_handler()`.
     pub fn step<B: AddressBus>(&mut self, bus: &mut B) -> StepResult {
-        use crate::core::types::{InternalStepResult, StepResult};
+        self.step_with_dispatch(bus, dispatch_instruction)
+    }
+
+    /// Execute one precise instruction using the supplied post-fetch dispatcher.
+    ///
+    /// The helper owns the normal `step()` prologue and epilogue so internal
+    /// callers can select a dispatcher after the precise opcode fetch without
+    /// fetching the opcode twice.
+    fn step_with_dispatch<B, F>(&mut self, bus: &mut B, dispatch: F) -> StepResult
+    where
+        B: AddressBus,
+        F: FnOnce(&mut CpuCore, &mut B, u16) -> super::types::InternalStepResult,
+    {
+        use crate::core::types::InternalStepResult;
 
         self.set_precise_bus(true);
         if self.stopped != 0 {
@@ -779,7 +792,7 @@ impl CpuCore {
         }
 
         let opcode_fetch_cached = bus.last_fetch_was_cached();
-        let result = dispatch_instruction(self, bus, self.ir as u16);
+        let result = dispatch(self, bus, self.ir as u16);
         let fetch_cached = if matches!(
             self.cpu_type,
             super::types::CpuType::M68EC020 | super::types::CpuType::M68020

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -856,8 +856,9 @@ impl CpuCore {
 
     /// Execute the narrow decoded subset allowed by the boundary-hook runner.
     ///
-    /// 命令取得後にのみ呼び出す。対象外は同じ取得済み opcode を既存 dispatcher
-    /// へ渡すため、fetch/prefetch を再実行しない。
+    /// Called only after the precise opcode fetch. Unsupported operations pass the
+    /// same fetched opcode to the existing dispatcher without repeating fetch or
+    /// prefetch work.
     fn dispatch_boundary_hook_decoded<B: AddressBus>(
         &mut self,
         bus: &mut B,
@@ -865,7 +866,8 @@ impl CpuCore {
     ) -> super::types::InternalStepResult {
         use super::types::{CpuType, InternalStepResult};
 
-        // Trace 状態では通常 dispatch が trace 例外と model 固有処理を担当する。
+        // Trace states remain on the normal dispatcher so it can preserve trace
+        // exceptions and model-specific behavior.
         if self.run_mode != RUN_MODE_NORMAL || (self.t1_flag | self.t0_flag) != 0 {
             return dispatch_instruction(self, bus, opcode);
         }
@@ -874,7 +876,8 @@ impl CpuCore {
             self.cpu_type,
             DecodedSimpleOp::decode(self.cpu_type, opcode),
         ) {
-            // 68040 の NOP には T0 pipeline-sync の通常処理があるため除外する。
+            // M68040 NOP is excluded because the normal path performs T0 pipeline
+            // synchronization.
             (
                 CpuType::M68000 | CpuType::M68010 | CpuType::M68020 | CpuType::M68030,
                 Some(op @ DecodedSimpleOp::Nop),

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -5,7 +5,7 @@
 use super::cpu::{CpuCore, SFLAG_SET};
 use super::decode::{dispatch_instruction, needs_rollback_snapshot};
 use super::memory::AddressBus;
-use super::op_cache::BatchInnerExit;
+use super::op_cache::{BatchInnerExit, DecodedSimpleOp};
 use super::trace_jit;
 use super::types::{
     BatchExit, BatchResult, CycleBatchControl, CycleBatchExit, CycleBatchResult,
@@ -394,7 +394,11 @@ impl CpuCore {
             } else {
                 0
             };
-            let step_result = self.step(bus);
+            let step_result = if CALL_INSTRUCTION_HOOK && CALL_INTERRUPT_HOOK {
+                self.step_with_dispatch(bus, CpuCore::dispatch_boundary_hook_decoded)
+            } else {
+                self.step(bus)
+            };
             if CALL_INSTRUCTION_HOOK {
                 self.int_level = deferred_irq;
             }
@@ -848,6 +852,47 @@ impl CpuCore {
         }
 
         res
+    }
+
+    /// Execute the narrow decoded subset allowed by the boundary-hook runner.
+    ///
+    /// 命令取得後にのみ呼び出す。対象外は同じ取得済み opcode を既存 dispatcher
+    /// へ渡すため、fetch/prefetch を再実行しない。
+    fn dispatch_boundary_hook_decoded<B: AddressBus>(
+        &mut self,
+        bus: &mut B,
+        opcode: u16,
+    ) -> super::types::InternalStepResult {
+        use super::types::{CpuType, InternalStepResult};
+
+        // Trace 状態では通常 dispatch が trace 例外と model 固有処理を担当する。
+        if self.run_mode != RUN_MODE_NORMAL || (self.t1_flag | self.t0_flag) != 0 {
+            return dispatch_instruction(self, bus, opcode);
+        }
+
+        let fast_op = match (
+            self.cpu_type,
+            DecodedSimpleOp::decode(self.cpu_type, opcode),
+        ) {
+            // 68040 の NOP には T0 pipeline-sync の通常処理があるため除外する。
+            (
+                CpuType::M68000 | CpuType::M68010 | CpuType::M68020 | CpuType::M68030,
+                Some(op @ DecodedSimpleOp::Nop),
+            ) => op,
+            (
+                CpuType::M68000
+                | CpuType::M68010
+                | CpuType::M68020
+                | CpuType::M68030
+                | CpuType::M68040,
+                Some(op @ DecodedSimpleOp::Moveq { .. }),
+            ) => op,
+            _ => return dispatch_instruction(self, bus, opcode),
+        };
+
+        InternalStepResult::Ok {
+            cycles: fast_op.execute(self, bus),
+        }
     }
 
     /// Execute a single instruction with HLE trap handling (CPU + bus access).

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -889,7 +889,7 @@ impl CpuCore {
                 | CpuType::M68030
                 | CpuType::M68040,
                 Some(op @ DecodedSimpleOp::Moveq { .. }),
-            ) => op,
+            ) if opcode & 0x0100 == 0 => op,
             _ => return dispatch_instruction(self, bus, opcode),
         };
 

--- a/tests/run_for_cycles_tests.rs
+++ b/tests/run_for_cycles_tests.rs
@@ -962,3 +962,84 @@ fn boundary_hook_decoded_subset_observes_hook_cpu_state_changes() {
     assert_cpu_state_eq(&decoded_cpu, &precise_cpu);
     assert_eq!(decoded_cpu.d(1), 2);
 }
+
+#[test]
+fn boundary_hook_decoded_subset_matches_step_when_hook_raises_irq() {
+    for cpu_type in [CpuType::M68000, CpuType::M68020, CpuType::M68040] {
+        let mut initial_bus = EventBus::new();
+        initial_bus.load_word(0x1000, 0x7001); // MOVEQ #1,D0: fast-path target
+        initial_bus.load_word(0x1002, 0x7201); // MOVEQ #1,D1: must not execute
+        initial_bus.load_long(0x6C, 0x2000); // level-3 autovector
+        initial_bus.load_word(0x2000, 0x4E71); // handler entry: must not execute
+        initial_bus.boundary_on_interrupt_acknowledge = true;
+
+        let mut precise_bus = initial_bus.clone();
+        let mut decoded_bus = initial_bus;
+        let mut precise_cpu = cpu_at(cpu_type, 0x1000);
+        let mut decoded_cpu = cpu_at(cpu_type, 0x1000);
+        precise_cpu.set_sr(0x2000); // supervisor, interrupt mask 0
+        decoded_cpu.set_sr(0x2000);
+
+        let mut precise_instruction_events = Vec::new();
+        let precise =
+            precise_cpu.run_for_cycles_with_hook(&mut precise_bus, 100, |cpu, _, cycles| {
+                precise_instruction_events.push(CycleBoundaryEvent::Instruction { cycles });
+                if cpu.ppc == 0x1000 {
+                    cpu.set_irq(3);
+                }
+                CycleBatchControl::Continue
+            });
+        assert_eq!(precise_instruction_events.len(), 1, "{cpu_type:?}");
+        let mut precise_events = precise_instruction_events;
+        let instruction_cycles = match precise_events[0] {
+            CycleBoundaryEvent::Instruction { cycles } => cycles,
+            CycleBoundaryEvent::InterruptEntry { .. } => unreachable!(),
+        };
+        precise_events.push(CycleBoundaryEvent::InterruptEntry {
+            cycles: precise.cycles - instruction_cycles,
+        });
+
+        let mut decoded_events = Vec::new();
+        let decoded = decoded_cpu.run_for_cycles_with_boundary_hook(
+            &mut decoded_bus,
+            100,
+            |cpu, _, event| {
+                decoded_events.push(event);
+                if matches!(event, CycleBoundaryEvent::Instruction { .. }) && cpu.ppc == 0x1000 {
+                    cpu.set_irq(3);
+                }
+                CycleBatchControl::Continue
+            },
+        );
+
+        assert_eq!(decoded, precise, "{cpu_type:?}");
+        assert_eq!(decoded_events, precise_events, "{cpu_type:?}");
+        assert_eq!(
+            decoded_events,
+            vec![
+                CycleBoundaryEvent::Instruction {
+                    cycles: instruction_cycles,
+                },
+                CycleBoundaryEvent::InterruptEntry {
+                    cycles: precise.cycles - instruction_cycles,
+                },
+            ],
+            "{cpu_type:?}"
+        );
+        assert_eq!(decoded.instructions, 1, "{cpu_type:?}");
+        assert_eq!(
+            decoded.exit,
+            CycleBatchExit::BoundaryRequested,
+            "{cpu_type:?}"
+        );
+        assert_eq!(decoded_cpu.pc, 0x2000, "{cpu_type:?}");
+        assert_eq!(decoded_cpu.d(1), 0, "{cpu_type:?}");
+        assert_cpu_state_eq(&decoded_cpu, &precise_cpu);
+        assert_eq!(decoded_bus.memory, precise_bus.memory, "{cpu_type:?}");
+        assert_eq!(
+            &decoded_bus.memory[0x7F00..0x8000],
+            &precise_bus.memory[0x7F00..0x8000],
+            "{cpu_type:?} stack frame"
+        );
+    }
+}

--- a/tests/run_for_cycles_tests.rs
+++ b/tests/run_for_cycles_tests.rs
@@ -1043,3 +1043,47 @@ fn boundary_hook_decoded_subset_matches_step_when_hook_raises_irq() {
         );
     }
 }
+
+#[test]
+fn boundary_hook_decoded_subset_rejects_reserved_moveq_encoding() {
+    let mut initial_bus = EventBus::new();
+    initial_bus.load_word(0x1000, 0x7100); // Reserved group-7 encoding, not MOVEQ.
+    initial_bus.start_recording_word_reads();
+
+    let mut precise_bus = initial_bus.clone();
+    let mut decoded_bus = initial_bus;
+    let mut precise_cpu = cpu_at(CpuType::M68000, 0x1000);
+    let mut decoded_cpu = cpu_at(CpuType::M68000, 0x1000);
+    precise_cpu.set_d(0, 0xDEAD_BEEF);
+    decoded_cpu.set_d(0, 0xDEAD_BEEF);
+    let mut precise_hooks = 0;
+    let mut decoded_hooks = 0;
+
+    let precise = precise_cpu.run_for_cycles_with_hook(&mut precise_bus, 100, |_, _, _| {
+        precise_hooks += 1;
+        CycleBatchControl::Continue
+    });
+    let decoded =
+        decoded_cpu.run_for_cycles_with_boundary_hook(&mut decoded_bus, 100, |_, _, event| {
+            if matches!(event, CycleBoundaryEvent::Instruction { .. }) {
+                decoded_hooks += 1;
+            }
+            CycleBatchControl::Continue
+        });
+
+    let expected_exit = CycleBatchExit::IllegalInstruction { opcode: 0x7100 };
+    assert_eq!(precise.exit, expected_exit);
+    assert_eq!(decoded, precise);
+    assert_eq!(decoded.cycles, 0);
+    assert_eq!(decoded.instructions, 0);
+    assert_eq!(precise_hooks, 0);
+    assert_eq!(decoded_hooks, 0);
+    assert_cpu_state_eq(&decoded_cpu, &precise_cpu);
+    assert_eq!(decoded_cpu.ir, precise_cpu.ir);
+    assert_eq!(decoded_cpu.dar_save, precise_cpu.dar_save);
+    assert_eq!(decoded_cpu.sr_save, precise_cpu.sr_save);
+    assert_eq!(decoded_cpu.prefetch_queue, precise_cpu.prefetch_queue);
+    assert_eq!(decoded_cpu.prefetch_count, precise_cpu.prefetch_count);
+    assert_eq!(decoded_bus.memory, precise_bus.memory);
+    assert_eq!(decoded_bus.word_reads, precise_bus.word_reads);
+}

--- a/tests/run_for_cycles_tests.rs
+++ b/tests/run_for_cycles_tests.rs
@@ -284,6 +284,8 @@ struct EventBus {
     boundary_write_address: Option<u32>,
     boundary_on_interrupt_acknowledge: bool,
     boundary_requested: bool,
+    record_word_reads: bool,
+    word_reads: Vec<u32>,
 }
 
 impl EventBus {
@@ -296,6 +298,8 @@ impl EventBus {
             boundary_write_address: None,
             boundary_on_interrupt_acknowledge: false,
             boundary_requested: false,
+            record_word_reads: false,
+            word_reads: Vec::new(),
         }
     }
 
@@ -312,6 +316,11 @@ impl EventBus {
         self.overlay_memory[address as usize & 0xFFFF] = hi;
         self.overlay_memory[address.wrapping_add(1) as usize & 0xFFFF] = lo;
     }
+
+    fn start_recording_word_reads(&mut self) {
+        self.word_reads.clear();
+        self.record_word_reads = true;
+    }
 }
 
 impl AddressBus for EventBus {
@@ -325,6 +334,9 @@ impl AddressBus for EventBus {
     }
 
     fn read_word(&mut self, address: u32) -> u16 {
+        if self.record_word_reads {
+            self.word_reads.push(address);
+        }
         u16::from_be_bytes([
             self.read_byte(address),
             self.read_byte(address.wrapping_add(1)),
@@ -835,4 +847,118 @@ fn cycle_batch_matches_step_after_fast_path_warmup() {
     assert_eq!(result.instructions, instructions);
     assert_eq!(result.exit, CycleBatchExit::BudgetExhausted);
     assert_cpu_state_eq(&batch_cpu, &step_cpu);
+}
+
+#[test]
+fn boundary_hook_decoded_subset_matches_step_for_each_supported_cpu_model() {
+    let words = [
+        (0x1000, 0x4E71), // NOP
+        (0x1002, 0x7001), // MOVEQ #1,D0
+        (0x1004, 0x4E71), // NOP
+        (0x1006, 0x76FE), // MOVEQ #-2,D3
+    ];
+
+    for cpu_type in [
+        CpuType::M68000,
+        CpuType::M68010,
+        CpuType::M68020,
+        CpuType::M68030,
+        CpuType::M68040,
+    ] {
+        let mut precise_bus = bus_with(&words);
+        let mut decoded_bus = bus_with(&words);
+        let mut precise_cpu = cpu_at(cpu_type, 0x1000);
+        let mut decoded_cpu = cpu_at(cpu_type, 0x1000);
+        let mut precise_hooks = 0;
+        let mut decoded_hooks = 0;
+
+        let precise = precise_cpu.run_for_cycles_with_hook(&mut precise_bus, 16, |_, _, _| {
+            precise_hooks += 1;
+            CycleBatchControl::Continue
+        });
+        let decoded =
+            decoded_cpu.run_for_cycles_with_boundary_hook(&mut decoded_bus, 16, |_, _, event| {
+                if matches!(event, CycleBoundaryEvent::Instruction { .. }) {
+                    decoded_hooks += 1;
+                }
+                CycleBatchControl::Continue
+            });
+
+        assert_eq!(decoded, precise, "{cpu_type:?}");
+        assert_eq!(decoded_hooks, precise_hooks, "{cpu_type:?}");
+        assert_cpu_state_eq(&decoded_cpu, &precise_cpu);
+    }
+}
+
+#[test]
+fn boundary_hook_decoded_subset_falls_back_without_changing_fetch_order() {
+    let mut initial_bus = EventBus::new();
+    initial_bus.load_word(0x1000, 0x7001); // MOVEQ #1,D0
+    initial_bus.load_word(0x1002, 0x5280); // ADDQ.L #1,D0: unsupported
+    initial_bus.load_word(0x1004, 0x4E71); // NOP
+    initial_bus.load_word(0x1006, 0x76FE); // MOVEQ #-2,D3
+    initial_bus.start_recording_word_reads();
+
+    let mut precise_bus = initial_bus.clone();
+    let mut decoded_bus = initial_bus;
+    let mut precise_cpu = cpu_at(CpuType::M68000, 0x1000);
+    let mut decoded_cpu = cpu_at(CpuType::M68000, 0x1000);
+    let mut precise_hooks = 0;
+    let mut decoded_hooks = 0;
+
+    let precise = precise_cpu.run_for_cycles_with_hook(&mut precise_bus, 20, |_, _, _| {
+        precise_hooks += 1;
+        CycleBatchControl::Continue
+    });
+    let decoded =
+        decoded_cpu.run_for_cycles_with_boundary_hook(&mut decoded_bus, 20, |_, _, event| {
+            if matches!(event, CycleBoundaryEvent::Instruction { .. }) {
+                decoded_hooks += 1;
+            }
+            CycleBatchControl::Continue
+        });
+
+    assert_eq!(decoded, precise);
+    assert_eq!(decoded_hooks, precise_hooks);
+    assert_cpu_state_eq(&decoded_cpu, &precise_cpu);
+    assert_eq!(decoded_bus.word_reads, precise_bus.word_reads);
+}
+
+#[test]
+fn boundary_hook_decoded_subset_observes_hook_cpu_state_changes() {
+    let words = [
+        (0x1000, 0x4E71), // NOP
+        (0x1002, 0x7001), // skipped by the hook's PC update
+        (0x1004, 0x7202), // MOVEQ #2,D1
+        (0x1006, 0x4E71), // M68040 fallback
+    ];
+    let mut precise_bus = bus_with(&words);
+    let mut decoded_bus = bus_with(&words);
+    let mut precise_cpu = cpu_at(CpuType::M68020, 0x1000);
+    let mut decoded_cpu = cpu_at(CpuType::M68020, 0x1000);
+
+    let update_after_first_instruction = |cpu: &mut CpuCore| {
+        if cpu.ppc == 0x1000 {
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_sr(cpu.get_sr() | 1);
+            cpu.pc = 0x1004;
+            cpu.invalidate_prefetch();
+        }
+    };
+    let precise = precise_cpu.run_for_cycles_with_hook(&mut precise_bus, 12, |cpu, _, _| {
+        update_after_first_instruction(cpu);
+        CycleBatchControl::Continue
+    });
+
+    let decoded =
+        decoded_cpu.run_for_cycles_with_boundary_hook(&mut decoded_bus, 12, |cpu, _, event| {
+            if matches!(event, CycleBoundaryEvent::Instruction { .. }) {
+                update_after_first_instruction(cpu);
+            }
+            CycleBatchControl::Continue
+        });
+
+    assert_eq!(decoded, precise);
+    assert_cpu_state_eq(&decoded_cpu, &precise_cpu);
+    assert_eq!(decoded_cpu.d(1), 2);
 }


### PR DESCRIPTION
Addresses #71

## Summary

This is a bounded internal experiment for `run_for_cycles_with_boundary_hook()`.

It adds a narrow decoded dispatch for register-only, exact-timing operations while preserving the existing precise instruction-boundary contract. There are no public API changes, and this PR does not use or modify FastMem, portable traces, or native traces.

## Design

`step()` now delegates to a private `step_with_dispatch()` helper. The helper retains the existing precise path:

- `set_precise_bus(true)`
- stopped-state handling
- `begin_instruction_fetches()`
- `ppc`, rollback, and SR snapshots
- precise opcode fetch and prefetch behavior
- fault handling
- cache/fetch accounting
- instruction-end prefetch top-up
- trace and IRQ handling

The boundary-hook runner selects its dispatcher only after that precise opcode fetch has completed.

For an unsupported opcode, the fast dispatcher does not call `step()` again and does not fetch again. It passes the already fetched opcode to the existing `dispatch_instruction()` path before any fast-executor register, flag, or memory mutation.

The shared precise fetch prologue may update the same fetch, prefetch, PPC, and rollback state that `step()` updates; the fallback guarantee applies to mutations performed by the narrow decoded executor itself.

The initial allowlist is intentionally small:

| Operation | CPU models |
| --- | --- |
| NOP | M68000, M68010, M68020, M68030 |
| MOVEQ | M68000, M68010, M68020, M68030, M68040 |

M68040 NOP is excluded because the normal dispatcher includes model-specific T0 pipeline synchronization that this narrow executor does not reproduce.

The existing runner ordering is unchanged: after normal instruction retirement, the hook is invoked, any hook-side CPU or bus changes take effect, bus boundary requests are checked, and IRQ state is reevaluated before another ordinary instruction can execute. `InterruptEntry` remains separate from retired instruction accounting.

The narrow dispatcher is only selected during normal run mode when T0 and T1 tracing are inactive.

## Prefetch and Host-side PC Changes

This PR does not add automatic prefetch invalidation after a hook changes `cpu.pc`.

`CpuCore::invalidate_prefetch()` is the existing host contract for an externally forced PC or instruction-visible mapping change. The differential test explicitly calls it after changing PC, on both the repeated-step reference path and the boundary-hook path.

## Tests

Added coverage verifies:

- CPU state, cycles, and hook counts against the repeated-step runner for M68000 through M68040.
- Unsupported `ADDQ` falls through to the normal dispatcher without changing the M68000 word-read access order.
- Hook-side changes to PC, SR, and CPU type preserve equivalence when the existing prefetch invalidation contract is followed.
- A hook-raised IRQ is serviced before the next ordinary instruction for M68000, M68020, and M68040.
- The hook-raised IRQ differential compares consumed cycles, retired instructions, instruction-hook count, interrupt-entry event sequence, return reason, PC/SR/D/A registers, stack state, and guest memory.
- Existing hook return, bus boundary, IRQ promotion, interrupt-entry, and resume tests remain green.

Validation was run after rebasing onto current `master`:

```text
cargo fmt --all -- --check
cargo clippy --all-targets --all-features --locked -- -D warnings
cargo test --all-features --locked
cargo package --locked
```

All four commands completed successfully.

## Controlled Release Benchmark

The benchmark uses a CPU-only `AddressBus` with no FastMem. It keeps the two Issue #71 workloads unchanged.

All measurements used the same release test binary:

- binary: `m68k_issue71_benchmark-ba0d5d12d26b4b4b.exe`
- SHA-256: `A327ED60C0FEBC148086F5ABE45742458FC93FAF8CF4E45EAC6F104AA0CA4EDF`
- Rust: `rustc 1.93.0 (254b59607 2026-01-19)`, `x86_64-pc-windows-msvc`
- host: Windows 10 Pro build 19045, Intel Core i7-6700K

Each of two separate processes used:

- a 100,000,000-cycle budget
- three warm-up pairs per workload
- twenty measured step/boundary pairs per workload
- alternating runner order
- exact equality assertions for consumed cycles, retired instructions, hook count, the architectural CPU register/control state compared by the benchmark, and guest RAM

The process was pinned to logical CPU 0 through `SetProcessAffinityMask`. The Windows power plan was left unchanged at Balanced, and no frequency pinning was applied.

The paired ratio is `boundary / step`; values below 1.0 are faster.

| Workload | Run 1 median | Run 2 median | Combined median | 10% trimmed mean | IQR |
| --- | ---: | ---: | ---: | ---: | ---: |
| NOP / BRA | 1.018309 | 1.007964 | 1.009591 | 1.015726 | 0.075824 |
| MOVEQ / MOVEQ / BRA | 0.785594 | 0.777737 | 0.785408 | 0.785579 | 0.061511 |

| Workload | Cycles | Instructions / hooks | Fast hits | Fallbacks |
| --- | ---: | ---: | ---: | ---: |
| NOP / BRA | 100,000,002 | 14,285,715 | 7,142,858 NOP | 7,142,857 BRA |
| MOVEQ / MOVEQ / BRA | 100,000,008 | 16,666,668 | 11,111,112 MOVEQ | 5,555,556 BRA |

The NOP/BRA workload is near parity and slightly slower at the combined median. Its 50% fallback ratio makes dispatch classification overhead outweigh the narrow fast path.

The MOVEQ/MOVEQ/BRA workload shows a repeatable material improvement: the combined median is 0.785408, or approximately 21.46% faster than the repeated-step reference.

No samples were silently discarded. Secondary Tukey 1.5*IQR analysis removes five NOP/BRA and one MOVEQ/MOVEQ/BRA ratio outliers; the corresponding medians remain 1.010295 and 0.785263. The large NOP/BRA variance is consistent with host scheduling or interference, but this attribution is not proven.

The raw sample records and complete statistical summary are available on request.

## Known Limitations

- This is not a decoded cache, trace engine, or FastMem path.
- The allowlist is deliberately limited to NOP and MOVEQ.
- M68040 NOP remains on the normal dispatcher.
- The benchmark is CPU-only and host frequency is unpinned.
- Future opcode expansion requires separate proof for each CPU model's timing, special state, precise fetch/prefetch behavior, AddressBus order, hook behavior, and fallback-before-mutation behavior.
