### PR TITLE
perf: jit stores to brief-indexed destinations (MOVE, CLR)

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -810,6 +810,64 @@ fn bench_sub_reg_to_mem_loop() {
     );
 }
 
+/// Exercise the brief-indexed store forms the profiles flagged: a MOVE.W
+/// to a scaled-index destination and a CLR.B one byte beside it, swept by
+/// the DBRA counter so every iteration stores through a different address.
+fn bench_indexed_dest_store_loop() {
+    // 542,635 outer cycles of 387 instructions end exactly at the outer
+    // label. Each inner iteration writes D0 to (A0 + 2*D1) and clears the
+    // low byte, so the final words hold D0 with a zeroed low byte.
+    const CYCLES: u32 = 542_635;
+    const INSTRS: u32 = CYCLES * 387;
+    const CODE_BASE: u32 = 0x7000;
+    let words = [
+        0x204B, // outer: MOVEA.L A3,A0
+        0x727F, // MOVEQ #127,D1
+        0x3180, 0x1200, // inner: MOVE.W D0,(0,A0,D1.W*2)
+        0x4230, 0x1201, // CLR.B (1,A0,D1.W*2)
+        0x51C9, 0xFFF6, // DBRA D1,inner
+        0x60EE, // BRA.S outer
+    ];
+    let mut bus = LinearMemoryBus::new(0x10000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_d(0, 0x0000_BEEF);
+        cpu.set_a(3, 0x4000);
+        cpu.set_a(7, 0x8000);
+        cpu
+    };
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(cpu.pc, CODE_BASE, "the run ends exactly at the outer label");
+    assert_eq!(
+        bus.read_word(0x4000),
+        0xBE00,
+        "the store went through and the clear zeroed its low byte"
+    );
+    assert_eq!(
+        bus.read_word(0x4000 + 254),
+        0xBE00,
+        "the sweep reached D1=127"
+    );
+    println!(
+        "batch     indexed dest stores     {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 /// Reproduce a path-biased trace that is first recorded through an uncommon
 /// conditional edge before settling into a copy loop on the opposite edge.
 /// A first-path-only
@@ -1421,6 +1479,10 @@ fn main() {
     }
     if only.as_deref() == Some("register-count-shift") {
         bench_register_count_shift_loop();
+        return;
+    }
+    if only.as_deref() == Some("indexed-dest-store") {
+        bench_indexed_dest_store_loop();
         return;
     }
     if only.as_deref() == Some("sub-reg-to-mem") {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -365,6 +365,13 @@ pub(crate) enum JitTraceOp {
         size: Size,
         src: JitEa,
     },
+    /// CLR through a checked brief-indexed effective address. The store
+    /// address passes the window and code-overlap checks before anything
+    /// commits, so a bail leaves memory and flags untouched.
+    ClrMem {
+        size: Size,
+        dst: JitEa,
+    },
     /// CMPA.W/L through `(An)` or `d16(An)`. Unlike ordinary CMP, the
     /// destination is always the full address register and a word source is
     /// sign-extended before the 32-bit comparison.
@@ -1366,6 +1373,7 @@ impl TraceJit {
                     | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::CmpiWordMem { .. }
                     | JitTraceOp::TstMem { .. }
+                    | JitTraceOp::ClrMem { .. }
                     | JitTraceOp::AddrCmpMemToReg { .. }
                     | JitTraceOp::AddRegToMem { .. }
                     | JitTraceOp::AnDispUnary { .. }
@@ -1583,6 +1591,10 @@ impl TraceJit {
                     JitTraceOp::TstMem { .. } => {
                         let env = mem_env.as_ref().expect("TstMem implies a window env");
                         emit_tst_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
+                    JitTraceOp::ClrMem { .. } => {
+                        let env = mem_env.as_ref().expect("ClrMem implies a window env");
+                        emit_clr_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
                     JitTraceOp::AddrCmpMemToReg { .. } => {
                         let env = mem_env
@@ -1877,7 +1889,8 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::AddRegToMem { .. }
             | JitTraceOp::MemAddqSubq { .. }
             | JitTraceOp::AnDispBit { .. }
-            | JitTraceOp::PeaDisp { .. } => return false,
+            | JitTraceOp::PeaDisp { .. }
+            | JitTraceOp::ClrMem { .. } => return false,
         }
     }
     mem_written_flags != 0 && consumed & !mem_written_flags == 0
@@ -2142,6 +2155,15 @@ impl JitTraceOp {
                     18
                 } else {
                     14
+                }
+            }
+            // CLR is the M68000UM store cost (8, or 12 for long) plus the
+            // same indexed EA calculation as the read above.
+            Self::ClrMem { size, .. } => {
+                if size == Size::Long {
+                    26
+                } else {
+                    18
                 }
             }
             Self::AddrCmpMemToReg { .. } => 24,
@@ -2587,6 +2609,14 @@ fn decode_an_disp_trace_op<B: AddressBus>(
                 },
             )
         }
+        DecodedMemOp::Clr {
+            size,
+            ea: FastEa::AnIndex(reg),
+        } => {
+            let extension = read_ext(2, bus)?;
+            let dst = decode_jit_ea(6, u16::from(reg), extension, cpu_type)?;
+            (Some(extension), None, JitTraceOp::ClrMem { size, dst })
+        }
         DecodedMemOp::Pea {
             ea: FastEa::AnDisp(reg),
         } => {
@@ -3020,6 +3050,9 @@ fn execute_portable_op(
     if matches!(op.op, JitTraceOp::TstMem { .. }) {
         return execute_portable_tst_mem(cpu, op);
     }
+    if matches!(op.op, JitTraceOp::ClrMem { .. }) {
+        return execute_portable_clr_mem(cpu, op, code_start, code_end);
+    }
     if matches!(op.op, JitTraceOp::AddrCmpMemToReg { .. }) {
         return execute_portable_addr_cmp_mem_to_reg(cpu, op);
     }
@@ -3318,6 +3351,62 @@ fn execute_portable_tst_mem(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i3
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
     if super::mem_ops::execute_mem_op(cpu, DecodedMemOp::Tst { size, ea }) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
+#[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
+fn execute_portable_clr_mem(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    code_start: u32,
+    code_end: u32,
+) -> Option<i32> {
+    let JitTraceOp::ClrMem { size, dst } = trace.op else {
+        return None;
+    };
+    let JitEa::Index {
+        base,
+        index,
+        index_long,
+        scale,
+        displacement,
+    } = dst
+    else {
+        return None;
+    };
+    // Pre-check the store target against the trace's own code, as the
+    // compiled version does, so a self-modifying store bails instead of
+    // executing.
+    let base_value = cpu.dar[8 + base as usize];
+    let raw_index = match index {
+        JitDirectReg::Addr(r) => cpu.dar[8 + r as usize],
+        JitDirectReg::Data(r) => cpu.dar[r as usize],
+    };
+    let index_value = if index_long {
+        raw_index
+    } else {
+        raw_index as u16 as i16 as i32 as u32
+    };
+    let raw = base_value
+        .wrapping_add(index_value << scale)
+        .wrapping_add(displacement as i32 as u32);
+    let masked = raw & cpu.address_mask;
+    if masked < code_end && masked.wrapping_add(size.bytes()) > code_start {
+        return None;
+    }
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::Clr {
+            size,
+            ea: FastEa::AnIndex(base),
+        },
+    ) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -4137,6 +4226,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::TstMem { .. } => {
             unreachable!("TstMem is handled by execute_portable_tst_mem")
         }
+        JitTraceOp::ClrMem { .. } => {
+            unreachable!("ClrMem is handled by execute_portable_clr_mem")
+        }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is handled by execute_portable_addr_cmp_mem_to_reg")
         }
@@ -4762,6 +4854,9 @@ fn emit_jit_op(
         JitTraceOp::TstMem { .. } => {
             unreachable!("TstMem is emitted by emit_tst_mem")
         }
+        JitTraceOp::ClrMem { .. } => {
+            unreachable!("ClrMem is emitted by emit_clr_mem")
+        }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is emitted by emit_addr_cmp_mem_to_reg")
         }
@@ -5072,6 +5167,65 @@ fn emit_tst_mem(
     let (off, _) = checked_window_off(builder, env, bail, address, size);
     let value = window_load(builder, env, off, size);
     set_logic_flags(builder, cpu, value, size);
+    cycles_const(builder, trace.op.max_cycles())
+}
+
+/// Emit CLR to a brief-indexed destination. The address passes the window
+/// and code-overlap checks before the store and the flag writes, so a bail
+/// commits nothing. CLR sets Z and clears N, V, and C; X is untouched.
+#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+fn emit_clr_mem(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::ClrMem {
+        size,
+        dst:
+            JitEa::Index {
+                base,
+                index,
+                index_long,
+                scale,
+                displacement,
+            },
+    } = trace.op
+    else {
+        unreachable!("memory CLR decoder admitted an unsupported EA")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
+    let raw_index = load_reg(builder, cpu, index);
+    let index = if index_long {
+        raw_index
+    } else {
+        let word = builder.ins().ireduce(types::I16, raw_index);
+        builder.ins().sextend(types::I32, word)
+    };
+    let index = if scale == 0 {
+        index
+    } else {
+        builder.ins().ishl_imm(index, i64::from(scale))
+    };
+    let address = builder.ins().iadd(base, index);
+    let address = builder.ins().iadd_imm(address, displacement as i64);
+    let (off, masked) = checked_window_off(builder, env, bail, address, size);
+    guard_store_not_code(builder, env, bail, masked, size);
+    let zero = iconst_u32(builder, 0);
+    window_store(builder, env, off, size, zero);
+    store_u32(builder, cpu, offset_of!(CpuCore, n_flag), 0);
+    store_u32(builder, cpu, offset_of!(CpuCore, not_z_flag), 0);
+    store_u32(builder, cpu, offset_of!(CpuCore, v_flag), 0);
+    store_u32(builder, cpu, offset_of!(CpuCore, c_flag), 0);
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -8655,6 +8809,183 @@ mod portable_tests {
             assert_eq!(actual.dar, expected.dar, "case {case}: registers");
             assert_eq!(actual.get_ccr(), expected.get_ccr(), "case {case}: ccr");
             assert_eq!(amem, emem, "case {case}: memory");
+        }
+    }
+
+    #[test]
+    fn clr_to_indexed_destination_decodes_and_clears_with_correct_flags() {
+        // 4230/4270 = CLR.B/W (d8,An,Xn): the indexed-destination stores
+        // two profiled heads terminate on.
+        let mut dcpu = cpu();
+        dcpu.set_cpu_type(CpuType::M68040);
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        bus.write_word(0x0100, 0x4230);
+        bus.write_word(0x0102, 0x2004); // (4,A0,D2.W)
+        let byte_trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("CLR.B (d8,An,Xn) should decode");
+        assert!(matches!(
+            byte_trace.op,
+            JitTraceOp::ClrMem {
+                size: Size::Byte,
+                dst: JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                },
+            }
+        ));
+        bus.write_word(0x0100, 0x4270);
+        let word_trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("CLR.W (d8,An,Xn) should decode");
+        assert!(matches!(
+            word_trace.op,
+            JitTraceOp::ClrMem {
+                size: Size::Word,
+                ..
+            }
+        ));
+
+        // CLR sets Z, clears N/V/C, and leaves X alone.
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0100..0x0102].copy_from_slice(&0x4270u16.to_be_bytes());
+        mem[0x0102..0x0104].copy_from_slice(&0x2004u16.to_be_bytes());
+        mem[0x0306..0x0308].copy_from_slice(&0xCAFEu16.to_be_bytes());
+        let mut c = cpu();
+        c.set_cpu_type(CpuType::M68040);
+        c.set_a(0, 0x0300);
+        c.set_d(2, 2);
+        c.set_ccr(0x1F); // all set: X must survive, NZVC must be rewritten
+        attach_window(&mut c, &mut mem);
+        let cycles = execute_portable_op(&mut c, word_trace, 0x0100, 0x0104)
+            .expect("portable indexed CLR executes");
+        assert!(cycles > 0);
+        assert_eq!(&mem[0x0306..0x0308], &[0, 0], "destination cleared");
+        assert_eq!(c.get_ccr(), 0x14, "Z set, N/V/C cleared, X preserved");
+        assert_eq!(c.pc, 0x0104, "pc advanced past opcode and extension");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_clr_to_indexed_destination_matches_portable_and_bails_atomically() {
+        // Case 0: CLR.B with a negative word index. Case 1: CLR.W with a
+        // scaled long index (68040 brief format).
+        let cases: [(u16, u16, JitTraceOp); 2] = [
+            (
+                0x4230,
+                0x20FC, // (-4,A0,D2.W)
+                JitTraceOp::ClrMem {
+                    size: Size::Byte,
+                    dst: JitEa::Index {
+                        base: 0,
+                        index: JitDirectReg::Data(2),
+                        index_long: false,
+                        scale: 0,
+                        displacement: -4,
+                    },
+                },
+            ),
+            (
+                0x4270,
+                0x3A08, // (8,A0,D3.L*2)
+                JitTraceOp::ClrMem {
+                    size: Size::Word,
+                    dst: JitEa::Index {
+                        base: 0,
+                        index: JitDirectReg::Data(3),
+                        index_long: true,
+                        scale: 1,
+                        displacement: 8,
+                    },
+                },
+            ),
+        ];
+        for (case, (opcode, extension, op)) in cases.iter().enumerate() {
+            let clr = TraceBuildOp {
+                opcode: *opcode,
+                extension: Some(*extension),
+                extension2: None,
+                pc: 0x0100,
+                op: *op,
+            };
+            let branch = TraceBuildOp {
+                opcode: 0x60FA,
+                extension: None,
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -6,
+                    length: 2,
+                    expected_taken: None,
+                },
+            };
+            let ops = vec![clr, branch];
+            let prepare = |mem: &mut Vec<u8>| {
+                mem[0x0100..0x0102].copy_from_slice(&opcode.to_be_bytes());
+                mem[0x0102..0x0104].copy_from_slice(&extension.to_be_bytes());
+                mem[0x0300..0x0400].fill(0xAA);
+                let mut c = cpu();
+                c.set_cpu_type(CpuType::M68040);
+                c.set_a(0, 0x0320);
+                c.set_d(2, 0xFFFF_FF00); // word part -256
+                c.set_d(3, 0x0000_0040); // scaled by 2 = 0x80
+                c.set_ccr(0x10);
+                attach_window(&mut c, mem);
+                c
+            };
+            let mut emem = vec![0u8; 0x1000];
+            let mut expected = prepare(&mut emem);
+            let expected_packed = execute_portable_trace(&mut expected, &ops, 0x0100, 0x0106);
+            let mut amem = vec![0u8; 0x1000];
+            let mut actual = prepare(&mut amem);
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(&actual, 0x0100, CpuType::M68040, ops.clone(), Some(0x0100))
+                .expect("indexed CLR loop should compile");
+            let actual_packed = unsafe { compiled.call_native(&mut actual, 1) };
+            assert_eq!(
+                actual_packed, expected_packed,
+                "case {case}: cycles/retired"
+            );
+            assert_eq!(actual.dar, expected.dar, "case {case}: registers");
+            assert_eq!(actual.get_ccr(), expected.get_ccr(), "case {case}: ccr");
+            assert_eq!(amem, emem, "case {case}: memory");
+            let cleared = if case == 0 {
+                0x0320 - 256 - 4
+            } else {
+                0x0320 + 0x80 + 8
+            };
+            assert_eq!(amem[cleared], 0, "case {case}: destination byte cleared");
+
+            if case == 0 {
+                // A store aimed at the trace's own code must bail on both
+                // paths with nothing committed.
+                let overlap = |mem: &mut Vec<u8>| {
+                    let mut c = prepare(mem);
+                    // 0x0102 = base - 256 - 4  =>  base = 0x0206
+                    c.set_a(0, 0x0206);
+                    c
+                };
+                let mut pmem = vec![0u8; 0x1000];
+                let mut pcpu = overlap(&mut pmem);
+                let packed = execute_portable_trace(&mut pcpu, &ops, 0x0100, 0x0106);
+                assert_eq!(packed, 0, "portable bails on a store into code");
+                assert_eq!(pcpu.pc, 0x0100);
+                assert_eq!(pcpu.get_ccr(), 0x10);
+                assert_eq!(pmem[0x0102], 0x20, "extension word untouched");
+
+                let mut nmem = vec![0u8; 0x1000];
+                let mut ncpu = overlap(&mut nmem);
+                let before = ncpu.dar;
+                let packed = unsafe { compiled.call_native(&mut ncpu, 1) };
+                assert_eq!(packed, 0, "native bails on a store into code");
+                assert_eq!(ncpu.pc, 0x0100);
+                assert_eq!(ncpu.dar, before);
+                assert_eq!(ncpu.get_ccr(), 0x10);
+                assert_eq!(nmem, pmem, "native bail commits nothing");
+            }
         }
     }
 

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -2775,11 +2775,11 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     };
     let src = decode_ea(src_mode, opcode & 7)?;
     let dst = decode_ea(dst_mode, (opcode >> 9) & 7)?;
-    // The measured loop only needs indexed reads. Indexed stores can be
-    // added when a profile demonstrates that their extra emitter paths pay.
-    if matches!(dst, JitEa::Index { .. }) {
-        return None;
-    }
+    // Indexed destinations were gated until "a profile demonstrates that
+    // their extra emitter paths pay". Three profiled heads across two
+    // workloads now terminate on indexed-destination stores (MOVE.W 3180
+    // and the CLR forms 4230/4270), so the store side gets the same brief-
+    // indexed support the read side has had.
     if !src.is_mem() && !dst.is_mem() {
         return None;
     }
@@ -3572,7 +3572,43 @@ fn execute_portable_move_mem(
             write(cpu, off, value);
             cpu.set_logic_flags(value, size);
         }
-        JitEa::Index { .. } => return None,
+        JitEa::Index {
+            base,
+            index,
+            index_long,
+            scale,
+            displacement,
+        } => {
+            let base_value = dst_base(cpu, base);
+            // The index register must also observe a staged source
+            // adjustment: in `MOVE.W (A2)+,(d8,A1,A2.W)` the source
+            // post-increment commits before the destination EA evaluates.
+            let raw_index = match index {
+                JitDirectReg::Addr(r) => match staged {
+                    Some((idx, v)) if idx == 8 + r as usize => v,
+                    _ => cpu.dar[8 + r as usize],
+                },
+                JitDirectReg::Data(r) => cpu.dar[r as usize],
+            };
+            let index_value = if index_long {
+                raw_index
+            } else {
+                raw_index as u16 as i16 as i32 as u32
+            };
+            let addr = base_value
+                .wrapping_add(index_value << scale)
+                .wrapping_add(displacement as i32 as u32);
+            let off = locate(cpu, addr)?;
+            let masked = addr & cpu.address_mask;
+            if masked < code_end && masked.wrapping_add(bytes) > code_start {
+                return None;
+            }
+            if let Some((idx, v)) = staged {
+                cpu.dar[idx] = v;
+            }
+            write(cpu, off, value);
+            cpu.set_logic_flags(value, size);
+        }
     }
 
     Some(JitTraceOp::MoveMem { size, src, dst }.max_cycles())
