### PR TITLE
feat: classify pure poll loops at trace compile time

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -419,6 +419,9 @@ pub(crate) enum JitTraceOp {
 /// it is reported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RegionRejectReason {
+    /// The recorded self-loop is a pure poll: a wait, deliberately left
+    /// uncompiled. Reported as a wait rather than as a silent rejection.
+    WaitLoop,
     NoTraceTerminal,
     TooShort,
     IndirectJsrTooShort,
@@ -1007,6 +1010,14 @@ impl TraceJit {
         use super::trace_profile::TraceRejectReason as Public;
         // Exhaustive so a new compile gate must declare how it is reported.
         match reason {
+            // A classified wait is routed to `note_wait_loop` by
+            // `finish_recording` before this mapping is consulted; the
+            // profiler represents it through the shape-keyed wait table
+            // flag and the wait-loops report section, never as a silent
+            // rejection.
+            RegionRejectReason::WaitLoop => {
+                unreachable!("classified waits are reported via note_wait_loop")
+            }
             RegionRejectReason::NoTraceTerminal => Public::NoTraceTerminal,
             RegionRejectReason::TooShort => Public::TooShort,
             RegionRejectReason::IndirectJsrTooShort => Public::IndirectJsrTooShort,
@@ -1099,7 +1110,15 @@ impl TraceJit {
             // decoded path outranks the compile-stage reason: it bounds how
             // far this head can ever record, which no opcode coverage can
             // change.
-            if end != RecordingEnd::Blocker {
+            if reason == RegionRejectReason::WaitLoop {
+                // A classified wait is accounted as a wait, keyed by the
+                // recorded shape so the accounting is independent of any
+                // blocker shapes at the same head, in either recording
+                // order. It keeps its own report section and its exclusion
+                // from the opportunity ranking, rather than being filed as
+                // a generic rejection.
+                super::trace_profile::note_wait_loop(start_pc, cpu_type, recorded_shape);
+            } else if end != RecordingEnd::Blocker {
                 let reason = match end {
                     RecordingEnd::Stopped(cause) => Self::profile_stop_reason(cause),
                     _ => Self::profile_reject_reason(reason),
@@ -1319,6 +1338,23 @@ impl TraceJit {
             })
         {
             return Err(RegionRejectReason::LinearMemoryAlu);
+        }
+
+        // A pure poll loop burns wall time by design: its exit depends only
+        // on memory it never writes, so executing it faster cannot make it
+        // exit sooner. It is also exactly the class no trap-anchored wait
+        // detector can see. Compiling it as a native spin multiplies the
+        // instructions burned per wall second while the guest waits, so
+        // refuse the compilation and leave the loop on the decoded path.
+        //
+        // This requires the recording to have actually gone round, not
+        // merely to end in a branch whose static target is the head.
+        // `self_loop` is true for a fall-through path as well, and a
+        // recording that fell through to an unsupported operation is a
+        // different shape entirely: reporting it as a wait would remove a
+        // real blocker from the opportunity ranking.
+        if recorded_exit_pc == Some(start_pc) && is_pure_poll_loop(&ops) {
+            return Err(RegionRejectReason::WaitLoop);
         }
 
         let needs_window = ops.iter().any(|op| {
@@ -1734,6 +1770,116 @@ struct CompileParams<'a> {
     aligned_only: bool,
     #[cfg_attr(any(not(feature = "jit"), target_family = "wasm"), allow(dead_code))]
     address_mask: u32,
+}
+
+const CC_N: u8 = 0b1000;
+const CC_Z: u8 = 0b0100;
+const CC_V: u8 = 0b0010;
+const CC_C: u8 = 0b0001;
+
+/// Condition codes a 68k conditional branch reads. `T`/`F` read nothing.
+fn branch_flags_read(condition: u8) -> u8 {
+    match condition & 0xF {
+        0 | 1 => 0,              // T / F
+        2 | 3 => CC_C | CC_Z,    // HI / LS
+        4 | 5 => CC_C,           // CC / CS
+        6 | 7 => CC_Z,           // NE / EQ
+        8 | 9 => CC_V,           // VC / VS
+        10 | 11 => CC_N,         // PL / MI
+        12 | 13 => CC_N | CC_V,  // GE / LT
+        _ => CC_N | CC_V | CC_Z, // GT / LE
+    }
+}
+
+/// A recorded self-loop is a pure poll when it consists of memory reads
+/// that mutate nothing except the condition codes, followed by a single
+/// terminal conditional branch whose consumed flags were all written by
+/// those reads (conservative flag provenance: a BTST-only loop branching
+/// on carry does not classify, because BTST writes only Z). Interior
+/// branches disqualify: a guarded interior branch means the head can
+/// record multiple dynamic shapes, and the profiler's per-head wait flag
+/// is only sound when the recorded path is structurally unique. Such a
+/// loop's exit can only be driven by memory it never writes, so
+/// executing it faster cannot make it exit sooner — it is a wait. The
+/// match is exhaustive so every future trace operation must declare its
+/// classification here.
+fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
+    let Some((terminal, body)) = ops.split_last() else {
+        return false;
+    };
+    let JitTraceOp::Branch { condition, .. } = terminal.op else {
+        return false;
+    };
+    let consumed = branch_flags_read(condition);
+    if consumed == 0 {
+        // An unconditional terminal branch has no memory-driven exit.
+        return false;
+    }
+    let mut mem_written_flags: u8 = 0;
+    for op in body {
+        match op.op {
+            // No-ops mutate nothing.
+            JitTraceOp::Nop => {}
+            // Interior branches make the recorded path non-unique for
+            // this head; per-head wait accounting would then erase
+            // opportunity data belonging to other shapes.
+            JitTraceOp::Branch { .. } => return false,
+            // Memory-reading compares and tests write NZVC only; the
+            // polled value is the only input that can change.
+            JitTraceOp::TstMem { .. }
+            | JitTraceOp::CmpiWordMem { .. }
+            | JitTraceOp::AddrCmpMemToReg { .. }
+            | JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                ..
+            }
+            | JitTraceOp::AnDispUnary {
+                op: JitUnaryOp::Tst,
+                ..
+            } => mem_written_flags |= CC_N | CC_Z | CC_V | CC_C,
+            // A bit test writes only Z.
+            JitTraceOp::AnDispBit {
+                op: JitBitOp::Test, ..
+            } => mem_written_flags |= CC_Z,
+            // Everything else mutates registers or memory, or transfers
+            // control in a way that can end the wait from inside: any of
+            // those makes the loop's progress self-driven, so it is not a
+            // pure poll.
+            JitTraceOp::MoveReg { .. }
+            | JitTraceOp::Moveq { .. }
+            | JitTraceOp::UnaryDataReg { .. }
+            | JitTraceOp::AddqSubqReg { .. }
+            | JitTraceOp::AddqSubqAddr { .. }
+            | JitTraceOp::BinaryDataReg { .. }
+            | JitTraceOp::BinaryImmediateDataReg { .. }
+            | JitTraceOp::MulWordDataReg { .. }
+            | JitTraceOp::MulWordImmediate { .. }
+            | JitTraceOp::MulLongDataReg { .. }
+            | JitTraceOp::AddrDataReg { .. }
+            | JitTraceOp::AddrCmpImmediate { .. }
+            | JitTraceOp::LeaAn { .. }
+            | JitTraceOp::LeaIndex { .. }
+            | JitTraceOp::AddSubxReg { .. }
+            | JitTraceOp::BitReg { .. }
+            | JitTraceOp::Exg { .. }
+            | JitTraceOp::Ext { .. }
+            | JitTraceOp::Extb { .. }
+            | JitTraceOp::SccDataReg { .. }
+            | JitTraceOp::ShiftReg { .. }
+            | JitTraceOp::Swap { .. }
+            | JitTraceOp::Dbcc { .. }
+            | JitTraceOp::IndirectJsr { .. }
+            | JitTraceOp::MoveMem { .. }
+            | JitTraceOp::MovemWordPostInc { .. }
+            | JitTraceOp::AluMemToReg { .. }
+            | JitTraceOp::AnDispUnary { .. }
+            | JitTraceOp::AddRegToMem { .. }
+            | JitTraceOp::MemAddqSubq { .. }
+            | JitTraceOp::AnDispBit { .. }
+            | JitTraceOp::PeaDisp { .. } => return false,
+        }
+    }
+    mem_written_flags != 0 && consumed & !mem_written_flags == 0
 }
 
 /// Attempt to execute a compiled trace at the current PC. See
@@ -9420,5 +9566,516 @@ mod portable_tests {
                 assert_eq!(actual.ir, 0x60FC);
             }
         }
+    }
+
+    #[test]
+    fn pure_poll_classification_requires_idempotence_and_a_memory_read() {
+        let branch = TraceBuildOp {
+            opcode: 0x67FA,
+            extension: None,
+            extension2: None,
+            pc: 0x0104,
+            op: JitTraceOp::Branch {
+                condition: 7,
+                displacement: -6,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+        let poll = TraceBuildOp {
+            opcode: 0xB26D,
+            extension: Some(0xFFF0),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Cmp,
+                size: Size::Word,
+                src: JitEa::Disp(5, -16),
+                dst: 1,
+            },
+        };
+        // A memory compare plus the loop branch: a pure poll.
+        assert!(is_pure_poll_loop(&[poll, branch]));
+
+        // A memory-tested loop is also a poll.
+        let tst = TraceBuildOp {
+            opcode: 0x4A6D,
+            extension: Some(0xFFF0),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::AnDispUnary {
+                op: JitUnaryOp::Tst,
+                size: Size::Word,
+                reg: 5,
+                displacement: -16,
+            },
+        };
+        assert!(is_pure_poll_loop(&[tst, branch]));
+
+        // No memory read: burning by intent (a calibration loop), not a poll.
+        assert!(!is_pure_poll_loop(&[branch]));
+
+        // Any register mutation makes progress self-driven.
+        let counter = TraceBuildOp {
+            opcode: 0x5280,
+            extension: None,
+            extension2: None,
+            pc: 0x0102,
+            op: JitTraceOp::AddqSubqReg {
+                reg: 0,
+                data: 1,
+                size: Size::Long,
+                is_sub: false,
+            },
+        };
+        assert!(!is_pure_poll_loop(&[poll, counter, branch]));
+
+        // A memory ALU that writes its destination register is not a poll.
+        let add = TraceBuildOp {
+            op: JitTraceOp::AluMemToReg {
+                op: JitBinaryOp::Add,
+                size: Size::Word,
+                src: JitEa::Disp(5, -16),
+                dst: 1,
+            },
+            ..poll
+        };
+        assert!(!is_pure_poll_loop(&[add, branch]));
+
+        // Loading through a scratch register is register mutation, even
+        // though the loop "only" polls: not classified (v1 is strict).
+        let scratch_load = TraceBuildOp {
+            op: JitTraceOp::MoveMem {
+                size: Size::Word,
+                src: JitEa::Disp(5, -16),
+                dst: JitEa::Data(0),
+            },
+            ..poll
+        };
+        assert!(!is_pure_poll_loop(&[scratch_load, branch]));
+
+        // Flag provenance: a bit test writes only Z, so a loop branching
+        // on Z classifies…
+        let btst = TraceBuildOp {
+            opcode: 0x082D,
+            extension: Some(0x0003),
+            extension2: Some(0xFFF0),
+            pc: 0x0100,
+            op: JitTraceOp::AnDispBit {
+                op: JitBitOp::Test,
+                bit: JitBitSource::Imm(3),
+                reg: 5,
+                displacement: -16,
+            },
+        };
+        let bne = TraceBuildOp {
+            op: JitTraceOp::Branch {
+                condition: 6,
+                displacement: -8,
+                length: 2,
+                expected_taken: None,
+            },
+            ..branch
+        };
+        assert!(is_pure_poll_loop(&[btst, bne]));
+
+        // …but the same loop branching on carry does not: BTST never
+        // writes C, so the exit would depend on preserved pre-loop state.
+        let bcs = TraceBuildOp {
+            op: JitTraceOp::Branch {
+                condition: 5,
+                displacement: -8,
+                length: 2,
+                expected_taken: None,
+            },
+            ..branch
+        };
+        assert!(!is_pure_poll_loop(&[btst, bcs]));
+
+        // A loop with only an unconditional branch has no memory-driven
+        // exit and is not classified.
+        let bra = TraceBuildOp {
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -6,
+                length: 2,
+                expected_taken: None,
+            },
+            ..branch
+        };
+        assert!(!is_pure_poll_loop(&[poll, bra]));
+
+        // Regression for the multi-shape hazard: an interior guarded
+        // branch means this head can record several dynamic paths (a poll
+        // path and a mutating path), and the per-head wait flag would
+        // erase the non-wait shapes' opportunity data. Such loops must
+        // not classify; only a single terminal conditional branch keeps
+        // the recorded path structurally unique.
+        let guarded = TraceBuildOp {
+            op: JitTraceOp::Branch {
+                condition: 6,
+                displacement: 4,
+                length: 2,
+                expected_taken: Some(false),
+            },
+            ..branch
+        };
+        assert!(!is_pure_poll_loop(&[poll, guarded, bra]));
+        assert!(!is_pure_poll_loop(&[poll, guarded, branch]));
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        feature = "trace-profile",
+        not(target_family = "wasm")
+    ))]
+    #[test]
+    fn blocker_then_eviction_then_wait_keeps_the_blocker_ranked() {
+        // Ben's reverse-order reproduction: record the fall-through blocker
+        // first, evict the slot, then classify the taken loop as a wait.
+        // Both orderings must converge to the same reported state: the
+        // blocker stays visible in the opportunity ranking, the wait shape
+        // reports in the wait section, and wait-attributed volume cannot
+        // inflate projected dispatches.
+        super::super::trace_profile::reset();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x4000);
+        bus.write_word(0x0100, 0xB26D); // CMP.W (-0x10,A5),D1
+        bus.write_word(0x0102, 0xFFF0);
+        bus.write_word(0x0104, 0x67FA); // BEQ.S head
+        bus.write_word(0x0106, 0xC3F0); // MULS.W (0,A0,D0.W),D1 -- untraceable
+        bus.write_word(0x0108, 0x0800);
+        bus.write_word(0x010A, 0x60F4); // BRA.S head
+        bus.write_word(0x0300, 0x1234); // the polled word
+        bus.write_word(0x2100, 0x5282); // ADDQ.L #1,D2
+        bus.write_word(0x2102, 0x60FC); // BRA.S 0x2100
+
+        let mut cpu = cpu();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(5, 0x0310);
+        cpu.set_a(0, 0x0400);
+        cpu.set_a(7, 0x0900);
+        cpu.set_d(0, 0);
+
+        // Phase 1: unequal compare -- fall-through records the blocker.
+        cpu.pc = 0x0100;
+        cpu.set_d(1, 0x5555);
+        cpu.run_batch(&mut bus, 5_000, &[]);
+        let mid = super::super::trace_profile::snapshot();
+        assert_eq!(
+            mid.rows
+                .iter()
+                .find(|row| row.start_pc == 0x0100)
+                .expect("phase 1 head profiled")
+                .blocker_pc,
+            Some(0x0106),
+            "phase 1 records the real blocker"
+        );
+
+        // Phase 2: evict the direct-mapped slot with the colliding head.
+        cpu.pc = 0x2100;
+        cpu.run_batch(&mut bus, 200, &[]);
+
+        // Phase 3: equal compare -- the taken loop classifies as a wait.
+        cpu.pc = 0x0100;
+        cpu.set_d(1, 0x1234);
+        cpu.run_batch(&mut bus, 5_000, &[]);
+
+        let snapshot = super::super::trace_profile::snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0x0100)
+            .expect("phase 3 head profiled");
+        assert_eq!(
+            row.blocker_pc,
+            Some(0x0106),
+            "the wait classification never disturbs blocker accounting"
+        );
+        assert!(row.wait_hits > 0, "phase-3 spins attribute as wait hits");
+        assert!(
+            snapshot
+                .wait_shapes
+                .iter()
+                .any(|shape| shape.start_pc == 0x0100),
+            "the wait shape reports independently"
+        );
+        assert_eq!(
+            row.projected_dispatches(),
+            row.rejected_hits
+                .saturating_sub(row.wait_hits)
+                .saturating_mul(u64::from(row.prefix_ops)),
+            "wait volume is subtracted from the ranking metric"
+        );
+
+        let report = snapshot.report();
+        let ranking = report
+            .split("wait loops")
+            .next()
+            .expect("report has a ranking section");
+        assert!(
+            ranking.contains("00000100"),
+            "the blocker keeps the head visible in the ranking: {ranking}"
+        );
+        assert!(report.contains("wait loops"));
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        feature = "trace-profile",
+        not(target_family = "wasm")
+    ))]
+    #[test]
+    fn wait_then_eviction_then_fall_through_restores_the_blocker() {
+        // The wait bit must reflect the most recent completed recording,
+        // not the first. Sequence: classify a genuine wait; evict its
+        // direct-mapped slot with a colliding head (0x0100 and 0x2100 both
+        // map to slot 0x80); revisit with the compare unequal so the back
+        // edge falls through into an unsupported operation. The second
+        // recording finds a real blocker, and the head must return to the
+        // opportunity ranking rather than staying hidden in the wait
+        // section by the stale classification.
+        super::super::trace_profile::reset();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x4000);
+        // Wait/fall-through head at 0x0100.
+        bus.write_word(0x0100, 0xB26D); // CMP.W (-0x10,A5),D1
+        bus.write_word(0x0102, 0xFFF0);
+        bus.write_word(0x0104, 0x67FA); // BEQ.S head
+        bus.write_word(0x0106, 0xC3F0); // MULS.W (0,A0,D0.W),D1 -- untraceable
+        bus.write_word(0x0108, 0x0800);
+        bus.write_word(0x010A, 0x60F4); // BRA.S head
+        bus.write_word(0x0300, 0x1234); // the polled word
+        // Colliding loop head at 0x2100.
+        bus.write_word(0x2100, 0x5282); // ADDQ.L #1,D2
+        bus.write_word(0x2102, 0x60FC); // BRA.S 0x2100
+
+        let mut cpu = cpu();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(5, 0x0310);
+        cpu.set_a(0, 0x0400);
+        cpu.set_a(7, 0x0900);
+        cpu.set_d(0, 0);
+
+        // Phase 1: equal compare -- the loop spins and classifies as a wait.
+        cpu.pc = 0x0100;
+        cpu.set_d(1, 0x1234);
+        cpu.run_batch(&mut bus, 5_000, &[]);
+        let mid = super::super::trace_profile::snapshot();
+        let row = mid
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0x0100)
+            .expect("phase 1 head profiled");
+        assert!(
+            mid.wait_shapes.iter().any(|shape| shape.start_pc == 0x0100),
+            "phase 1 classifies the taken loop as a wait shape"
+        );
+        assert!(row.wait_hits > 0, "phase 1 spins attribute as wait hits");
+
+        // Phase 2: a backward branch to the colliding head evicts the
+        // rejected slot for 0x0100.
+        cpu.pc = 0x2100;
+        cpu.run_batch(&mut bus, 200, &[]);
+
+        // Phase 3: unequal compare -- the back edge falls through into the
+        // unsupported multiply and a fresh recording finds the blocker.
+        cpu.pc = 0x0100;
+        cpu.set_d(1, 0x5555);
+        cpu.run_batch(&mut bus, 5_000, &[]);
+
+        let snapshot = super::super::trace_profile::snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0x0100)
+            .expect("phase 3 head profiled");
+        assert_eq!(
+            row.blocker_pc,
+            Some(0x0106),
+            "the real blocker is attributed"
+        );
+        // The fall-through's [CMP, BEQ] prefix compiles as a 2-op loop, so
+        // fall-through volume flows through guard exits rather than
+        // rejected hits: projected stays 0, and it is the recorded blocker
+        // that keeps the head visible in the ranking.
+        assert!(
+            row.wait_hits > 0,
+            "phase-1 spin volume stays wait-attributed"
+        );
+        assert_eq!(
+            row.rejected_hits, row.wait_hits,
+            "no non-wait rejected volume exists in this flow"
+        );
+        assert!(
+            snapshot
+                .wait_shapes
+                .iter()
+                .any(|shape| shape.start_pc == 0x0100),
+            "the phase-1 wait shape survives independently"
+        );
+
+        let report = snapshot.report();
+        let ranking = report
+            .split("wait loops")
+            .next()
+            .expect("report has a ranking section");
+        assert!(
+            ranking.contains("00000100"),
+            "the head returns to the opportunity ranking: {ranking}"
+        );
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        feature = "trace-profile",
+        not(target_family = "wasm")
+    ))]
+    #[test]
+    fn fall_through_past_a_back_edge_is_not_a_wait() {
+        // The recorded operations here are byte-identical to a pure poll --
+        // a memory compare and a conditional branch back to the head -- but
+        // the branch was *not* taken and execution fell through into an
+        // unsupported state-mutating operation. Classifying on the branch's
+        // static target alone would call this a wait and drop its real
+        // blocker out of the opportunity ranking.
+        super::super::trace_profile::reset();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        bus.write_word(0x0100, 0xB26D); // head: CMP.W (-0x10,A5),D1
+        bus.write_word(0x0102, 0xFFF0);
+        bus.write_word(0x0104, 0x67FA); // BEQ.S head  (never taken)
+        bus.write_word(0x0106, 0xC3F0); // MULS.W (0,A0,D0.W),D1 -- untraceable
+        bus.write_word(0x0108, 0x0800);
+        bus.write_word(0x010A, 0x60F4); // BRA.S head
+        bus.write_word(0x0300, 0x0001); // the polled word
+
+        let mut cpu = cpu();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0x0100;
+        cpu.set_a(5, 0x0310);
+        cpu.set_a(0, 0x0400);
+        cpu.set_a(7, 0x0900);
+        // Unequal, so the back edge falls through every iteration.
+        cpu.set_d(1, 0x5555);
+        cpu.set_d(0, 0);
+        cpu.run_batch(&mut bus, 5_000, &[]);
+
+        let snapshot = super::super::trace_profile::snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0x0100)
+            .expect("the head was profiled");
+        assert_eq!(
+            row.wait_hits, 0,
+            "a fall-through path is not a wait even though its recorded ops look like one"
+        );
+        assert!(
+            snapshot
+                .wait_shapes
+                .iter()
+                .all(|shape| shape.start_pc != 0x0100),
+            "no wait shape is recorded for a fall-through"
+        );
+        assert_eq!(
+            row.blocker_pc,
+            Some(0x0106),
+            "the real blocker is still attributed"
+        );
+
+        let report = snapshot.report();
+        let ranking = report
+            .split("wait loops")
+            .next()
+            .expect("report has a ranking section");
+        assert!(
+            ranking.contains("00000100"),
+            "the head stays in the opportunity ranking: {ranking}"
+        );
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        feature = "trace-profile",
+        not(target_family = "wasm")
+    ))]
+    #[test]
+    fn pure_poll_loop_is_reported_as_wait_and_left_uncompiled() {
+        super::super::trace_profile::reset();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        bus.write_word(0x0100, 0xB26D); // CMP.W (-0x10,A5),D1
+        bus.write_word(0x0102, 0xFFF0);
+        bus.write_word(0x0104, 0x67FA); // BEQ.S back to 0x0100
+        bus.write_word(0x0FF0, 0x1234); // the polled value
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = 0x0100;
+        cpu.set_a(5, 0x1000);
+        cpu.set_d(1, 0x1234); // equal → the poll loops until the budget ends
+
+        let result = cpu.run_batch(&mut bus, 20_000, &[]);
+        assert_eq!(result.instructions, 20_000, "the wait executes decoded");
+
+        let snapshot = super::super::trace_profile::snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0x0100)
+            .expect("the poll head was profiled");
+        assert!(
+            row.wait_hits > 0,
+            "spins after classification attribute as wait hits"
+        );
+        assert_eq!(
+            row.projected_dispatches(),
+            0,
+            "a pure wait carries no ranked opportunity"
+        );
+        assert!(
+            snapshot
+                .wait_shapes
+                .iter()
+                .any(|shape| shape.start_pc == 0x0100 && shape.recordings > 0),
+            "the classified shape is recorded in the wait table"
+        );
+        // The chosen contract: the shape table (and the wait-loops report
+        // section) is the sole representation of a classified wait. It is
+        // not a silent rejection, so the reason field stays empty.
+        assert_eq!(
+            row.reject_reason, None,
+            "a classified wait never masquerades as a silent-rejection reason"
+        );
+        assert!(
+            !snapshot
+                .compiled_shapes
+                .iter()
+                .any(|shape| shape.start_pc == 0x0100),
+            "the wait was not compiled"
+        );
+        let report = snapshot.report();
+        assert!(report.contains("wait loops"));
+        assert!(
+            !report
+                .lines()
+                .take_while(|line| !line.contains("wait loops"))
+                .any(|line| line.contains("00000100")),
+            "the wait head is excluded from the opportunity ranking"
+        );
+
+        // The veto routes through the reasoned rejection path added for
+        // silent-rejection accounting, so assert it is attributed *as a
+        // wait* there rather than as a generic compile-stage refusal or by
+        // dropping out of the accounting entirely.
+        assert!(
+            !snapshot
+                .silent_rejections
+                .iter()
+                .any(|entry| entry.start_pc == 0x0100),
+            "a classified wait is not filed as a silent rejection"
+        );
+        assert!(
+            !report.contains("backend"),
+            "a classified wait is not attributed to the compiler backend"
+        );
     }
 }

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -34,6 +34,8 @@ pub struct TraceProfileRow {
     /// Most recent reason a recording at this head produced no trace
     /// without an unsupported opcode, if any. A head with this set and no
     /// `blocker_pc` carries no opcode-admission opportunity at all.
+    ///
+    /// Classified waits never appear here — see [`Self::wait_hits`].
     pub reject_reason: Option<TraceRejectReason>,
     /// Number of operations in the current compiled/portable trace.
     pub compiled_ops: u32,
@@ -48,6 +50,25 @@ pub struct TraceProfileRow {
     pub guarded_branch_exits: u64,
     /// Trace re-recordings triggered by adaptive branch behavior.
     pub adaptive_rerecords: u64,
+    /// The head's recorded loop was classified as a pure poll (a wait):
+    /// it was deliberately not compiled, and it is excluded from the
+    /// projected-dispatch opportunity ranking.
+    ///
+    /// Backward-branch hits attributed to a classified wait shape: hits
+    /// observed while the head's most recent completed recording was a
+    /// classified pure poll.
+    ///
+    /// Wait accounting is **shape-specific and independent** of blocker
+    /// accounting: classifying a wait never touches `blocker_pc`,
+    /// `prefix_ops`, or `reject_reason`, and recording a blocker never
+    /// erases wait shapes (see [`TraceProfileSnapshot::wait_shapes`]).
+    /// A head that has recorded both kinds of shape appears in the
+    /// opportunity ranking for its non-wait volume *and* in the wait
+    /// section for its wait shapes, in whichever order the recordings
+    /// happened. [`Self::projected_dispatches`] subtracts these hits so
+    /// wait-driven volume cannot inflate the ranking. A wait is not a
+    /// silent rejection and never sets [`Self::reject_reason`].
+    pub wait_hits: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -173,6 +194,24 @@ pub struct FailedTraceShapeProfileRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// One distinct recorded loop shape classified as a pure poll (a wait).
+///
+/// Wait shapes are keyed by their exact operation sequence, like failed
+/// shapes, so wait accounting survives cache eviction and interleaving
+/// with non-wait recordings at the same head in either order.
+#[non_exhaustive]
+pub struct WaitShapeProfileRow {
+    /// Guest program counter at which the classified loop starts.
+    pub start_pc: u32,
+    /// CPU model active while recording.
+    pub cpu_type: CpuType,
+    /// The classified loop's exact operations, in execution order.
+    pub ops: Vec<TraceShapeOp>,
+    /// Number of recordings that produced this exact wait shape.
+    pub recordings: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// One distinct recording that ended without an unsupported opcode.
 ///
 /// Complements [`FailedTraceShapeProfileRow`]: that type describes
@@ -249,7 +288,12 @@ impl TraceProfileRow {
     /// blocker. This deliberately excludes the blocker itself: some control-
     /// flow instructions should terminate a trace rather than execute in it.
     pub fn projected_dispatches(&self) -> u64 {
+        // Wait-attributed hits are volume the head accumulated while its
+        // live shape was a classified poll; counting them would let waits
+        // recruit the head into the ranking, which is the distortion this
+        // profiler exists to remove.
         self.rejected_hits
+            .saturating_sub(self.wait_hits)
             .saturating_mul(u64::from(self.prefix_ops))
     }
 }
@@ -278,8 +322,13 @@ pub struct TraceProfileSnapshot {
     /// Recordings that ended without an unsupported opcode: control left
     /// the decoded path, or a compile-stage policy declined the region.
     pub silent_rejections: Vec<SilentRejectionProfileRow>,
+    /// Recorded loop shapes classified as pure polls, keyed by exact
+    /// operation sequence.
+    pub wait_shapes: Vec<WaitShapeProfileRow>,
     /// Silent rejections dropped after the distinct-shape cap was reached.
     pub silent_rejection_overflow: u64,
+    /// Wait recordings dropped after the distinct wait-shape cap.
+    pub wait_shape_overflow: u64,
     /// Total observed backward branches.
     pub backward_hits: u64,
     /// Total rejected trace-entry opportunities.
@@ -293,7 +342,21 @@ pub struct TraceProfileSnapshot {
 impl TraceProfileSnapshot {
     /// Format the snapshot as a ranked, human-readable profiling report.
     pub fn report(&self) -> String {
-        let mut rows = self.rows.clone();
+        // Ranking and wait accounting are independent. A row ranks when it
+        // carries opcode-admission opportunity: a recorded blocker, or
+        // positive projected dispatches (wait-attributed hits are
+        // subtracted from that metric, so wait volume cannot recruit a
+        // head). A blocker-carrying head stays visible even at zero
+        // projected -- its volume may be flowing through a compiled prefix
+        // as guard exits rather than rejected hits -- while a pure wait
+        // (no blocker, nothing projected) reports only in the wait section
+        // below, in whichever order its recordings happened.
+        let mut rows: Vec<_> = self
+            .rows
+            .clone()
+            .into_iter()
+            .filter(|row| row.blocker_pc.is_some() || row.projected_dispatches() > 0)
+            .collect();
         rows.sort_unstable_by(|a, b| {
             b.projected_dispatches()
                 .cmp(&a.projected_dispatches())
@@ -344,6 +407,71 @@ impl TraceProfileSnapshot {
                 row.native_calls,
                 row.jit_retired
             );
+        }
+
+        if !self.wait_shapes.is_empty() {
+            let _ = writeln!(
+                out,
+                "wait loops (classified pure polls; not compiled; excluded from ranking)"
+            );
+            if self.wait_shape_overflow > 0 {
+                let _ = writeln!(
+                    out,
+                    "note: {} wait recordings dropped past the {}-shape cap",
+                    self.wait_shape_overflow, SILENT_REJECTION_CAP
+                );
+            }
+            // One line per (start_pc, cpu_type) head carrying the head-level
+            // wait-hit volume exactly once, with the shape-level recording
+            // counts nested under it. Keying the lookup by pc alone would
+            // print one CPU model's aggregate against another model's
+            // shapes; repeating the aggregate per shape would misattribute
+            // head volume as shape volume.
+            let mut heads: BTreeMap<(u32, u32), Vec<&WaitShapeProfileRow>> = BTreeMap::new();
+            for shape in &self.wait_shapes {
+                heads
+                    .entry((shape.start_pc, shape.cpu_type as u32))
+                    .or_default()
+                    .push(shape);
+            }
+            let mut head_rows: Vec<_> = heads
+                .into_iter()
+                .map(|((pc, _), shapes)| {
+                    let cpu_type = shapes[0].cpu_type;
+                    let wait_hits = self
+                        .rows
+                        .iter()
+                        .find(|row| row.start_pc == pc && row.cpu_type == cpu_type)
+                        .map_or(0, |row| row.wait_hits);
+                    (pc, cpu_type, wait_hits, shapes)
+                })
+                .collect();
+            head_rows.sort_unstable_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(&b.0)));
+            let _ = writeln!(
+                out,
+                "rank  start_pc  cpu      wait_hits  shapes  recordings"
+            );
+            for (rank, (pc, cpu_type, wait_hits, shapes)) in head_rows.iter().take(40).enumerate() {
+                let recordings: u64 = shapes.iter().map(|shape| shape.recordings).sum();
+                let _ = writeln!(
+                    out,
+                    "{:>4}  {:08X}  {:<8} {:>9} {:>7} {:>11}",
+                    rank + 1,
+                    pc,
+                    format!("{cpu_type:?}"),
+                    wait_hits,
+                    shapes.len(),
+                    recordings
+                );
+                for shape in shapes {
+                    let _ = writeln!(
+                        out,
+                        "      shape ops={} records={}",
+                        shape.ops.len(),
+                        shape.recordings
+                    );
+                }
+            }
         }
 
         let mut compiled_rows: Vec<_> = self
@@ -597,6 +725,11 @@ struct Row {
     jit_retired: u64,
     guarded_branch_exits: u64,
     adaptive_rerecords: u64,
+    wait_hits: u64,
+    /// Whether the most recent completed recording at this head was a
+    /// classified wait. Drives per-hit attribution only; presentation is
+    /// shape-keyed and never derived from this flag.
+    last_recording_was_wait: bool,
 }
 
 /// Upper bound on distinct failed shapes kept per process. Each entry holds
@@ -670,6 +803,11 @@ struct Profile {
     /// Recordings that ended without an unsupported opcode, bounded by
     /// `SILENT_REJECTION_CAP` on the same rationale.
     silent_rejections: BTreeMap<SilentRejectionKey, u64>,
+    /// Classified wait shapes: (start_pc, cpu_type, ops) -> recordings.
+    /// Shape-keyed so the accounting is order-independent; bounded by
+    /// `SILENT_REJECTION_CAP` on the same rationale as failed shapes.
+    wait_shapes: BTreeMap<(u32, u32, Vec<TraceShapeOp>), u64>,
+    wait_shape_overflow: u64,
     silent_rejection_overflow: u64,
     compiled_shapes: BTreeMap<CompiledShapeKey, u64>,
     decoded_mem_counts: Box<[u64]>,
@@ -687,6 +825,8 @@ impl Default for Profile {
             failed_shape_overflow: 0,
             silent_rejections: BTreeMap::new(),
             silent_rejection_overflow: 0,
+            wait_shapes: BTreeMap::new(),
+            wait_shape_overflow: 0,
         }
     }
 }
@@ -720,6 +860,7 @@ impl Profile {
                 jit_retired: row.jit_retired,
                 guarded_branch_exits: row.guarded_branch_exits,
                 adaptive_rerecords: row.adaptive_rerecords,
+                wait_hits: row.wait_hits,
             })
             .collect();
         let decoded_mem_ops = self
@@ -784,6 +925,18 @@ impl Profile {
                 },
             )
             .collect();
+        let wait_shapes = self
+            .wait_shapes
+            .iter()
+            .map(
+                |((start_pc, cpu_type, ops), &recordings)| WaitShapeProfileRow {
+                    start_pc: *start_pc,
+                    cpu_type: cpu_type_from_repr(*cpu_type),
+                    ops: ops.clone(),
+                    recordings,
+                },
+            )
+            .collect();
         TraceProfileSnapshot {
             backward_hits: rows.iter().map(|row| row.backward_hits).sum(),
             rejected_hits: rows.iter().map(|row| row.rejected_hits).sum(),
@@ -797,6 +950,8 @@ impl Profile {
             failed_shape_overflow: self.failed_shape_overflow,
             silent_rejections,
             silent_rejection_overflow: self.silent_rejection_overflow,
+            wait_shapes,
+            wait_shape_overflow: self.wait_shape_overflow,
         }
     }
 }
@@ -845,7 +1000,32 @@ pub(crate) fn note_backward_edge(pc: u32, cpu_type: CpuType, rejected: bool) {
         row.backward_hits = row.backward_hits.saturating_add(1);
         if rejected {
             row.rejected_hits = row.rejected_hits.saturating_add(1);
+            if row.last_recording_was_wait {
+                row.wait_hits = row.wait_hits.saturating_add(1);
+            }
         }
+    });
+}
+
+/// Record that a completed recording at `pc` was classified as a pure
+/// poll loop and deliberately left uncompiled.
+///
+/// Shape-keyed: the classification is stored against the loop's exact
+/// operation sequence, and only the per-hit attribution flag lives on the
+/// head row — so blocker accounting at the same head is never disturbed,
+/// in either recording order.
+pub(crate) fn note_wait_loop(pc: u32, cpu_type: CpuType, ops: Vec<TraceShapeOp>) {
+    PROFILE.with_borrow_mut(|profile| {
+        profile.0.row(pc, cpu_type).last_recording_was_wait = true;
+        let key = (pc, cpu_type as u32, ops);
+        if profile.0.wait_shapes.len() >= SILENT_REJECTION_CAP
+            && !profile.0.wait_shapes.contains_key(&key)
+        {
+            profile.0.wait_shape_overflow = profile.0.wait_shape_overflow.saturating_add(1);
+            return;
+        }
+        let recordings = profile.0.wait_shapes.entry(key).or_default();
+        *recordings = recordings.saturating_add(1);
     });
 }
 
