### PR TITLE
fix(trace-profile): attribute recordings that end with no unsupported opcode

### DIFF
--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -597,7 +597,7 @@ impl CpuCore {
                 // A full-dispatch instruction may have just extended a path
                 // recording before exhausting this outer batch's budget.
                 // The caller may mutate guest state before the next batch.
-                trace_jit::stop_recording(self);
+                trace_jit::stop_recording(self, trace_jit::RecordingStop::HostBoundary);
                 return BatchResult {
                     instructions: retired,
                     exit: BatchExit::BudgetExhausted,
@@ -684,7 +684,7 @@ impl CpuCore {
                 // The caller may emulate a surfaced trap and resume at an
                 // unrelated guest PC. Never let an in-progress path recording
                 // cross that host-controlled execution boundary.
-                trace_jit::stop_recording(self);
+                trace_jit::stop_recording(self, trace_jit::RecordingStop::TrapOrException);
                 return BatchResult {
                     instructions: retired,
                     exit,
@@ -699,7 +699,7 @@ impl CpuCore {
                 // The fault handler is not the sequential continuation of the
                 // instruction being recorded. Discard the partial path before
                 // execution resumes at the exception vector.
-                trace_jit::stop_recording(self);
+                trace_jit::stop_recording(self, trace_jit::RecordingStop::TrapOrException);
                 self.run_mode = RUN_MODE_NORMAL;
                 probe_on_entry = true;
             } else {
@@ -727,7 +727,7 @@ impl CpuCore {
             }
 
             if self.stopped != 0 {
-                trace_jit::stop_recording(self);
+                trace_jit::stop_recording(self, trace_jit::RecordingStop::HostBoundary);
                 return BatchResult {
                     instructions: retired,
                     exit: BatchExit::Stopped,
@@ -737,7 +737,7 @@ impl CpuCore {
             if !watch_pcs.is_empty() && watch_pcs.contains(&self.pc) {
                 // Match the decoded fast path: a watched-PC return is a host
                 // boundary, so a partial recording cannot survive it.
-                trace_jit::stop_recording(self);
+                trace_jit::stop_recording(self, trace_jit::RecordingStop::HostBoundary);
                 return BatchResult {
                     instructions: retired,
                     exit: BatchExit::WatchedPc { pc: self.pc },

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1113,7 +1113,7 @@ impl CpuCore {
                 }
                 CachedOp::Mem(op) => {
                     if !super::mem_ops::execute_mem_op(self, op) {
-                        trace_jit::stop_recording(self);
+                        trace_jit::stop_recording(self, trace_jit::RecordingStop::HostBoundary);
                         return BatchInnerExit::Miss(opcode);
                     }
                     #[cfg(feature = "trace-profile")]
@@ -1130,12 +1130,12 @@ impl CpuCore {
             remaining -= 1;
             *retired += 1;
             if watch && watch_pcs.contains(&self.pc) {
-                trace_jit::stop_recording(self);
+                trace_jit::stop_recording(self, trace_jit::RecordingStop::HostBoundary);
                 return BatchInnerExit::Watched(self.pc);
             }
         }
 
-        trace_jit::stop_recording(self);
+        trace_jit::stop_recording(self, trace_jit::RecordingStop::HostBoundary);
         BatchInnerExit::Budget
     }
 

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -395,6 +395,54 @@ pub(crate) enum JitTraceOp {
     },
 }
 
+/// Why a compile-stage gate declined a recorded region.
+///
+/// Kept separate from the public profiling enum so the always-compiled
+/// gate logic does not depend on the optional profiler; the mapping in
+/// `profile_reject_reason` is exhaustive, so a new gate must declare how
+/// it is reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegionRejectReason {
+    NoTraceTerminal,
+    TooShort,
+    IndirectJsrTooShort,
+    LinearMemoryAlu,
+    AddressWrap,
+    Backend,
+}
+
+/// Why an in-progress recording was stopped from outside the recorder.
+///
+/// The distinction is load-bearing for reporting: a trap or exception is a
+/// structural bound on how far a head can ever record, while a host
+/// boundary is an artifact of how the embedder sliced execution and says
+/// nothing about the head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecordingStop {
+    /// A trap or exception surfaced. The embedder handles it and may resume
+    /// at an unrelated guest PC, so no amount of instruction coverage
+    /// extends a recording past this point.
+    TrapOrException,
+    /// The batch ended at a host boundary: instruction budget exhausted, a
+    /// watched PC, a stopped CPU, or a decoded fast-path miss. The head may
+    /// well record further in a later batch.
+    HostBoundary,
+}
+
+/// How a recording ended, which decides whether the profiler has already
+/// attributed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordingEnd {
+    /// Decoding refused an executed instruction. `note_blocker` has already
+    /// recorded the head, its prefix, and the offending opcode.
+    Blocker,
+    /// Something outside the recorder stopped it mid-region.
+    Stopped(RecordingStop),
+    /// The region closed on its own terms: a back edge, a recorded branch,
+    /// or an operation limit.
+    Region,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct TraceBuildOp {
     opcode: u16,
@@ -936,6 +984,32 @@ impl TraceJit {
         )
     }
 
+    #[cfg(feature = "trace-profile")]
+    fn profile_reject_reason(
+        reason: RegionRejectReason,
+    ) -> super::trace_profile::TraceRejectReason {
+        use super::trace_profile::TraceRejectReason as Public;
+        // Exhaustive so a new compile gate must declare how it is reported.
+        match reason {
+            RegionRejectReason::NoTraceTerminal => Public::NoTraceTerminal,
+            RegionRejectReason::TooShort => Public::TooShort,
+            RegionRejectReason::IndirectJsrTooShort => Public::IndirectJsrTooShort,
+            RegionRejectReason::LinearMemoryAlu => Public::LinearMemoryAlu,
+            RegionRejectReason::AddressWrap => Public::AddressWrap,
+            RegionRejectReason::Backend => Public::Backend,
+        }
+    }
+
+    /// Exhaustive so a new stop cause must declare how it is reported.
+    #[cfg(feature = "trace-profile")]
+    fn profile_stop_reason(cause: RecordingStop) -> super::trace_profile::TraceRejectReason {
+        use super::trace_profile::TraceRejectReason as Public;
+        match cause {
+            RecordingStop::TrapOrException => Public::TrapOrException,
+            RecordingStop::HostBoundary => Public::HostBoundary,
+        }
+    }
+
     fn reject_recording(&mut self, cpu: &mut CpuCore) {
         if let Some(recording) = self.recording.take() {
             let idx = trace_cache_index(recording.start_pc);
@@ -948,7 +1022,8 @@ impl TraceJit {
         cpu.trace_recording = false;
     }
 
-    fn finish_recording(&mut self, cpu: &mut CpuCore, exit_pc: u32) {
+    #[cfg_attr(not(feature = "trace-profile"), allow(unused_variables))]
+    fn finish_recording(&mut self, cpu: &mut CpuCore, exit_pc: u32, end: RecordingEnd) {
         let Some(mut recording) = self.recording.take() else {
             cpu.trace_recording = false;
             return;
@@ -978,26 +1053,57 @@ impl TraceJit {
                 extension2: op.extension2,
             })
             .collect();
-        self.slots[idx] =
-            match self.compile_decoded_ops(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc)) {
-                Some(mut trace) => {
-                    trace.adaptive_rerecords = adaptive_rerecords;
-                    if adaptive_rerecords >= TRACE_MAX_ADAPTIVE_RERECORDS {
-                        trace.adaptive_branch = false;
-                    }
-                    TraceSlot::Compiled(trace)
+        let outcome =
+            self.compile_decoded_ops_reason(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc));
+        #[cfg(feature = "trace-profile")]
+        let reject_reason = outcome.as_ref().err().copied();
+        self.slots[idx] = match outcome {
+            Ok(mut trace) => {
+                trace.adaptive_rerecords = adaptive_rerecords;
+                if adaptive_rerecords >= TRACE_MAX_ADAPTIVE_RERECORDS {
+                    trace.adaptive_branch = false;
                 }
-                None => {
-                    push_probe_skip(cpu, start_pc);
-                    TraceSlot::Rejected {
-                        pc: start_pc,
-                        cpu_type,
-                    }
+                TraceSlot::Compiled(trace)
+            }
+            Err(_) => {
+                push_probe_skip(cpu, start_pc);
+                TraceSlot::Rejected {
+                    pc: start_pc,
+                    cpu_type,
                 }
-            };
+            }
+        };
         #[cfg(feature = "trace-profile")]
         if matches!(self.slots[idx], TraceSlot::Compiled(_)) {
             super::trace_profile::note_compiled(start_pc, cpu_type, recorded_shape);
+        } else if let Some(reason) = reject_reason {
+            // A recording that ends at an unsupported opcode is already
+            // attributed by `note_blocker`; anything else would leave no
+            // report entry at all, so attribute it here. Leaving the
+            // decoded path outranks the compile-stage reason: it bounds how
+            // far this head can ever record, which no opcode coverage can
+            // change.
+            if end != RecordingEnd::Blocker {
+                let reason = match end {
+                    RecordingEnd::Stopped(cause) => Self::profile_stop_reason(cause),
+                    _ => Self::profile_reject_reason(reason),
+                };
+                // Report the instruction that stopped the recording. For a
+                // trap `pc` has already advanced past its opcode word, so
+                // `ppc` is the actionable address. This is reporting only:
+                // `exit_pc` still drives self-loop detection above.
+                let reported_pc = match end {
+                    RecordingEnd::Stopped(RecordingStop::TrapOrException) => cpu.ppc,
+                    _ => exit_pc,
+                };
+                super::trace_profile::note_silent_rejection(
+                    start_pc,
+                    cpu_type,
+                    reported_pc,
+                    recorded_shape,
+                    reason,
+                );
+            }
         }
     }
 
@@ -1052,7 +1158,7 @@ impl TraceJit {
                     },
                 );
             }
-            self.finish_recording(cpu, executed_pc);
+            self.finish_recording(cpu, executed_pc, RecordingEnd::Blocker);
             return;
         };
         let op_len = op.length();
@@ -1069,16 +1175,16 @@ impl TraceJit {
             // dependent counter update is already compiled efficiently.
             JitTraceOp::Dbcc { .. } => {
                 self.recording.as_mut().unwrap().ops.push(op);
-                self.finish_recording(cpu, next_pc);
+                self.finish_recording(cpu, next_pc, RecordingEnd::Region);
                 return;
             }
             JitTraceOp::IndirectJsr { .. } => {
                 self.recording.as_mut().unwrap().ops.push(op);
-                self.finish_recording(cpu, next_pc);
+                self.finish_recording(cpu, next_pc, RecordingEnd::Region);
                 return;
             }
             _ if next_pc != executed_pc.wrapping_add(op_len as u32) => {
-                self.finish_recording(cpu, executed_pc);
+                self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
                 return;
             }
             _ => {}
@@ -1087,16 +1193,19 @@ impl TraceJit {
         let recording = self.recording.as_mut().unwrap();
         recording.ops.push(op);
         if next_pc == start_pc {
-            self.finish_recording(cpu, next_pc);
+            self.finish_recording(cpu, next_pc, RecordingEnd::Region);
             return;
         }
 
         let repeated = recording.ops.iter().any(|op| op.pc == next_pc);
         if recording.ops.len() >= TRACE_MAX_OPS || repeated {
-            self.finish_recording(cpu, next_pc);
+            self.finish_recording(cpu, next_pc, RecordingEnd::Region);
         }
     }
 
+    /// Outcome-only wrapper over [`Self::compile_decoded_ops_reason`], kept
+    /// for the many tests that assert only whether a region compiled.
+    #[cfg(test)]
     fn compile_decoded_ops(
         &mut self,
         cpu: &CpuCore,
@@ -1105,8 +1214,25 @@ impl TraceJit {
         ops: Vec<TraceBuildOp>,
         recorded_exit_pc: Option<u32>,
     ) -> Option<CompiledTrace> {
+        self.compile_decoded_ops_reason(cpu, start_pc, cpu_type, ops, recorded_exit_pc)
+            .ok()
+    }
+
+    /// Compile a recorded region, reporting *why* a region was declined.
+    ///
+    /// The reason exists so the profiler can attribute recordings that end
+    /// without any unsupported opcode; a head declined here has no blocker
+    /// and would otherwise leave no trace in the report at all.
+    fn compile_decoded_ops_reason(
+        &mut self,
+        cpu: &CpuCore,
+        start_pc: u32,
+        cpu_type: CpuType,
+        ops: Vec<TraceBuildOp>,
+        recorded_exit_pc: Option<u32>,
+    ) -> Result<CompiledTrace, RegionRejectReason> {
         if !ops.last().is_some_and(|op| op.op.ends_trace()) {
-            return None;
+            return Err(RegionRejectReason::NoTraceTerminal);
         }
 
         let self_loop = recorded_exit_pc == Some(start_pc)
@@ -1119,7 +1245,7 @@ impl TraceJit {
             TRACE_MIN_OPS
         };
         if ops.len() < min_ops {
-            return None;
+            return Err(RegionRejectReason::TooShort);
         }
 
         let max_cycles = ops.iter().map(|op| op.op.max_cycles()).sum();
@@ -1152,7 +1278,7 @@ impl TraceJit {
             .last()
             .is_some_and(|op| matches!(op.op, JitTraceOp::IndirectJsr { .. }));
         if ends_in_indirect_jsr && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS {
-            return None;
+            return Err(RegionRejectReason::IndirectJsrTooShort);
         }
 
         // Short checked memory ALU regions do not amortize trace validation
@@ -1170,7 +1296,7 @@ impl TraceJit {
                 )
             })
         {
-            return None;
+            return Err(RegionRejectReason::LinearMemoryAlu);
         }
 
         let needs_window = ops.iter().any(|op| {
@@ -1200,7 +1326,7 @@ impl TraceJit {
             let start = cpu.address(op.pc);
             let end = start as u64 + op.length() as u64;
             if end > cpu.address_mask as u64 + 1 || end > u32::MAX as u64 {
-                return None;
+                return Err(RegionRejectReason::AddressWrap);
             }
             code_start = code_start.min(start);
             code_end = code_end.max(end as u32);
@@ -1220,6 +1346,7 @@ impl TraceJit {
             aligned_only: cpu.is_pre_68020,
             address_mask: cpu.address_mask,
         })
+        .ok_or(RegionRejectReason::Backend)
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
@@ -1628,9 +1755,10 @@ pub(crate) fn record_executed<B: AddressBus>(
 /// End an in-progress recording before control leaves the fast decoded-op
 /// path. A usable prefix ending in a branch is compiled; otherwise the
 /// target is marked rejected.
-pub(crate) fn stop_recording(cpu: &mut CpuCore) {
+pub(crate) fn stop_recording(cpu: &mut CpuCore, cause: RecordingStop) {
     if cpu.trace_recording {
-        TRACE_JIT.with_borrow_mut(|jit| jit.finish_recording(cpu, cpu.pc));
+        TRACE_JIT
+            .with_borrow_mut(|jit| jit.finish_recording(cpu, cpu.pc, RecordingEnd::Stopped(cause)));
     }
 }
 

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -31,6 +31,10 @@ pub struct TraceProfileRow {
     pub blocker_pc: Option<u32>,
     /// Opcode word that blocked trace construction.
     pub blocker_opcode: Option<u16>,
+    /// Most recent reason a recording at this head produced no trace
+    /// without an unsupported opcode, if any. A head with this set and no
+    /// `blocker_pc` carries no opcode-admission opportunity at all.
+    pub reject_reason: Option<TraceRejectReason>,
     /// Number of operations in the current compiled/portable trace.
     pub compiled_ops: u32,
     /// Number of calls into the trace executor.
@@ -58,6 +62,58 @@ pub enum TraceDecodeFailureReason {
     /// Memory still contains the executed opcode, but its form is not
     /// traceable or an operand-extension read failed.
     UnsupportedFormOrOperandRead,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Why a recording produced no trace even though decoding never refused an
+/// instruction.
+///
+/// These outcomes carry no *opcode* opportunity: there is no blocker to
+/// support, so heads whose recordings end this way are reported separately
+/// and are absent from the opportunity ranking by construction.
+#[non_exhaustive]
+pub enum TraceRejectReason {
+    /// A trap or exception surfaced mid-recording. The embedder handles it
+    /// and may resume at an unrelated guest PC, so no instruction-set
+    /// coverage extends a recording past this point: it is a structural
+    /// bound on the head, not a missing feature.
+    TrapOrException,
+    /// The batch ended at a host boundary mid-recording — instruction
+    /// budget exhausted, a watched PC, a stopped CPU, or a decoded
+    /// fast-path miss. This says nothing about the head: it is an artifact
+    /// of how the embedder sliced execution, and the same head may record
+    /// further in a later batch.
+    HostBoundary,
+    /// The recorded prefix does not end in a trace-terminating operation.
+    NoTraceTerminal,
+    /// Fewer operations than the minimum for the region's kind.
+    TooShort,
+    /// An indirect-JSR region shorter than the minimum that amortizes the
+    /// call boundary.
+    IndirectJsrTooShort,
+    /// A linear (non-loop) region carrying checked memory ALU operations,
+    /// which does not amortize trace validation.
+    LinearMemoryAlu,
+    /// The region's code range wraps the address space.
+    AddressWrap,
+    /// The compiler backend declined the region or was unavailable.
+    Backend,
+}
+
+impl TraceRejectReason {
+    /// Short stable label used in the report.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::TrapOrException => "trap-or-exception",
+            Self::HostBoundary => "host-boundary",
+            Self::NoTraceTerminal => "no-trace-terminal",
+            Self::TooShort => "too-short",
+            Self::IndirectJsrTooShort => "indirect-jsr-too-short",
+            Self::LinearMemoryAlu => "linear-memory-alu",
+            Self::AddressWrap => "address-wrap",
+            Self::Backend => "backend",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -113,6 +169,34 @@ pub struct FailedTraceShapeProfileRow {
     /// Coarse classification of the reconstruction failure.
     pub reason: TraceDecodeFailureReason,
     /// Number of recording attempts with this exact shape.
+    pub recordings: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// One distinct recording that ended without an unsupported opcode.
+///
+/// Complements [`FailedTraceShapeProfileRow`]: that type describes
+/// recordings stopped by an instruction the decoder refused, this one
+/// describes recordings that ran out of decoded execution or were declined
+/// by a compile-stage policy. Both were previously indistinguishable from
+/// "this head was never hot".
+#[non_exhaustive]
+pub struct SilentRejectionProfileRow {
+    /// Guest program counter at which recording began.
+    pub start_pc: u32,
+    /// CPU model active while recording.
+    pub cpu_type: CpuType,
+    /// Why the recording produced no trace.
+    pub reason: TraceRejectReason,
+    /// Guest address of the instruction that stopped the recording: the
+    /// trapping instruction for [`TraceRejectReason::TrapOrException`], and
+    /// the PC the CPU had reached otherwise. For a trap this is the bound
+    /// on how far this head can ever record.
+    pub exit_pc: u32,
+    /// Operations successfully reconstructed before the recording ended, in
+    /// execution order.
+    pub prefix: Vec<TraceShapeOp>,
+    /// Number of recording attempts with this exact shape and outcome.
     pub recordings: u64,
 }
 
@@ -183,6 +267,11 @@ pub struct TraceProfileSnapshot {
     /// reached. Zero unless a pathological workload produced thousands of
     /// distinct failed paths.
     pub failed_shape_overflow: u64,
+    /// Recordings that ended without an unsupported opcode: control left
+    /// the decoded path, or a compile-stage policy declined the region.
+    pub silent_rejections: Vec<SilentRejectionProfileRow>,
+    /// Silent rejections dropped after the distinct-shape cap was reached.
+    pub silent_rejection_overflow: u64,
     /// Total observed backward branches.
     pub backward_hits: u64,
     /// Total rejected trace-entry opportunities.
@@ -347,6 +436,56 @@ impl TraceProfileSnapshot {
             let _ = writeln!(out);
         }
 
+        let mut silent_rejections = self.silent_rejections.clone();
+        silent_rejections.sort_unstable_by(|a, b| {
+            b.recordings
+                .cmp(&a.recordings)
+                .then_with(|| b.prefix.len().cmp(&a.prefix.len()))
+                .then_with(|| a.start_pc.cmp(&b.start_pc))
+        });
+        let _ = writeln!(
+            out,
+            "silent rejections (recordings that produced no trace with no unsupported opcode)"
+        );
+        let _ = writeln!(
+            out,
+            "note: these heads have no blocker to support, so they carry no opcode-admission opportunity and are absent from the ranking above. trap-or-exception is a structural bound — no instruction coverage extends a recording past it; host-boundary is only an artifact of batch slicing."
+        );
+        if self.silent_rejection_overflow > 0 {
+            let _ = writeln!(
+                out,
+                "note: {} silent rejections dropped past the {}-shape cap",
+                self.silent_rejection_overflow, SILENT_REJECTION_CAP
+            );
+        }
+        let _ = writeln!(out, "rank  start_pc  records stranded exit_pc  reason");
+        for (rank, shape) in silent_rejections.iter().take(40).enumerate() {
+            let _ = writeln!(
+                out,
+                "{:>4}  {:08X} {:>8} {:>8}   {:08X} {}",
+                rank + 1,
+                shape.start_pc,
+                shape.recordings,
+                shape.prefix.len(),
+                shape.exit_pc,
+                shape.reason.label()
+            );
+            let _ = write!(out, "      prefix:");
+            if shape.prefix.is_empty() {
+                let _ = write!(out, " (none)");
+            }
+            for op in &shape.prefix {
+                let _ = write!(out, " {:08X}:{:04X}", op.pc, op.opcode);
+                if let Some(extension) = op.extension {
+                    let _ = write!(out, "/{extension:04X}");
+                }
+                if let Some(extension) = op.extension2 {
+                    let _ = write!(out, "/{extension:04X}");
+                }
+            }
+            let _ = writeln!(out);
+        }
+
         let mut compiled_shapes = self.compiled_shapes.clone();
         compiled_shapes.sort_unstable_by(|a, b| {
             b.recordings
@@ -438,6 +577,7 @@ struct Row {
     prefix_ops: u32,
     blocker_pc: Option<u32>,
     blocker_opcode: Option<u16>,
+    reject_reason: Option<TraceRejectReason>,
     compiled_ops: u32,
     native_calls: u64,
     jit_retired: u64,
@@ -449,6 +589,19 @@ struct Row {
 /// a full prefix sequence, so the map must not grow for the whole session;
 /// drops past the cap are counted and reported.
 const FAILED_SHAPE_CAP: usize = 4096;
+
+/// Upper bound on distinct silent-rejection shapes kept per process, for
+/// the same reason as [`FAILED_SHAPE_CAP`].
+const SILENT_REJECTION_CAP: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SilentRejectionKey {
+    start_pc: u32,
+    cpu_type: u32,
+    reason: TraceRejectReason,
+    exit_pc: u32,
+    prefix: Vec<TraceShapeOp>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct FailedShapeKey {
@@ -499,6 +652,10 @@ struct Profile {
     /// is bounded for the process lifetime and the report states what was
     /// dropped instead of growing without limit.
     failed_shape_overflow: u64,
+    /// Recordings that ended without an unsupported opcode, bounded by
+    /// `SILENT_REJECTION_CAP` on the same rationale.
+    silent_rejections: BTreeMap<SilentRejectionKey, u64>,
+    silent_rejection_overflow: u64,
     compiled_shapes: BTreeMap<CompiledShapeKey, u64>,
     decoded_mem_counts: Box<[u64]>,
     decoded_mem_site_counts: SiteCounts,
@@ -513,6 +670,8 @@ impl Default for Profile {
             decoded_mem_counts: vec![0; super::op_cache::DECODE_TABLE_SIZE].into_boxed_slice(),
             decoded_mem_site_counts: SiteCounts::default(),
             failed_shape_overflow: 0,
+            silent_rejections: BTreeMap::new(),
+            silent_rejection_overflow: 0,
         }
     }
 }
@@ -540,6 +699,7 @@ impl Profile {
                 prefix_ops: row.prefix_ops,
                 blocker_pc: row.blocker_pc,
                 blocker_opcode: row.blocker_opcode,
+                reject_reason: row.reject_reason,
                 compiled_ops: row.compiled_ops,
                 native_calls: row.native_calls,
                 jit_retired: row.jit_retired,
@@ -584,6 +744,18 @@ impl Profile {
                 recordings,
             })
             .collect();
+        let silent_rejections = self
+            .silent_rejections
+            .iter()
+            .map(|(key, &recordings)| SilentRejectionProfileRow {
+                start_pc: key.start_pc,
+                cpu_type: cpu_type_from_repr(key.cpu_type),
+                reason: key.reason,
+                exit_pc: key.exit_pc,
+                prefix: key.prefix.clone(),
+                recordings,
+            })
+            .collect();
         let compiled_shapes = self
             .compiled_shapes
             .iter()
@@ -607,6 +779,8 @@ impl Profile {
             failed_shapes,
             compiled_shapes,
             failed_shape_overflow: self.failed_shape_overflow,
+            silent_rejections,
+            silent_rejection_overflow: self.silent_rejection_overflow,
         }
     }
 }
@@ -707,6 +881,39 @@ pub(crate) fn note_blocker(
             return;
         }
         let recordings = profile.0.failed_shapes.entry(key).or_default();
+        *recordings = recordings.saturating_add(1);
+    });
+}
+
+/// Record a recording that produced no trace without any unsupported
+/// opcode. Without this the head keeps its backward-branch counters but
+/// gains no prefix, blocker, or shape entry, so it is indistinguishable in
+/// the report from a head that was never hot — and it silently leaves the
+/// opportunity ranking, which orders by `rejected_hits * prefix_ops`.
+pub(crate) fn note_silent_rejection(
+    start_pc: u32,
+    cpu_type: CpuType,
+    exit_pc: u32,
+    prefix: Vec<TraceShapeOp>,
+    reason: TraceRejectReason,
+) {
+    PROFILE.with_borrow_mut(|profile| {
+        profile.0.row(start_pc, cpu_type).reject_reason = Some(reason);
+        let key = SilentRejectionKey {
+            start_pc,
+            cpu_type: cpu_type as u32,
+            reason,
+            exit_pc,
+            prefix,
+        };
+        if profile.0.silent_rejections.len() >= SILENT_REJECTION_CAP
+            && !profile.0.silent_rejections.contains_key(&key)
+        {
+            profile.0.silent_rejection_overflow =
+                profile.0.silent_rejection_overflow.saturating_add(1);
+            return;
+        }
+        let recordings = profile.0.silent_rejections.entry(key).or_default();
         *recordings = recordings.saturating_add(1);
     });
 }
@@ -1248,5 +1455,152 @@ mod tests {
         assert!(report.contains("decoded memory operations: total=3 distinct_opcodes=2"));
         assert!(report.find("20D9").unwrap() < report.find("10DC").unwrap());
         assert!(report.contains("00001000  20D9           2"));
+    }
+
+    #[test]
+    fn silently_rejected_head_is_reported_instead_of_vanishing() {
+        reset();
+        for _ in 0..4 {
+            note_backward_edge(0x900, CpuType::M68040, true);
+        }
+        note_silent_rejection(
+            0x900,
+            CpuType::M68040,
+            0x914,
+            dummy_prefix(0x900, 9),
+            TraceRejectReason::TrapOrException,
+        );
+
+        let snapshot = snapshot();
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0x900)
+            .expect("head keeps its row");
+        assert_eq!(row.reject_reason, Some(TraceRejectReason::TrapOrException));
+        // No blocker means no opcode to support: the head must not acquire
+        // projected dispatches it can never deliver.
+        assert_eq!(row.blocker_pc, None);
+        assert_eq!(row.prefix_ops, 0);
+        assert_eq!(row.projected_dispatches(), 0);
+
+        let report = snapshot.report();
+        assert!(report.contains("silent rejections"));
+        assert!(report.contains("00000900        1        9   00000914 trap-or-exception"));
+        // The stranded prefix is visible, which is what makes the exit pc
+        // actionable.
+        assert!(report.contains("00000900:7000"));
+    }
+
+    #[test]
+    fn trap_inside_a_loop_body_is_attributed_not_silently_dropped() {
+        // The shape that motivated this change: a hot loop whose body
+        // reaches a trap, so recording ends with a prefix too short to
+        // compile. Before this, the head kept its backward-branch counters
+        // but gained no prefix, blocker, or shape entry — indistinguishable
+        // in the report from a head that was never hot.
+        reset();
+        let mut bus = LinearMemoryBus::new(0x1000);
+        bus.write_word(0, 0x4A80); // TST.L D0          <- loop head
+        bus.write_word(2, 0x6704); // BEQ.S $0008
+        bus.write_word(4, 0x5380); // SUBQ.L #1,D0
+        bus.write_word(6, 0x60F8); // BRA.S $0000       (back edge)
+        bus.write_word(8, 0xA123); // A-line trap in the loop's exit path
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0;
+        // One iteration makes the head hot; the second is the recording
+        // pass, and it is the one that reaches the trap — so the recording
+        // never closes the loop.
+        cpu.set_d(0, 1);
+        let result = cpu.run_batch(&mut bus, 100, &[]);
+
+        assert_eq!(result.exit, BatchExit::AlineTrap { opcode: 0xA123 });
+        assert!(!cpu.trace_recording);
+
+        let snapshot = snapshot();
+        let rejection = snapshot
+            .silent_rejections
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("the trap-ended recording is attributed");
+        // The trap outranks the compile-stage reason: it is the bound on
+        // how far this head can ever record.
+        assert_eq!(rejection.reason, TraceRejectReason::TrapOrException);
+        assert_eq!(rejection.exit_pc, 8);
+        assert_eq!(rejection.prefix.len(), 2);
+        assert_eq!(rejection.prefix[0].opcode, 0x4A80);
+
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|row| row.start_pc == 0)
+            .expect("head row");
+        assert_eq!(row.reject_reason, Some(TraceRejectReason::TrapOrException));
+        assert_eq!(row.compiled_ops, 0);
+        assert!(snapshot.report().contains("trap-or-exception"));
+    }
+
+    #[test]
+    fn silent_rejection_reasons_are_distinguished() {
+        reset();
+        note_silent_rejection(
+            0x100,
+            CpuType::M68040,
+            0x110,
+            dummy_prefix(0x100, 2),
+            TraceRejectReason::TooShort,
+        );
+        note_silent_rejection(
+            0x200,
+            CpuType::M68040,
+            0x230,
+            dummy_prefix(0x200, 3),
+            TraceRejectReason::LinearMemoryAlu,
+        );
+        // Same head, same prefix, different outcome: distinct entries.
+        note_silent_rejection(
+            0x200,
+            CpuType::M68040,
+            0x230,
+            dummy_prefix(0x200, 3),
+            TraceRejectReason::LinearMemoryAlu,
+        );
+
+        let snapshot = snapshot();
+        assert_eq!(snapshot.silent_rejections.len(), 2);
+        let linear = snapshot
+            .silent_rejections
+            .iter()
+            .find(|row| row.reason == TraceRejectReason::LinearMemoryAlu)
+            .expect("linear-memory-alu entry");
+        assert_eq!(linear.recordings, 2);
+        assert_eq!(linear.exit_pc, 0x230);
+        let report = snapshot.report();
+        assert!(report.contains("too-short"));
+        assert!(report.contains("linear-memory-alu"));
+    }
+
+    #[test]
+    fn silent_rejections_are_capped_and_overflow_is_reported() {
+        reset();
+        for index in 0..(SILENT_REJECTION_CAP as u32 + 3) {
+            note_silent_rejection(
+                0x100 + index * 2,
+                CpuType::M68040,
+                0x100 + index * 2 + 8,
+                dummy_prefix(0x100, 1),
+                TraceRejectReason::Backend,
+            );
+        }
+        let snapshot = snapshot();
+        assert_eq!(snapshot.silent_rejections.len(), SILENT_REJECTION_CAP);
+        assert_eq!(snapshot.silent_rejection_overflow, 3);
+        assert!(
+            snapshot
+                .report()
+                .contains("3 silent rejections dropped past the 4096-shape cap")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #84. Recordings that produce no trace *without* any unsupported
opcode are now reported, and the two ways that happens are
distinguished.

Previously such a recording left no entry anywhere. The head kept its
backward-branch counters, but gained no prefix, no blocker, and no shape
row — and since the opportunity ranking orders by
`rejected_hits * prefix_ops`, with `prefix_ops` only ever set when an
opcode blocks recording, the head scored zero and dropped out of the
report entirely. It was indistinguishable from a head that was never
hot.

That is worst exactly where it hurts: admitting an operation can move a
head *into* this state, so the profile under-reports precisely the heads
whose admission work is furthest along. In #83 a head disappeared from
the report between the base and candidate builds while every total
stayed byte-identical, which is how this was found.

## The distinction that makes the report trustworthy

`stop_recording` has eight call sites and only two are traps or
exceptions; the rest are batch-budget exhaustion, a watched PC, a
stopped CPU, and a decoded fast-path miss. Reporting them alike would
label routine batch slicing as a structural property of the guest code,
so the two are kept apart:

- **`trap-or-exception`** — a trap or exception surfaced mid-recording.
  The embedder handles it and may resume at an unrelated PC, so no
  instruction-set coverage extends a recording past this point. It is a
  bound on the head.
- **`host-boundary`** — the batch ended for reasons belonging to the
  embedder. It says nothing about the head, which may record further in
  a later batch.

Compile-stage refusals report their own gate: `no-trace-terminal`,
`too-short`, `indirect-jsr-too-short`, `linear-memory-alu`,
`address-wrap`, `backend`. Both mappings are exhaustive matches, so a
new gate or stop cause must declare how it is reported before the crate
compiles.

## Deliberately not ranked

These heads do **not** acquire `prefix_ops`. With no blocker to support
there is no opcode-admission opportunity, and giving them a
projected-dispatch score would manufacture opportunity that cannot be
delivered — the failure mode #79 documents. They appear in their own
section with the stranded prefix and the address that stopped the
recording, and stay absent from the ranking.

## Measured effect

Re-running the deterministic 300M-instruction headless workload used in
#83, with the operation admitted there:

```
   6  00FA9732        1        9   00FA974A trap-or-exception
      prefix: 00FA9732:2003 00FA9734:E588 00FA9736:41EE/FFD8 00FA973A:41F0/0800
              00FA973E:5290 00FA9740:2004 00FA9742:5480 00FA9744:2D40/FFC0 00FA9748:594F
```

That head was #83's motivating target, ranked by a prior profile at 2.81
million projected dispatches. It is bounded by a trap nine operations
in — the operations are byte-contiguous, so the trap is reached
unconditionally on every pass and no recording of this head can ever
close its loop. The ranking had been counting opportunity that did not
exist, and the report now says so.

Across that workload the class is 41 `trap-or-exception` against 1
`host-boundary`, i.e. overwhelmingly structural rather than an artifact
of how the run was sliced.

## Implementation notes

- `compile_decoded_ops_reason` returns `Result<CompiledTrace,
  RegionRejectReason>` so the reason is the gate's own return value
  rather than re-derived by a second copy of the gate conditions. The
  outcome-only wrapper survives as `#[cfg(test)]` for the many tests
  that assert only whether a region compiled.
- The internal reason enum is private to `trace_jit`; the public,
  feature-gated enum lives with the other profiling types, so the
  always-compiled gate logic does not depend on the optional profiler
  and the public surface does not grow when the feature is off.
- The reported address for a trap is `ppc`, the trapping instruction
  itself, since `pc` has already advanced past its opcode word. This is
  reporting only — the `exit_pc` handed to the compiler is unchanged,
  because that value feeds self-loop detection and altering it would
  change compilation behavior rather than reporting.
- Entries are capped at 4096 distinct shapes with a counted overflow,
  matching `FAILED_SHAPE_CAP`.
- No behavior outside `trace-profile`: the hooks sit on paths that
  already ended recordings.

## Validation

- `cargo test --all-features` and `cargo test` — full suite with both
  fixture submodules initialized
- new unit tests: a silently rejected head is reported and does **not**
  gain projected dispatches; reasons and exit addresses stay distinct
  per shape; the cap counts and reports overflow
- new end-to-end test: a hot loop whose body reaches a trap is recorded,
  stopped, and attributed `trap-or-exception` at the trapping
  instruction with its stranded prefix — the shape that motivated this
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --no-default-features`

## Relationship to the open work

- #83 relied on this to establish its motivating head's fate; its body
  and a comment there now carry the measurement instead of the earlier
  inference.
- #81 partitions classified wait loops out of the same ranking for the
  same reason. When both land, the two exclusions read as one idea: the
  ranking should count only opportunity an operation admission can
  actually deliver.

<!-- Drafted by Claude Opus 5, 2026-08-06. -->