@@ -5659,6 +5695,50 @@ fn emit_move_mem(
             window_store(builder, env, off, size, value);
             set_logic_flags(builder, cpu, value, size);
         }
+        JitEa::Index {
+            base,
+            index,
+            index_long,
+            scale,
+            displacement,
+        } => {
+            let base_value = dst_base(builder, base);
+            // The index register must also observe a staged source
+            // adjustment (`MOVE.W (A2)+,(d8,A1,A2.W)`): the source
+            // post-increment commits before the destination EA evaluates.
+            let raw_index = match (index, staged) {
+                (JitDirectReg::Addr(ir), Some((sr, v))) if sr == ir => v,
+                _ => load_reg(builder, cpu, index),
+            };
+            let index_value = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index_value = if scale == 0 {
+                index_value
+            } else {
+                builder.ins().ishl_imm(index_value, i64::from(scale))
+            };
+            let a = builder.ins().iadd(base_value, index_value);
+            let addr = builder.ins().iadd_imm(a, displacement as i64);
+            let (off, masked) = checked_window_off(builder, env, bail, addr, size);
+            let lt_end =
+                builder
+                    .ins()
+                    .icmp_imm(IntCC::UnsignedLessThan, masked, env.code_end as i64);
+            let past = builder.ins().iadd_imm(masked, size.bytes() as i64);
+            let gt_start =
+                builder
+                    .ins()
+                    .icmp_imm(IntCC::UnsignedGreaterThan, past, env.code_start as i64);
+            let bad = builder.ins().band(lt_end, gt_start);
+            branch_guard(builder, bail, bad);
+            commit_staged(builder);
+            window_store(builder, env, off, size, value);
+            set_logic_flags(builder, cpu, value, size);
+        }
         JitEa::AbsWord(address) | JitEa::AbsLong(address) => {
             let address = iconst_u32(builder, address);
             let (off, masked) = checked_window_off(builder, env, bail, address, size);
@@ -5667,7 +5747,6 @@ fn emit_move_mem(
             window_store(builder, env, off, size, value);
             set_logic_flags(builder, cpu, value, size);
         }
-        JitEa::Index { .. } => unreachable!("indexed MOVE destination is not traceable"),
     }
 
     cycles_const(
@@ -8365,6 +8444,218 @@ mod portable_tests {
         assert_eq!(actual.c_flag, 0, "C is cleared by a zero count");
         assert_eq!(actual.v_flag, 0, "V is cleared");
         assert_ne!(actual.n_flag, 0, "N comes from the unshifted value");
+    }
+
+    #[test]
+    fn move_to_indexed_destination_decodes_and_matches_the_interpreter() {
+        // 3180 = MOVE.W D0,(d8,A0,Xn): the indexed-destination store that
+        // three profiled heads terminate on. The staged case is the subtle
+        // one -- MOVE.W (A2)+,(d8,A1,A2.W) commits the source post-
+        // increment before the destination EA evaluates -- and portable
+        // and native could share a wrong staging model, so both are
+        // checked against the interpreter's own decoded execution rather
+        // than only against each other.
+        let mut cpu = cpu();
+        cpu.set_cpu_type(CpuType::M68040);
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        bus.write_word(0x0100, 0x3180);
+        bus.write_word(0x0102, 0x2004); // (4,A0,D2.W)
+        let trace = decode_trace_op(&cpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("MOVE.W Dn,(d8,An,Xn) should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::MoveMem {
+                size: Size::Word,
+                src: JitEa::Data(0),
+                dst: JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                },
+            }
+        ));
+
+        // Staged-interaction differential: MOVE.W (A2)+,(d8,A1,A2.W).
+        // dst reg 1, dst mode 6 (index), src mode 3 (postinc), src reg 2
+        // => 0011 001 110 011 010 = 0x339A.
+        let mut dbus = super::super::memory::LinearMemoryBus::new(0x1000);
+        dbus.write_word(0x0100, 0x339A);
+        dbus.write_word(0x0102, 0xA008); // (8,A1,A2.W) index=A2 word
+        let staged_trace = decode_trace_op(&cpu, &mut dbus, 0x0100, CpuType::M68040)
+            .expect("staged indexed store should decode");
+        assert!(matches!(
+            staged_trace.op,
+            JitTraceOp::MoveMem {
+                size: Size::Word,
+                src: JitEa::PostInc(2),
+                dst: JitEa::Index {
+                    base: 1,
+                    index: JitDirectReg::Addr(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 8,
+                },
+            }
+        ));
+
+        let prepare = |mem: &mut Vec<u8>| {
+            let mut c = cpu_fn();
+            c.set_cpu_type(CpuType::M68040);
+            c.set_a(2, 0x0200); // source pointer; also the dst index register
+            c.set_a(1, 0x0400); // dst base
+            c.set_a(7, 0x0900);
+            mem[0x0200..0x0202].copy_from_slice(&0xBEEFu16.to_be_bytes());
+            // The interpreter reads the extension word from guest memory.
+            mem[0x0100..0x0102].copy_from_slice(&0x339Au16.to_be_bytes());
+            mem[0x0102..0x0104].copy_from_slice(&0xA008u16.to_be_bytes());
+            attach_window(&mut c, mem);
+            c.pc = 0x0100;
+            c
+        };
+        fn cpu_fn() -> CpuCore {
+            let mut c = CpuCore::new();
+            c.set_sr(0x2700);
+            c
+        }
+
+        // Interpreter (decoded fast path) reference.
+        let mut imem = vec![0u8; 0x1000];
+        let mut icpu = prepare(&mut imem);
+        icpu.pc = 0x0102; // execute_mem_op reads extensions from pc
+        assert!(super::super::mem_ops::execute_mem_op(
+            &mut icpu,
+            DecodedMemOp::Move {
+                size: Size::Word,
+                src: FastEa::AnPostInc(2),
+                dst: FastEa::AnIndex(1),
+            },
+        ));
+
+        // Portable trace op.
+        let mut pmem = vec![0u8; 0x1000];
+        let mut pcpu = prepare(&mut pmem);
+        let cycles = execute_portable_op(&mut pcpu, staged_trace, 0x0100, 0x0104)
+            .expect("portable staged indexed store executes");
+        assert!(cycles > 0);
+
+        assert_eq!(icpu.a(2), 0x0202, "interpreter commits the post-increment");
+        assert_eq!(pcpu.a(2), icpu.a(2), "portable matches interpreter A2");
+        // The stored address uses the UPDATED A2 as index: 0x400+0x202+8.
+        let addr = 0x0400 + 0x0202 + 8;
+        assert_eq!(
+            &imem[addr..addr + 2],
+            &0xBEEFu16.to_be_bytes(),
+            "interpreter stores through the post-incremented index"
+        );
+        assert_eq!(pmem, imem, "portable memory matches interpreter exactly");
+        assert_eq!(pcpu.get_ccr(), icpu.get_ccr(), "flags agree");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_move_to_indexed_destination_matches_portable() {
+        // Plain, negative-word-index, and staged-postinc cases.
+        let cases: [(JitEa, u16, u32, u32); 3] = [
+            (
+                JitEa::Data(0),
+                0x3180, // MOVE.W D0,(4,A0,D2.W)
+                0x0000_0010,
+                0x0000_0004,
+            ),
+            (
+                JitEa::Data(0),
+                0x3180,
+                0xFFFF_8000, // negative word index, sign-extension boundary
+                0x0000_0004,
+            ),
+            (
+                JitEa::PostInc(2),
+                0x339A, // MOVE.W (A2)+,(8,A1,A2.W) -- staged interaction
+                0,
+                0,
+            ),
+        ];
+        for (case, (src, opcode, d2, _)) in cases.iter().enumerate() {
+            let dst = if *opcode == 0x3180 {
+                JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 4,
+                }
+            } else {
+                JitEa::Index {
+                    base: 1,
+                    index: JitDirectReg::Addr(2),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 8,
+                }
+            };
+            let mv = TraceBuildOp {
+                opcode: *opcode,
+                extension: Some(if *opcode == 0x3180 { 0x2004 } else { 0xA008 }),
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::MoveMem {
+                    size: Size::Word,
+                    src: *src,
+                    dst,
+                },
+            };
+            let branch = TraceBuildOp {
+                opcode: 0x60FA,
+                extension: None,
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -6,
+                    length: 2,
+                    expected_taken: None,
+                },
+            };
+            let mut emem = vec![0u8; 0x1000];
+            let mut amem = vec![0u8; 0x1000];
+            let prepare = |mem: &mut Vec<u8>| {
+                let mut c = cpu();
+                c.set_cpu_type(CpuType::M68040);
+                c.set_d(0, 0x0000_CAFE);
+                c.set_d(2, *d2);
+                c.set_a(0, 0x0300);
+                c.set_a(1, 0x0400);
+                c.set_a(2, 0x0200);
+                c.set_a(7, 0x0900);
+                mem[0x0200..0x0202].copy_from_slice(&0x1234u16.to_be_bytes());
+                attach_window(&mut c, mem);
+                c
+            };
+            let mut expected = prepare(&mut emem);
+            let expected_packed =
+                execute_portable_trace(&mut expected, &[mv, branch], 0x0100, 0x0106);
+            let mut actual = prepare(&mut amem);
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(
+                    &actual,
+                    0x0100,
+                    CpuType::M68040,
+                    vec![mv, branch],
+                    Some(0x0100),
+                )
+                .expect("indexed-destination store loop should compile");
+            let actual_packed = unsafe { compiled.call_native(&mut actual, 1) };
+            assert_eq!(
+                actual_packed, expected_packed,
+                "case {case}: cycles/retired"
+            );
+            assert_eq!(actual.dar, expected.dar, "case {case}: registers");
+            assert_eq!(actual.get_ccr(), expected.get_ccr(), "case {case}: ccr");
+            assert_eq!(amem, emem, "case {case}: memory");
+        }
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]


