### PR TITLE
perf: JIT brief-indexed LEA

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1104,6 +1104,69 @@ fn bench_pea_displacement_loop() {
     );
 }
 
+/// Measure a JIT-compiled loop whose address computation is an indexed
+/// LEA — the register-only form that blocks a deterministic boot-phase
+/// head in EV Override profiling. The loop sweeps the word index and
+/// wraps it, so the run ends at an exact wrap boundary with fully
+/// asserted final state:
+///
+/// ```c
+/// for (;;) {
+///     entry = &table[i];        /* LEA (4,A0,D2.W),A1 */
+///     if (++i < 0x7FFF) continue; /* ADDQ; CMPI; BLT   */
+///     i = 0;                    /* MOVEQ #0,D2         */
+/// }
+/// ```
+fn bench_indexed_lea_loop() {
+    const CODE_BASE: u32 = 0x6E00;
+    const WRAP_INSTRS: u32 = 4 * 0x7FFF + 2;
+    const WRAPS: u32 = 763;
+    const INSTRS: u32 = WRAP_INSTRS * WRAPS;
+    let words = [
+        0x43F0, 0x2004, // loop: LEA (4,A0,D2.W),A1
+        0x5282, // ADDQ.L #1,D2
+        0x0C42, 0x7FFF, // CMPI.W #$7FFF,D2
+        0x6DF4, // BLT.S loop
+        0x7400, // MOVEQ #0,D2
+        0x60F0, // BRA.S loop
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(0, 0x4200);
+        cpu.set_a(7, 0x8000);
+        cpu
+    };
+
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(cpu.d(2), 0, "the run ends exactly at a wrap boundary");
+    assert_eq!(cpu.a(0), 0x4200, "the base register is untouched");
+    assert_eq!(
+        cpu.a(1),
+        0x4200 + 0x8002,
+        "the last computed address is the final table entry"
+    );
+    println!(
+        "batch     indexed lea loop        {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 /// Measure decoded generic memory operations without allowing a backward
 /// branch to turn the workload into a native JIT loop. Each pass walks the
 /// same straight-line code, retaining the decoded-op cache while resetting
@@ -1231,6 +1294,10 @@ fn main() {
     }
     if only.as_deref() == Some("pea-displacement") {
         bench_pea_displacement_loop();
+        return;
+    }
+    if only.as_deref() == Some("indexed-lea") {
+        bench_indexed_lea_loop();
         return;
     }
     if only.as_deref() == Some("immediate-shifts") {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -253,6 +253,14 @@ pub(crate) enum JitTraceOp {
         displacement: i16,
         cycles: i32,
     },
+    /// `LEA (d8,An,Xn),An` with the brief extension decoded once while
+    /// recording. LEA is register-only: it accesses no memory and changes
+    /// no condition codes.
+    LeaIndex {
+        src: JitEa,
+        dst: u8,
+        cycles: i32,
+    },
     AddSubxReg {
         src: u8,
         dst: u8,
@@ -1710,6 +1718,7 @@ impl JitTraceOp {
             Self::AddrDataReg { .. } => 8,
             Self::AddrCmpImmediate { cycles, .. } => cycles,
             Self::LeaAn { cycles, .. } => cycles,
+            Self::LeaIndex { cycles, .. } => cycles,
             Self::AddSubxReg { .. } => 8,
             Self::BitReg {
                 op: JitBitOp::Test, ..
@@ -2357,6 +2366,23 @@ fn decode_an_disp_trace_op<B: AddressBus>(
                     dst,
                     displacement: displacement as i16,
                     cycles: if is_pre_68020(cpu_type) { 8 } else { 4 },
+                },
+            )
+        }
+        DecodedMemOp::Lea {
+            reg: dst,
+            ea: FastEa::AnIndex(base),
+        } => {
+            let extension = read_ext(2, bus)?;
+            let src = decode_jit_ea(6, u16::from(base), extension, cpu_type)?;
+            (
+                Some(extension),
+                None,
+                JitTraceOp::LeaIndex {
+                    src,
+                    dst,
+                    // MC68000 LEA (d8,An,Xn) is twelve cycles.
+                    cycles: if is_pre_68020(cpu_type) { 12 } else { 4 },
                 },
             )
         }
@@ -3494,6 +3520,31 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
                 cpu.dar[8 + base as usize].wrapping_add(displacement as i32 as u32);
             cycles
         }
+        JitTraceOp::LeaIndex { src, dst, cycles } => {
+            let JitEa::Index {
+                base,
+                index,
+                index_long,
+                scale,
+                displacement,
+            } = src
+            else {
+                unreachable!("indexed LEA decoder admitted an unsupported EA")
+            };
+            let raw_index = match index {
+                JitDirectReg::Data(reg) => cpu.dar[reg as usize],
+                JitDirectReg::Addr(reg) => cpu.dar[8 + reg as usize],
+            };
+            let index_value = if index_long {
+                raw_index
+            } else {
+                raw_index as u16 as i16 as i32 as u32
+            };
+            cpu.dar[8 + dst as usize] = cpu.dar[8 + base as usize]
+                .wrapping_add(index_value.wrapping_shl(u32::from(scale)))
+                .wrapping_add(displacement as i32 as u32);
+            cycles
+        }
         JitTraceOp::AddSubxReg {
             src,
             dst,
@@ -4051,6 +4102,35 @@ fn emit_jit_op(
         } => {
             let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
             let address = builder.ins().iadd_imm(base, displacement as i64);
+            store_reg(builder, cpu, JitDirectReg::Addr(dst), address);
+            cycles_const(builder, op.op.max_cycles())
+        }
+        JitTraceOp::LeaIndex { src, dst, .. } => {
+            let JitEa::Index {
+                base,
+                index,
+                index_long,
+                scale,
+                displacement,
+            } = src
+            else {
+                unreachable!("indexed LEA decoder admitted an unsupported EA")
+            };
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
+            let raw_index = load_reg(builder, cpu, index);
+            let index = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index = if scale == 0 {
+                index
+            } else {
+                builder.ins().ishl_imm(index, i64::from(scale))
+            };
+            let address = builder.ins().iadd(base, index);
+            let address = builder.ins().iadd_imm(address, displacement as i64);
             store_reg(builder, cpu, JitDirectReg::Addr(dst), address);
             cycles_const(builder, op.op.max_cycles())
         }
@@ -7097,6 +7177,123 @@ mod portable_tests {
         assert_eq!(packed, 0, "store-overlap guard retires nothing");
         assert_eq!(smc.dar, before);
         assert_eq!(smc_mem, untouched_mem);
+    }
+
+    #[test]
+    fn indexed_lea_decode_and_portable_execution() {
+        let mut cpu = cpu();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_a(0, 0x1000);
+        cpu.set_d(2, 0x0010);
+        cpu.set_ccr(0x1F);
+
+        let mut decode_bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        decode_bus.write_word(0x0100, 0x43F0);
+        decode_bus.write_word(0x0102, 0x2004);
+        let trace = decode_trace_op(&cpu, &mut decode_bus, 0x0100, CpuType::M68040)
+            .expect("LEA (d8,An,Xn) should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::LeaIndex {
+                src: JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                },
+                dst: 1,
+                cycles: 4,
+            }
+        ));
+        assert_eq!(trace.extension, Some(0x2004));
+        assert_eq!(
+            execute_portable_op(&mut cpu, trace, 0x0100, 0x0104),
+            Some(4)
+        );
+        assert_eq!(cpu.dar[9], 0x1014, "A1 = A0 + D2.W + 4");
+        assert_eq!(cpu.dar[8], 0x1000, "the base register is untouched");
+        assert_eq!(cpu.get_ccr(), 0x1F, "LEA changes no condition codes");
+
+        // Word indexes sign-extend.
+        cpu.set_d(2, 0x0001_8000);
+        assert_eq!(
+            execute_portable_op(&mut cpu, trace, 0x0100, 0x0104),
+            Some(4)
+        );
+        assert_eq!(
+            cpu.dar[9],
+            0x1000u32.wrapping_sub(0x8000).wrapping_add(4),
+            "a word index sign-extends before the add"
+        );
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_indexed_lea_matches_portable() {
+        let lea = TraceBuildOp {
+            opcode: 0x43F0,
+            extension: Some(0x2004),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::LeaIndex {
+                src: JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                },
+                dst: 1,
+                cycles: 4,
+            },
+        };
+        let branch = TraceBuildOp {
+            opcode: 0x60FA,
+            extension: None,
+            extension2: None,
+            pc: 0x0104,
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -6,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+
+        let prepare = || {
+            let mut cpu = cpu();
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_a(0, 0x1000);
+            cpu.set_d(2, 0x8000);
+            cpu.set_ccr(0x15);
+            cpu
+        };
+
+        let mut expected = prepare();
+        let expected_packed = execute_portable_trace(&mut expected, &[lea, branch], 0x0100, 0x0106);
+
+        let mut actual = prepare();
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(
+                &actual,
+                0x0100,
+                CpuType::M68040,
+                vec![lea, branch],
+                Some(0x0100),
+            )
+            .expect("indexed LEA loop should compile");
+        let actual_packed = unsafe { compiled.call_native(&mut actual, 1) };
+        assert_eq!(actual_packed, expected_packed);
+        assert_eq!(actual.pc, expected.pc);
+        assert_eq!(actual.dar, expected.dar);
+        assert_eq!(actual.get_ccr(), expected.get_ccr());
+        assert_eq!(
+            actual.dar[9],
+            0x1000u32.wrapping_sub(0x8000).wrapping_add(4),
+            "the negative word index case matches natively"
+        );
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]


### PR DESCRIPTION
## Summary

Admit `LEA (d8,An,Xn),An` as a register-only trace operation. The brief
extension word is decoded once while recording; execution computes
`An + index + d8` with word indexes sign-extended and the scale applied,
writes the destination address register, accesses no memory, and changes
no condition codes. Per-decode cycles: twelve on pre-68020 models
(M68000UM), four after, following the existing `LeaAn` convention.

This follows the merged #68/#69/#72/#73/#74 and applies directly to
master at v0.8.1.

## Why this operation

In capped (`--cpu-mhz 25`) EV Override profiling, this form blocks a
boot-phase head with an **identical 937,836 rejected recordings in every
session** — deterministic across scene states, capped and uncapped,
which is also what proves it is genuine bounded work rather than a wait
(a wait's hit count scales with execution speed and idle time; this one
never varies). After the wait-aware reading of the profile established
by #79/#81, it ranked as the top legitimate opportunity: 2.81 million
projected trace operations at a three-operation prefix. (The
whole-application measurement below revises this honestly: the LEA was
that head's *first* obstacle, not its only one.)

Relationship to #81: this operation writes a register, so the
classifier there correctly treats it as loop progress (not a poll); its
exhaustive classification match will force this variant to declare that
bucket when the two branches meet, which is that design working as
intended.

## Correctness and safety

- Decode only the brief-indexed control form; full extension words
  (68020+) keep their existing dispatch.
- Sign-extend word index registers, preserve long ones, apply the scale
  and signed 8-bit displacement exactly once — the same address
  arithmetic as the merged indexed compare and CMPI operations.
- Register-only: no window interaction, no bail paths, no flags.
- Portable and native execution with parity tests, including the
  negative sign-extended word-index case.

## Performance

Focused benchmark: `indexed-lea`, an index-sweeping loop that wraps at
an exact instruction boundary and asserts the final index, base, and
computed address.

Five alternating runs against a baseline worktree at v0.8.1 master
carrying an identical copy of the benchmark, M guest instructions/s:

| Run | v0.8.1 base | this PR |
|---:|---:|---:|
| 1 | 29.8 | 289.4 |
| 2 | 24.6 | 353.0 |
| 3 | 35.5 | 350.5 |
| 4 | 35.0 | 289.6 |
| 5 | 31.6 | 332.0 |
| **Median** | **31.6** | **332.0** |

That is a **10.5x** focused-loop speedup over the actual PR base.

### Whole-application measurement (deterministic headless ladder)

Headless execution is fully deterministic here, which permits a
stronger-than-sampling whole-application comparison: twelve 300M-guest-
instruction runs (five alternating order-flipped timing pairs plus one
trace-profile pair, pristine save state re-seeded per run) produced the
**same final-framebuffer SHA-256 in all twelve runs across both
builds** — byte-identical guest work.

**Result: neutral, and provably so.** The trace-profile pair's JIT
totals are byte-identical between base and this PR — `backward_hits`
624,279, `rejected_hits` 615,734, `native_calls` 47,671, `jit_retired`
11,146,241 — so the two builds executed identical instruction streams
and any timing difference is host environment by construction. The
timing pairs bear that out: user-CPU medians 204.3 s (base) versus
198.0 s (this PR), with per-run spread (164–239 s on identical work)
an order of magnitude larger than the median gap. No whole-application
cost, no whole-application win on this workload.

What the profile pair does show is the admission working and the next
obstacles, precisely:

- Three heads advance past brief-indexed LEA blockers. `00FB1BD8`
  (36,864 hits) now records through its `41F3` and blocks two ops later
  at `9190` (`SUB.L D0,(A0)`); `00FAA45C` and `00FAB518` pass their
  `41F0` and block at `0450` (`SUBI.W #imm,(An)`). Memory-destination
  SUB forms are therefore the natural next admissions, with this LEA
  already paid for.
- A live illustration of #79's ranking-inflation mechanism:
  `00FB1BD8`'s projected dispatches rose 147,448 → 221,172 purely
  because its admitted prefix lengthened.
- The `00FA9732` boot head (the motivating target, 27,292 hits in this
  workload) does **not** compile under this PR. Recording now proceeds
  nine operations past the head — through both LEAs, the
  `ADDQ.L #1,(A0)` increment, and a `SUBQ.W #4,SP` — and then stops at
  `00FA974A`, where **a trap or exception surfaces inside the loop
  body**. Traps are hard trace boundaries, so no instruction-set
  coverage extends a recording past that point: this head cannot
  compile as a loop, and its 2.81M projected dispatches were never
  achievable. That is an instance of the ranking-inflation family #79
  describes, and it means this PR's honest claim for that head is "one
  obstacle of at least two removed", not "unblocked".

  Provenance, since it matters for how much weight to give that: the
  stop cause is **measured**, not inferred. A first pass established
  only that *some* recording-stop path fired there; the profiler could
  not say which, because recordings that end at a trap or in a compile
  gate were attributed nowhere. That gap is filed as #84, whose
  implementation distinguishes a trap or exception from a host batch
  boundary, and a re-run of this same workload with it reports
  `trap-or-exception` at `00FA974A` with the nine-operation prefix
  intact. Workload-wide the class is overwhelmingly structural: 41
  trap-or-exception against 1 host-boundary. The remaining inference is
  only the trap's *identity* — the reserve-then-call stack shape
  (`SUBQ.W #4,SP`, trap, `MOVE.L (SP)+`, compare) is the long-returning
  Toolbox A-line ABI — but the profiler classifies the family, not the
  vector, so that specific reading is not claimed as measured.

The capped (`--cpu-mhz 25`) GUI ladder remains the canonical
interactive-scene methodology; this deterministic headless ladder is
the whole-application evidence a boot-phase-targeted admission can
collect without confounds.

## Validation

- `cargo test --all-features` and `cargo test` — full suite with both
  fixture submodules initialized
- decode, portable/native parity (including the negative word-index
  case), condition codes untouched, base register untouched
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --no-default-features`

<!-- Drafted by Claude Opus 5, 2026-08-06. -->