@@ -864,6 +1044,10 @@ pub(crate) fn note_blocker(
 ) {
     PROFILE.with_borrow_mut(|profile| {
         let row = profile.0.row(start_pc, cpu_type);
+        // Flip per-hit attribution: subsequent hits at this head belong to
+        // the just-recorded non-wait shape. Wait shapes already recorded
+        // stay in the shape table untouched.
+        row.last_recording_was_wait = false;
         // Keep the longest observed prefix for this trace head. It is the
         // conservative amount of already-supported work stranded behind the
         // blocker; path variation is visible through the shape table.
@@ -915,7 +1099,10 @@ pub(crate) fn note_silent_rejection(
     reason: TraceRejectReason,
 ) {
     PROFILE.with_borrow_mut(|profile| {
-        profile.0.row(start_pc, cpu_type).reject_reason = Some(reason);
+        let row = profile.0.row(start_pc, cpu_type);
+        // Same attribution flip as note_blocker.
+        row.last_recording_was_wait = false;
+        row.reject_reason = Some(reason);
         let key = SilentRejectionKey {
             start_pc,
             cpu_type: cpu_type as u32,
@@ -938,7 +1125,10 @@ pub(crate) fn note_silent_rejection(
 
 pub(crate) fn note_compiled(pc: u32, cpu_type: CpuType, ops: Vec<TraceShapeOp>) {
     PROFILE.with_borrow_mut(|profile| {
-        profile.0.row(pc, cpu_type).compiled_ops = ops.len() as u32;
+        let row = profile.0.row(pc, cpu_type);
+        // Same attribution flip as note_blocker.
+        row.last_recording_was_wait = false;
+        row.compiled_ops = ops.len() as u32;
         let recordings = profile
             .0
             .compiled_shapes
@@ -1577,6 +1767,151 @@ mod tests {
         assert_eq!(row.reject_reason, Some(TraceRejectReason::TrapOrException));
         assert_eq!(row.compiled_ops, 0);
         assert!(snapshot.report().contains("trap-or-exception"));
+    }
+
+    #[test]
+    fn wait_section_is_shape_and_cpu_sound() {
+        // Ben's reproduction: the same PC recorded under two CPU models
+        // with distinct wait volumes, and multiple wait shapes under one
+        // model. The report must print each model's own wait_hits (a
+        // pc-only lookup prints the first model's aggregate on both
+        // lines), and per-shape recording counts must be per shape, not
+        // the head aggregate repeated.
+        reset();
+        // M68000: one shape, 3 wait-attributed hits.
+        note_wait_loop(0x100, CpuType::M68000, dummy_prefix(0x100, 2));
+        for _ in 0..3 {
+            note_backward_edge(0x100, CpuType::M68000, true);
+        }
+        // M68040: two distinct shapes (one recorded twice), 7 hits.
+        note_wait_loop(0x100, CpuType::M68040, dummy_prefix(0x100, 2));
+        note_wait_loop(0x100, CpuType::M68040, dummy_prefix(0x100, 3));
+        note_wait_loop(0x100, CpuType::M68040, dummy_prefix(0x100, 3));
+        for _ in 0..7 {
+            note_backward_edge(0x100, CpuType::M68040, true);
+        }
+
+        let snapshot = snapshot();
+        let hits = |cpu: CpuType| {
+            snapshot
+                .rows
+                .iter()
+                .find(|row| row.start_pc == 0x100 && row.cpu_type == cpu)
+                .map_or(0, |row| row.wait_hits)
+        };
+        assert_eq!(hits(CpuType::M68000), 3);
+        assert_eq!(hits(CpuType::M68040), 7);
+        assert_eq!(
+            snapshot
+                .wait_shapes
+                .iter()
+                .filter(|shape| shape.cpu_type == CpuType::M68040)
+                .count(),
+            2,
+            "two distinct shapes under M68040"
+        );
+
+        let report = snapshot.report();
+        let wait_section = report
+            .split("wait loops")
+            .nth(1)
+            .expect("wait section present");
+        assert!(
+            wait_section.contains("M68000") && wait_section.contains("M68040"),
+            "both models present: {wait_section}"
+        );
+        // Each model's own volume on its own line.
+        let m68000_line = wait_section
+            .lines()
+            .find(|line| line.contains("M68000"))
+            .unwrap();
+        let m68040_line = wait_section
+            .lines()
+            .find(|line| line.contains("M68040"))
+            .unwrap();
+        assert!(
+            m68000_line.split_whitespace().any(|w| w == "3"),
+            "M68000 line carries its own 3 hits: {m68000_line}"
+        );
+        assert!(
+            m68040_line.split_whitespace().any(|w| w == "7"),
+            "M68040 line carries its own 7 hits: {m68040_line}"
+        );
+        // Per-shape recording counts are per shape (1 and 2), never the
+        // head aggregate (3) repeated.
+        assert!(
+            wait_section.contains("shape ops=2 records=1")
+                && wait_section.contains("shape ops=3 records=2"),
+            "shape lines carry per-shape recordings: {wait_section}"
+        );
+    }
+
+    #[test]
+    fn wait_attribution_is_order_independent_and_cannot_inflate_ranking() {
+        // Deterministic note-level check of the attribution arithmetic, in
+        // both recording orders. 5 non-wait rejected edges against a 2-op
+        // blocker prefix project 10 dispatches; 7 wait-attributed edges
+        // must not change that.
+        for wait_first in [false, true] {
+            reset();
+            let blocker = TraceBlocker {
+                pc: 0x104,
+                executed_opcode: 0x4AFC,
+                memory_opcode: Some(0x4AFC),
+                next_word: None,
+                next_word2: None,
+            };
+            let record_wait = || {
+                note_wait_loop(0x100, CpuType::M68040, dummy_prefix(0x100, 2));
+                for _ in 0..7 {
+                    note_backward_edge(0x100, CpuType::M68040, true);
+                }
+            };
+            let record_blocker = || {
+                note_blocker(0x100, CpuType::M68040, dummy_prefix(0x100, 2), blocker);
+                for _ in 0..5 {
+                    note_backward_edge(0x100, CpuType::M68040, true);
+                }
+            };
+            if wait_first {
+                record_wait();
+                record_blocker();
+            } else {
+                record_blocker();
+                record_wait();
+            }
+
+            let snapshot = snapshot();
+            let row = snapshot
+                .rows
+                .iter()
+                .find(|row| row.start_pc == 0x100)
+                .expect("head profiled");
+            assert_eq!(row.rejected_hits, 12, "order {wait_first}");
+            assert_eq!(row.wait_hits, 7, "order {wait_first}");
+            assert_eq!(
+                row.projected_dispatches(),
+                10,
+                "wait volume must not inflate the ranking (order {wait_first})"
+            );
+            assert_eq!(row.blocker_pc, Some(0x104), "order {wait_first}");
+            assert_eq!(
+                snapshot
+                    .wait_shapes
+                    .iter()
+                    .filter(|shape| shape.start_pc == 0x100)
+                    .map(|shape| shape.recordings)
+                    .sum::<u64>(),
+                1,
+                "the wait shape is recorded once (order {wait_first})"
+            );
+            let report = snapshot.report();
+            let ranking = report.split("wait loops").next().unwrap();
+            assert!(
+                ranking.contains("00000100"),
+                "blocker head ranks in both orders (order {wait_first})"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stage 1 of RFC #79: classify pure poll loops at trace-compile time,
refuse to compile them as native spins, report them distinctly, and
exclude them from the opportunity ranking.

A recorded self-loop is classified as a **pure poll** when every
operation either reads guest state without mutating anything except the
condition codes (memory compares, tests, and bit-tests) or is the loop's
own branching, and at least one operation reads memory. Such a loop's
exit can only be driven by memory it never writes, so executing it
faster cannot make it exit sooner — it is a wait, and it is precisely
the class that no trap-anchored wait mechanism (the spin templates, the
idle-cycle prover) can see. The classifying match is exhaustive over
every trace operation, so each future operation must declare its bucket
before the crate compiles.

## What changes

- A classified poll is not compiled (native or portable-trace); it
  executes on the decoded path as an unrecorded loop does today. This
  caps the burn multiplier at 1×: the wall time the guest spends in the
  wait is unchanged, but it no longer consumes JIT-speed instruction
  volume (measured on the motivating workload: ~18 CPU-ns/instruction of
  native spinning, one capped session feeding 19.2M of a 25M
  instructions/second budget to spin — see #79's evidence).
- The profiler reports classified waits in their own `wait loops`
  section and excludes them from the `projected_dispatches` ranking, so
  opportunity rankings stop recruiting wait idioms as optimization
  targets (which is how one became the top-ranked target of #76).

Stage 1 deliberately parks nothing and changes no execution semantics —
the only behavioral change is declining a compilation — so it carries no
correctness risk beyond that refusal. Stages 2 and 3 (wait-typed trace
exits consumed by the runner's advance/park machinery; closed-form tick
waits) are specified in #79.

## Measured effect on EV Override's rankings

A capped (`--cpu-mhz 25`) profiler session pair on the same stationary
scene — v0.8.0 baseline versus v0.8.0 plus this change — answers what
this does to the real profile:

- **Nothing currently classifies.** The wait-loops section is empty:
  every hot self-loop that completes recording in this scene mutates
  state (record scans, buffer fills) and is correctly left rankable and
  compilable. Consequently the two sessions' head tables are identical
  up to dwell length — this change costs the current EV profile nothing.
- **The benefit here is prophylactic and forward-looking.** The class
  this refuses is exactly what recent op-admission PRs were completing:
  trap-less pure polls whose compilation multiplied burn (measured on
  the #76 candidate: ~18 CPU-ns/instruction of native spinning, one
  capped session feeding 19.2M of its 25M instructions/second budget to
  spin — evidence in #79). Any future admission that would finish such a
  loop now classifies it instead of compiling it, and the ranking can no
  longer recruit it.
- **Stated residue.** Trap-containing wait idioms remain ranked: the
  session pair's top slots are 21/22-op prefixes blocked at `486D` (8.1M
  and 7.7M projected) and the `42A7` template-D idiom at 1.0M projected
  — blocked recordings, not completed ones, so Stage 1's classifier
  never sees them. Their ranking inflation is Stage 2/3 scope per #79.
- A genuine target the pair surfaced: a `41F0`-blocked head with an
  identical 937,836 hits in both sessions — a deterministic boot-phase
  loop, unaffected by wait dynamics, and the profile's legitimate top
  opportunity.

## Whole-application measurement

A deterministic headless ladder (300M guest instructions, v0.8.1
baseline versus this PR, both with `trace-profile`) settles the safety
question in the strongest available form:

- **The trace-profile report is byte-identical to baseline** — every
  head row, every failed- and compiled-shape table, every decoded-site
  table, and every total (`backward_hits` 624,279, `rejected_hits`
  615,734, `native_calls` 47,671, `jit_retired` 11,146,241). The final
  framebuffer SHA-256 matches as well. With the classifier active,
  execution is bit-identical to master over a 300M-instruction
  boot-through-gameplay run. Wall time 196.5 s versus 199.9 s user CPU,
  inside the ±19% host-noise band measured for this harness in #83 and
  meaningless next to the identity result.
- **Nothing classifies in this workload either.** The `wait loops`
  section prints only when non-empty, and it is absent — matching the
  capped GUI session pair reported above. Both measured workloads agree:
  every hot self-loop that completes recording in this title mutates
  state and is correctly left compilable.

Stated plainly, so the trade is easy to judge: **this PR's measured
benefit on today's workloads is zero, and that is the intended result
for a conservative veto that matches nothing.** Its value is the two
things measurement cannot show — the regression class it forecloses
(each future op admission can no longer convert a trap-less wait into a
native spin, capping that burn multiplier at 1×; #79 documents one such
episode at 19.2M of a 25M instruction/second budget) and the ranking
hygiene that stops waits being recruited as optimization targets. The
cost side is correspondingly small: one refused compilation, no
execution-path change, bit-identical output.

Methodology note: whole-application sampling in this project uses
`--cpu-mhz 25` (uncapped GUI execution is elastic, so CPU share
conflates efficiency with throughput). The headless ladder above is a
complementary instrument — it fixes total guest work exactly and proves
work-identity by framebuffer hash, which is what makes a bit-identity
claim possible at all; the capped GUI ladder remains canonical for
interactive-scene claims, where wait dynamics and audio differ.

## Acceptance criteria from #79 review

- **Conservative flag provenance**: every flag any branch in the loop
  consumes must have been written by one of the loop's memory reads; a
  `BTST`-only loop branching on carry does not classify (BTST writes
  only Z), and a loop whose only backward branch is unconditional does
  not classify (no memory-driven exit). Covered by unit tests including
  partial-flag and preserved-flag shapes.
- **False-positive/false-negative shapes**: register-mutating loops
  (counters, destination-writing memory ALU, scratch-register loads),
  branch-only calibration loops, and `DBcc` counted waits all classify
  false; memory-compare, memory-test, bit-test-on-Z, and
  guarded-interior-exit polls classify true.
- **Unchanged execution**: the end-to-end test runs a classified poll
  for an exact instruction budget on the decoded path with identical
  architectural results.
- **Distinct accounting**: classified heads report in their own
  `wait loops` profiler section and leave `projected_dispatches`.
- **Classification requires the recording to have closed back to its
  head.** `self_loop` is deliberately permissive for codegen — it is also
  true when the last recorded operation is merely a branch whose static
  target is the head, which happens on a *fall-through* path — so the
  wait classification gates on `recorded_exit_pc == Some(start_pc)`
  instead. Covered by an end-to-end regression.
- **Wait accounting is shape-keyed and independent of blocker
  accounting.** Classified waits live in their own `wait_shapes` table
  (keyed by the loop's exact operations, like failed shapes, capped and
  overflow-counted); classifying a wait never touches `blocker_pc`,
  `prefix_ops`, or `reject_reason`, and recording a blocker never erases
  wait shapes — so a head that records both kinds of shape reports in
  both sections, in whichever order the recordings happen (both orders
  covered end-to-end, plus a deterministic note-level test of the
  arithmetic in both orders, mutation-tested). Per-hit attribution
  (`wait_hits`) follows the most recent completed recording, and
  `projected_dispatches` subtracts wait-attributed volume, so a wait
  cannot recruit its head into the ranking. The ranking prints a row when
  it carries opcode-admission opportunity (a recorded blocker or positive
  projected dispatches); pure waits report only in the wait section.
- **The veto/parking invariant**: this predicate is used only to decline
  compilation; it is not a parking proof and is not exported for one.
  Parking is Stage 2 scope in a separate design (per the #79 review),
  where wait exits must prove complete live-state invariance or model
  every permitted delta.
- **On #76**: measured honestly, the #76 burn concentrated in
  store-containing loops whose invocation frequency is wait-driven —
  correctly not classifiable — so this PR does not claim to prevent that
  episode synthetically; #76 remains gated on post-classification
  whole-application measurement.

## Validation

- `cargo test --all-features` and `cargo test` — full suite with both
  fixture submodules initialized
- classifier unit tests: memory-compare and memory-test polls classify;
  branch-only (calibration) loops, register-mutating loops, and
  destination-writing memory ALU loops do not
- end-to-end test: a `CMP.W (d16,A5),D1; BEQ` poll runs its exact
  instruction budget on the decoded path, is flagged `wait` in the
  profile, does not appear among compiled shapes, and is absent from the
  opportunity ranking
- end-to-end regression: the same recorded operations reached by a
  *fall-through* — the back edge not taken, execution continuing into an
  untraceable `MULS.W (0,A0,D0.W),D1` — are **not** classified as a wait,
  the blocker stays attributed at its address, and the head stays in the
  opportunity ranking
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --no-default-features`

<!-- Drafted by Claude Opus 5, 2026-08-05. -->