### PR DESCRIPTION
## Summary

Lift the decoder's indexed-destination gate for MOVE and add a `ClrMem`
trace op for `CLR.B/W/L (d8,An,Xn)`. The decoder comment gated indexed
stores on "a profile demonstrates that their extra emitter paths pay";
three profiled heads across two workloads now terminate on exactly this
capability, so the store side gets the same brief-indexed support the
read side gained across the indexed-read series (guarded scans,
memory-source ALU, immediate compares, LEA). Applies to `master` at `5ecdc72`.

## Why these forms

Three independent chain heads converge on indexed-destination stores —
the only shared missing capability across both measured workloads:

| opcode | form | head it blocks | workload |
|---|---|---|---|
| `3180` | `MOVE.W Dn,(d8,An,Xn)` | `00FB1C4A` (next link after the shift admission) | headless |
| `4230` | `CLR.B (d8,An,Xn)` | `00EE9DBA` (multiply-chain head) | headless |
| `4270` | `CLR.W (d8,An,Xn)` | gameplay head (capped session 2026-08-08) | gameplay |

One address computation (brief extension: base + sign-extended or long
index, optional scale, d8) plus the established checked-store tail
(window check → store-not-code guard → staged commit → store → flags)
serves all three.

## Whole-application acceptance (deterministic headless A/B vs `5ecdc72`)

Measured in the four-feature bundle (sub + shifts + pea + this) against
`5ecdc72`; the base totals reproduce the deterministic byte-identical
baseline of every prior run.

| | base | with bundle |
|---|---|---|
| `00FB1C4A` (jointly with #96) | blocked at `E2A0`, prefix 4, chain shows `3180` next | **compiled: 23 ops, 313 calls, 879,405 instructions retired, 2,810 ops/call, zero guard exits** |
| `00FB1BD8` | blocked at `9190`, prefix 6 | **compiled: 24 ops, 254 calls, 882,168 retired, 3,473 ops/call, zero guard exits** (reproduces the solo-SUB acceptance exactly) |
| `00EE9DBA` | blocked at `4230`, prefix 25 | `4230` admitted; advanced to `31BC` (`MOVE.W #imm,(d8,An,Xn)`), prefix 30, residual 35 hits / 1,020 projected — headless residue is negligible |
| totals | `native_calls` 47,671; `jit_retired` 11,146,241 | 65,322; **15,986,450 (+43.4%)** |

The two named heads account for 1.76M of the +4.84M retired delta; the
remaining ~3.1M is other heads the shared indexed-store path unblocked —
the convergence hypothesis paying beyond its named targets. Backward
hits into the recorder fell 869K → 582K (loops now spend those
iterations inside native traces).

## Gameplay (capped `--cpu-mhz 25` session, 847M guest instructions)

- `00FB1C4A` (#96's shifts + this `MOVE.W` form) compiled end-to-end in play:
  23 ops, 1,283 calls, **3,505,568 retired, zero guard exits**.
- Neither `4230` nor `4270` blocks anything ranked — the CLR forms are
  consumed into longer recordings.
- Session-wide with the four-feature bundle: `jit_retired` 424,277,987
  = **50.1% of every instruction the session executed**.
- The next link this admission revealed (`31BC`, immediate→indexed
  MOVE) projects only 244K dispatches in gameplay and 1K headless —
  documented, not chased.

## Focused benchmark

`benches/microbench.rs indexed-dest-store`: `MOVE.W D0,(0,A0,D1.W*2)`
plus `CLR.B (1,A0,D1.W*2)` swept by the DBRA counter, so every
iteration stores through a different address and the final memory
pattern proves both stores executed across the sweep. Five alternating
runs against base carrying an identical copy of the benchmark: median
24.9 → 225.1 M instr/s (**9.0×**); per-pair ratios 7.4–9.1.

## Correctness

- **The staged-source case is the subtle one**: in
  `MOVE.W (A2)+,(d8,A1,A2.W)` the source post-increment commits before
  the destination EA evaluates, so the destination's index-register read
  must observe the staged value. Because portable and native could share
  a wrong staging model, the test checks portable against the
  interpreter's own decoded execution (`execute_mem_op`), which
  demonstrably stores through the post-incremented index. Native parity
  covers the plain, negative-word-index (sign-extension boundary), and
  staged cases; the staged-index mutation (native reading the stale
  register) fails the parity memory comparison.
- **CLR semantics**: Z set, N/V/C cleared, X untouched — asserted
  explicitly; portable delegates to the interpreter's decoded CLR so
  store and flag semantics have one source of truth.
- **Store-into-code bails atomically on both paths**: the checked window
  offset and store-not-code guard precede the store and flag writes;
  tests aim a store at the trace's own extension word and assert nothing
  commits (portable and native). Dropping the portable pre-check fails
  the bail assertion (mutation-tested).
- **Classifier**: `ClrMem` declares non-poll in `is_pure_poll_loop` (a
  store ends a wait shape), keeping #81's exhaustive-match contract.
- Cycle maxima follow the `TstMem` convention: M68000UM store cost plus
  the indexed EA calculation (MOVE unchanged; CLR 18 B/W, 26 long).

## Validation

- 190 lib tests on the branch (196 in the four-feature bundle), clippy
  clean, wasm32 check green, `cargo fmt` clean.

<!-- Drafted by Claude Fable 5, 2026-08-08. -->



