### PR TITLE
perf: seed trace candidacy from guard exits and chain compiled continuations

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1094,6 +1094,66 @@ fn bench_salvaged_prefix_loop() {
     );
 }
 
+/// A mixed-path loop whose conditional branch alternates every iteration
+/// (EORI #1 flips Z), so whichever spine the head trace records, it
+/// guard-exits on half of all calls forever -- below the adaptive
+/// re-record ratio, above any useful coverage. The continuation between
+/// the branch join and the DBRA is what exit-seeded candidacy compiles.
+fn bench_mixed_path_loop() {
+    const CODE_BASE: u32 = 0x6000;
+    const INSTRS: u32 = 100_000_000;
+    let words = [
+        0x0A01, 0x0001, // head: EORI.B #1,D1
+        0x6602, // BNE.S join
+        0x5282, // ADDQ.L #1,D2
+        // join: a field-shaped continuation -- long enough that a chained
+        // native call amortizes its entry boundary, as the stranded
+        // continuations in the gameplay profile are.
+        0x1ADC, // join: MOVE.B (A4)+,(A5)+
+        0x5283, // ADDQ.L #1,D3
+        0x1ADC, 0x5283, // x2
+        0x1ADC, 0x5283, // x3
+        0x1ADC, 0x5283, // x4
+        0x1ADC, 0x5283, // x5
+        0x1ADC, 0x5283, // x6
+        0x51C8, 0xFFDE, // DBRA D0,head
+        0x2845, // outer: MOVEA.L D5,A4
+        0x2A46, // MOVEA.L D6,A5
+        0x707F, // MOVEQ #127,D0
+        0x60D4, // BRA.S head
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(4, 0x4000);
+        cpu.set_a(5, 0x5000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 127);
+        cpu.set_d(5, 0x4000);
+        cpu.set_d(6, 0x5000);
+        cpu
+    };
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "batch     mixed-path loop         {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 /// Reproduce a path-biased trace that is first recorded through an uncommon
 /// conditional edge before settling into a copy loop on the opposite edge.
 /// A first-path-only
@@ -1729,6 +1789,10 @@ fn main() {
     }
     if only.as_deref() == Some("sub-reg-to-mem") {
         bench_sub_reg_to_mem_loop();
+        return;
+    }
+    if only.as_deref() == Some("mixed-path") {
+        bench_mixed_path_loop();
         return;
     }
     if only.as_deref() == Some("indexed-lea") {

--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1062,7 +1062,16 @@ impl CpuCore {
                             probe = true;
                             continue;
                         }
-                        CachedRunResult::Miss(opcode) => return BatchInnerExit::Miss(opcode),
+                        CachedRunResult::Miss(opcode) => {
+                            // A chained continuation can retire instructions
+                            // before its successor misses validation; those
+                            // are real completed instructions and must be
+                            // accounted before the missed opcode dispatches.
+                            // (`remaining` needs no update: this return path
+                            // leaves the budget loop entirely.)
+                            *retired += instructions;
+                            return BatchInnerExit::Miss(opcode);
+                        }
                     }
                 }
             }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -667,8 +667,13 @@ impl TraceJit {
     /// Attempt to execute a compiled trace at the current PC.
     ///
     /// On `CachedRunResult::Ran`, the returned count is the number of
-    /// guest instructions the trace retired. The count is 0 for
-    /// `Fault`/`Miss`.
+    /// guest instructions the trace retired. On `Miss` the count is the
+    /// number of instructions retired BEFORE the miss: zero when the
+    /// entered trace's own first opcode changed, but non-zero when a
+    /// chained continuation missed validation after its parent (and any
+    /// earlier links) retired instructions -- callers must account the
+    /// count before dispatching the missed opcode, as
+    /// `run_decoded_simple_batch` does. The count is 0 for `Fault`.
     ///
     /// A self-looping trace (one whose closing branch targets its own
     /// head) may run many iterations per call: up to `instr_budget`

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -12702,7 +12702,7 @@ mod portable_tests {
         const CODE_BASE: u32 = 0x7000;
         let words = [
             0x5282, // head: ADDQ.L #1,D2
-            0x3088, // MOVE.W D0,(A0)   (A0 -> head; writes 0x5282 back)
+            0x3080, // MOVE.W D0,(A0)   (A0 -> head; writes 0x5282 back)
             0x51C9, 0xFFFA, // DBRA D1,head
             0x60F6, // BRA.S head
         ];

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -697,6 +697,14 @@ impl TraceJit {
         if cpu.has_pmmu && cpu.pmmu_enabled || cpu.cycles_remaining <= 0 {
             return None;
         }
+        if instr_budget == 0 {
+            // With nothing left to retire, even a validation miss is too
+            // much: consuming a changed opcode would hand run_batch one
+            // instruction past its exact budget. A chained child can be
+            // entered this way when its parent retired the final permitted
+            // instruction; the next entry validates with budget to act.
+            return None;
+        }
         if cpu.trace_recording || self.recording.is_some() {
             // A recorder is already following an executed path on this
             // thread. Nested backward edges and interleaved CPU instances
@@ -9736,6 +9744,262 @@ mod portable_tests {
         assert_eq!(pcpu.a(7), icpu.a(7), "portable matches interpreter A7");
         assert_eq!(pmem, imem, "memory matches interpreter exactly");
         assert_eq!(pcpu.get_ccr(), icpu.get_ccr(), "flags agree");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn zero_budget_entry_never_consumes_a_validation_miss() {
+        // A chained continuation is entered with the parent's leftover
+        // budget, which is zero when the parent retired the final
+        // permitted instruction. Entering the child then must not touch
+        // anything: its validation would otherwise consume a rewritten
+        // first opcode as a miss and hand run_batch one instruction past
+        // its exact budget. This drives the child exactly as the chain
+        // site does.
+        let continuation_ops = vec![
+            TraceBuildOp {
+                opcode: 0x5285,
+                extension: None,
+                extension2: None,
+                pc: 0x010A,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 5,
+                    data: 1,
+                    size: Size::Long,
+                    is_sub: false,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x5286,
+                extension: None,
+                extension2: None,
+                pc: 0x010C,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 6,
+                    data: 1,
+                    size: Size::Long,
+                    is_sub: false,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x60FA,
+                extension: None,
+                extension2: None,
+                pc: 0x010E,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -6,
+                    length: 2,
+                    expected_taken: None,
+                },
+            },
+        ];
+        let words: [u16; 3] = [0x5285, 0x5286, 0x60FA];
+        let run = |budget: u32| {
+            let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+            for (index, word) in words.iter().enumerate() {
+                bus.write_word(0x010A + index as u32 * 2, *word);
+            }
+            let mut cpu = CpuCore::new();
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_sr(0x2700);
+            cpu.pc = 0x010A;
+            cpu.cycles_remaining = 1_000_000;
+            let mut jit = TraceJit::new();
+            let continuation = jit
+                .compile_decoded_ops(
+                    &cpu,
+                    0x010A,
+                    CpuType::M68040,
+                    continuation_ops.clone(),
+                    None,
+                )
+                .expect("continuation compiles");
+            jit.slots[trace_cache_index(0x010A)] = TraceSlot::Compiled(continuation);
+            // The first opcode changes after compilation.
+            bus.write_word(0x010A, 0x4E71);
+            let result = jit.try_execute(
+                &mut cpu,
+                &mut bus,
+                CpuType::M68040,
+                budget,
+                false,
+                &[],
+                TRACE_EXIT_CHAIN_BUDGET,
+            );
+            (result, cpu.pc)
+        };
+
+        // Zero budget: no validation, no consumption -- the count and PC
+        // stay exactly at the boundary.
+        let (result, pc) = run(0);
+        assert!(
+            result.is_none(),
+            "zero-budget entry returns to the caller untouched"
+        );
+        assert_eq!(pc, 0x010A, "PC stays at the boundary");
+
+        // One instruction of budget: consuming the changed opcode as a
+        // validation miss is the correct SMC handling and fits the count.
+        let (result, pc) = run(1);
+        assert!(
+            matches!(result, Some((CachedRunResult::Miss(0x4E71), 0))),
+            "with budget to act the miss surfaces"
+        );
+        assert_eq!(pc, 0x010C, "the miss consumed the changed opcode");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn blocked_recording_salvages_the_prefix_through_the_last_branch() {
+        // Nine admissible ops (the last a recorded interior branch), then
+        // the A7 LINK/UNLK pair -- refused by documented design, so no
+        // future coverage can admit this blocker -- then a loop tail. Without
+        // salvage the whole head rejects; with it the prefix through the
+        // branch compiles and the tail stays interpreted.
+        const A: u32 = 0x0100;
+        let words = [
+            0x5282, // head: ADDQ.L #1,D2
+            0x5283, // ADDQ.L #1,D3
+            0x5284, // ADDQ.L #1,D4
+            0x5285, // ADDQ.L #1,D5
+            0x5286, // ADDQ.L #1,D6
+            0x5287, // ADDQ.L #1,D7
+            0x5281, // ADDQ.L #1,D1
+            0x4A41, // TST.W D1
+            0x6602, // BNE.S +2 (always taken: D1 counts up)
+            0x4E71, // NOP (skipped)
+            0x4A42, // TST.W D2 -- past the branch: no terminal to stop at
+            0x4A42, // TST.W D2
+            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
+            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
+            0x51C8, 0xFFE0, // DBRA D0,head
+            0x707F, // MOVEQ #127,D0
+            0x60DA, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(A + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = A;
+        cpu.set_a(6, 0x3000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        let result = cpu.run_batch(&mut bus, 40_000, &[0]);
+        assert_eq!(result.instructions, 40_000, "loop runs to budget");
+        // Every iteration bumps D2..D7 and D1 exactly once each.
+        assert!(cpu.d(2) > 2_000, "the loop actually iterated");
+        assert!(
+            cpu.d(2).abs_diff(cpu.d(3)) <= 1 && cpu.d(2).abs_diff(cpu.d(7)) <= 1,
+            "counters advance in lockstep"
+        );
+        let salvaged = TRACE_JIT.with_borrow(|jit| match &jit.slots[trace_cache_index(A)] {
+            TraceSlot::Compiled(trace) if trace.pc == A => Some((
+                trace.ops.len(),
+                matches!(
+                    trace.ops.last().map(|op| op.op),
+                    Some(JitTraceOp::Branch { .. })
+                ),
+                trace
+                    .ops
+                    .iter()
+                    .all(|op| op.opcode != 0x4E57 && op.opcode != 0x4E5F),
+            )),
+            _ => None,
+        });
+        let (ops, ends_in_branch, excludes_blocked_tail) =
+            salvaged.expect("the blocked head compiles its salvageable prefix");
+        assert_eq!(ops, 9, "trimmed at the recorded branch");
+        assert!(ends_in_branch, "the trimmed terminal is the branch");
+        assert!(
+            excludes_blocked_tail,
+            "the unsupported tail is not recorded"
+        );
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn blocked_recording_without_a_branch_still_rejects() {
+        // A straight-line prefix has no terminal to trim to; the head
+        // must reject exactly as before regardless of length.
+        const A: u32 = 0x0100;
+        let words = [
+            0x5282, 0x5283, 0x5284, 0x5285, 0x5286, 0x5287, 0x5281, 0x5280,
+            0x4A41, // nine straight-line ops, no branch
+            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
+            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
+            0x51C8, 0xFFE6, // DBRA D0,head
+            0x707F, // MOVEQ #127,D0
+            0x60E0, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(A + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = A;
+        cpu.set_a(6, 0x3000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        cpu.run_batch(&mut bus, 40_000, &[0]);
+        TRACE_JIT.with_borrow(|jit| {
+            assert!(
+                matches!(
+                    &jit.slots[trace_cache_index(A)],
+                    TraceSlot::Rejected { pc, .. } if *pc == A
+                ),
+                "no recorded branch means nothing to salvage"
+            );
+        });
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn short_blocked_recordings_still_reject() {
+        // A five-op prefix whose last terminal sits at op four: below
+        // SALVAGE_MIN_OPS the head must reject exactly as before. (The
+        // blocker must not directly follow the branch: a recording whose
+        // last op is already a terminal compiles today without salvage.)
+        const A: u32 = 0x0100;
+        let words = [
+            0x5282, // head: ADDQ.L #1,D2
+            0x5283, // ADDQ.L #1,D3
+            0x4A42, // TST.W D2
+            0x6602, // BNE.S +2 (always taken)
+            0x4E71, // NOP (skipped)
+            0x5284, // ADDQ.L #1,D4
+            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
+            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
+            0x51C8, 0xFFEC, // DBRA D0,head
+            0x707F, // MOVEQ #127,D0
+            0x60E6, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(A + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = A;
+        cpu.set_a(6, 0x3000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        cpu.run_batch(&mut bus, 40_000, &[0]);
+        TRACE_JIT.with_borrow(|jit| {
+            assert!(
+                matches!(
+                    &jit.slots[trace_cache_index(A)],
+                    TraceSlot::Rejected { pc, .. } if *pc == A
+                ),
+                "a four-op prefix is below the salvage bar"
+            );
+        });
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -973,12 +973,17 @@ impl TraceJit {
                 #[cfg(feature = "trace-profile")]
                 super::trace_profile::note_adaptive_rerecord(pc, cpu_type);
             }
-            // A guard exit landed the interpreter mid-continuation. Treat
-            // the exit target as a trace-head candidate: hot fall-through
-            // continuations then form their own traces, and once compiled
-            // they run directly from here (bounded chaining) instead of
-            // waiting for a backward-branch probe that never comes.
-            if partial_call_this_entry && !single_iter && chain_budget > 0 && cpu.pc != pc {
+            // A guarded BRANCH exit landed the interpreter mid-
+            // continuation. Treat the exit target as a trace-head
+            // candidate: hot fall-through continuations then form their
+            // own traces, and once compiled they run directly from here
+            // (bounded chaining) instead of waiting for a backward-branch
+            // probe that never comes. Memory bails (window, alignment,
+            // self-modifying-code) are deliberately excluded: their exit
+            // pc is an access the trace could not execute, so seeding it
+            // would probe and compile a continuation that starts on the
+            // very op that just bailed.
+            if guarded_branch_exit && !single_iter && chain_budget > 0 && cpu.pc != pc {
                 match self.note_trace_exit(cpu.pc, cpu_type) {
                     ExitSeed::Chain => {
                         // The callee excludes its entry pc from its own
@@ -991,8 +996,8 @@ impl TraceJit {
                         let entry_watched = watch_pcs
                             .iter()
                             .any(|&watched| cpu.address(watched) == cpu.address(cpu.pc));
-                        if !entry_watched
-                            && let Some((CachedRunResult::Ran, chained)) = self.try_execute(
+                        if !entry_watched {
+                            match self.try_execute(
                                 cpu,
                                 bus,
                                 cpu_type,
@@ -1000,9 +1005,18 @@ impl TraceJit {
                                 false,
                                 watch_pcs,
                                 chain_budget - 1,
-                            )
-                        {
-                            retired += chained;
+                            ) {
+                                Some((CachedRunResult::Ran, chained)) => retired += chained,
+                                // The continuation's first opcode changed:
+                                // the child has already consumed it (ppc/ir
+                                // set, pc advanced) and the caller must
+                                // dispatch it. Surface the miss while
+                                // keeping every instruction retired so far.
+                                Some((miss @ CachedRunResult::Miss(_), chained)) => {
+                                    return Some((miss, retired + chained));
+                                }
+                                None => {}
+                            }
                         }
                     }
                     ExitSeed::StartRecording => cpu.trace_recording = true,
@@ -10108,6 +10122,100 @@ mod portable_tests {
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
     #[test]
+    fn chained_continuation_miss_surfaces_the_rewritten_opcode() {
+        // Three deterministic phases against a step() twin, with identical
+        // external mutations at identical instruction counts:
+        //   1. The branch predicate holds, so the head trace compiles on
+        //      the taken spine -- which EXCLUDES the continuation.
+        //   2. The predicate is flipped externally; every head call now
+        //      guard-exits, seeding and compiling the continuation, and
+        //      the parent chains into it. Kept short so adaptive
+        //      re-recording (64-call window) cannot replace the head spine.
+        //   3. The continuation's first opcode is rewritten externally
+        //      (ADDQ.L #1,D2 -> ADDQ.L #2,D2) in both twins. The next
+        //      chained entry must surface the validation miss so the
+        //      rewritten opcode is dispatched; silently dropping the miss
+        //      skips the instruction and diverges D2.
+        const CODE_BASE: u32 = 0x7000;
+        let words = [
+            0xB206, // head: CMP.B D6,D1
+            0x6706, // BEQ.S skip (taken while D1 == D6)
+            0x5282, // cont: ADDQ.L #1,D2   <- rewritten in phase 3
+            0x1ADC, // MOVE.B (A4)+,(A5)+
+            0x5283, // ADDQ.L #1,D3
+            0x51C8, 0xFFF4, // skip: DBRA D0,head
+            0x60F0, // BRA.S head
+        ];
+        let mk = |bus: &mut super::super::memory::LinearMemoryBus| {
+            for (index, word) in words.iter().enumerate() {
+                bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+            }
+            let mut cpu = CpuCore::new();
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_sr(0x2700);
+            cpu.pc = CODE_BASE;
+            cpu.set_a(4, 0x3000);
+            cpu.set_a(5, 0x4000);
+            cpu.set_a(7, 0x9000);
+            cpu.set_d(0, 0x7FFF);
+            cpu.set_d(1, 5);
+            cpu.set_d(6, 5); // equal: BEQ taken
+            cpu
+        };
+        let mut bus_a = super::super::memory::LinearMemoryBus::new(0x10000);
+        let mut cpu_a = mk(&mut bus_a); // step twin
+        let mut bus_b = super::super::memory::LinearMemoryBus::new(0x10000);
+        let mut cpu_b = mk(&mut bus_b); // run_batch twin
+
+        let step_n =
+            |cpu: &mut CpuCore, bus: &mut super::super::memory::LinearMemoryBus, n: u32| {
+                for _ in 0..n {
+                    assert!(matches!(cpu.step(bus), crate::StepResult::Ok { .. }));
+                }
+            };
+        let batch_n =
+            |cpu: &mut CpuCore, bus: &mut super::super::memory::LinearMemoryBus, n: u32| {
+                let mut left = n;
+                while left > 0 {
+                    let r = cpu.run_batch(bus, left, &[0]);
+                    assert!(r.instructions > 0, "batch made no progress");
+                    left -= r.instructions;
+                }
+            };
+
+        // Phase 1: 30 instructions of taken-spine iterations.
+        step_n(&mut cpu_a, &mut bus_a, 30);
+        batch_n(&mut cpu_b, &mut bus_b, 30);
+        // Phase 2: flip the predicate in both twins; 30 instructions of
+        // guard exits, seeding, and chaining.
+        cpu_a.set_d(1, 9);
+        cpu_b.set_d(1, 9);
+        step_n(&mut cpu_a, &mut bus_a, 30);
+        batch_n(&mut cpu_b, &mut bus_b, 30);
+        // The continuation must exist as its own compiled trace for phase 3
+        // to test anything.
+        let cont_pc = CODE_BASE + 4;
+        let cont_compiled = TRACE_JIT.with_borrow(|jit| {
+            matches!(
+                &jit.slots[trace_cache_index(cont_pc)],
+                TraceSlot::Compiled(CompiledTrace { pc, .. }) if *pc == cont_pc
+            )
+        });
+        assert!(cont_compiled, "phase 2 must compile the continuation");
+        // Phase 3: rewrite the continuation head in both twins, then run
+        // one full not-taken iteration through each.
+        bus_a.write_word_at(cont_pc, 0x5482);
+        bus_b.write_word_at(cont_pc, 0x5482);
+        step_n(&mut cpu_a, &mut bus_a, 6);
+        batch_n(&mut cpu_b, &mut bus_b, 6);
+
+        assert_eq!(cpu_b.dar, cpu_a.dar, "registers diverged (D2 skip?)");
+        assert_eq!(cpu_b.pc, cpu_a.pc, "pc diverged");
+        assert_eq!(cpu_b.get_ccr(), cpu_a.get_ccr(), "ccr diverged");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
     fn native_cmp_indexed_matches_portable_and_bails_atomically() {
         let cmp = TraceBuildOp {
             opcode: 0xB270,
@@ -12569,30 +12677,72 @@ mod portable_tests {
                 })
                 .count()
         });
+        assert!(
+            compiled >= 2,
+            "exit seeding should compile a continuation inside the loop \
+             body in addition to the head trace (found {compiled})"
+        );
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn memory_bails_do_not_create_exit_candidacy() {
+        // The loop stores its own head opcode back onto itself: harmless
+        // when interpreted (the write is idempotent), but the compiled
+        // trace's store-not-code guard bails on every call at op 1 -- a
+        // MEMORY bail, not a guarded branch exit. The bail target must
+        // never become a trace-head candidate in any form (counting,
+        // compiled, or rejected): seeding it would record and compile a
+        // continuation that starts on the very op that cannot execute.
+        const CODE_BASE: u32 = 0x7000;
+        let words = [
+            0x5282, // head: ADDQ.L #1,D2
+            0x3088, // MOVE.W D0,(A0)   (A0 -> head; writes 0x5282 back)
+            0x51C9, 0xFFFA, // DBRA D1,head
+            0x60F6, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(0, CODE_BASE);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x5282);
+        cpu.set_d(1, 0x7F);
+        let result = cpu.run_batch(&mut bus, 20_000, &[0]);
+        assert_eq!(result.instructions, 20_000, "loop runs to budget");
+        let bail_pc = CODE_BASE + 2; // the MOVE that memory-bails
+        let touched = TRACE_JIT.with_borrow(|jit| match &jit.slots[trace_cache_index(bail_pc)] {
+            TraceSlot::Counting { pc, .. } if *pc == bail_pc => true,
+            TraceSlot::Compiled(CompiledTrace { pc, .. }) if *pc == bail_pc => true,
+            TraceSlot::Rejected { pc, .. } if *pc == bail_pc => true,
+            _ => false,
+        });
         let dump = TRACE_JIT.with_borrow(|jit| {
-            loop_pcs
-                .iter()
-                .map(|&pc| {
-                    let slot = &jit.slots[trace_cache_index(pc)];
-                    let desc = match slot {
+            (0..5u32)
+                .map(|w| {
+                    let pc = CODE_BASE + w * 2;
+                    match &jit.slots[trace_cache_index(pc)] {
                         TraceSlot::Compiled(CompiledTrace { pc: c, ops, .. }) if *c == pc => {
-                            format!("Compiled({} ops)", ops.len())
+                            format!("{pc:05X}:Compiled({})", ops.len())
                         }
                         TraceSlot::Counting { pc: c, hits, .. } if *c == pc => {
-                            format!("Counting(hits={hits})")
+                            format!("{pc:05X}:Cnt({hits})")
                         }
-                        TraceSlot::Rejected { pc: c, .. } if *c == pc => "Rejected".into(),
-                        _ => "-".into(),
-                    };
-                    format!("{pc:05X}:{desc}")
+                        TraceSlot::Rejected { pc: c, .. } if *c == pc => format!("{pc:05X}:Rej"),
+                        _ => format!("{pc:05X}:-"),
+                    }
                 })
                 .collect::<Vec<_>>()
                 .join(" ")
         });
         assert!(
-            compiled >= 2,
-            "exit seeding should compile a continuation inside the loop \
-             body in addition to the head trace (found {compiled}): {dump}"
+            !touched,
+            "a memory bail must not seed candidacy at its target in any form: {dump}"
         );
     }
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -989,39 +989,37 @@ impl TraceJit {
             // would probe and compile a continuation that starts on the
             // very op that just bailed.
             if guarded_branch_exit && !single_iter && chain_budget > 0 && cpu.pc != pc {
-                match self.note_trace_exit(cpu.pc, cpu_type) {
+                // A watched exit target still counts candidacy hits, but
+                // neither chains nor starts a recording: a chained entry
+                // is not observed by the runner (watches fire before an
+                // interpreted instruction), and run_batch may return at
+                // the watch with host-visible state -- no recording may
+                // survive that boundary. The candidate is preserved for a
+                // later unwatched entry.
+                let entry_watched = watch_pcs
+                    .iter()
+                    .any(|&watched| cpu.address(watched) == cpu.address(cpu.pc));
+                match self.note_trace_exit(cpu.pc, cpu_type, entry_watched) {
                     ExitSeed::Chain => {
-                        // The callee excludes its entry pc from its own
-                        // watch check (run_batch semantics: watches fire
-                        // before an interpreted instruction, and the head
-                        // was reached by ordinary execution). A chained
-                        // entry is not observed by the runner, so a watch
-                        // on the chain target must fall back to the
-                        // interpreter instead.
-                        let entry_watched = watch_pcs
-                            .iter()
-                            .any(|&watched| cpu.address(watched) == cpu.address(cpu.pc));
-                        if !entry_watched {
-                            match self.try_execute(
-                                cpu,
-                                bus,
-                                cpu_type,
-                                instr_budget.saturating_sub(retired),
-                                false,
-                                watch_pcs,
-                                chain_budget - 1,
-                            ) {
-                                Some((CachedRunResult::Ran, chained)) => retired += chained,
-                                // The continuation's first opcode changed:
-                                // the child has already consumed it (ppc/ir
-                                // set, pc advanced) and the caller must
-                                // dispatch it. Surface the miss while
-                                // keeping every instruction retired so far.
-                                Some((miss @ CachedRunResult::Miss(_), chained)) => {
-                                    return Some((miss, retired + chained));
-                                }
-                                None => {}
+                        match self.try_execute(
+                            cpu,
+                            bus,
+                            cpu_type,
+                            instr_budget.saturating_sub(retired),
+                            false,
+                            watch_pcs,
+                            chain_budget - 1,
+                        ) {
+                            Some((CachedRunResult::Ran, chained)) => retired += chained,
+                            // The continuation's first opcode changed:
+                            // the child has already consumed it (ppc/ir
+                            // set, pc advanced) and the caller must
+                            // dispatch it. Surface the miss while
+                            // keeping every instruction retired so far.
+                            Some((miss @ CachedRunResult::Miss(_), chained)) => {
+                                return Some((miss, retired + chained));
                             }
+                            None => {}
                         }
                     }
                     ExitSeed::StartRecording => cpu.trace_recording = true,
@@ -1104,14 +1102,25 @@ impl TraceJit {
     /// `record_trace_target`, an exit seed never evicts a compiled trace on
     /// a cache-index collision: backward-branch targets are proven loop
     /// heads, exit targets are speculative.
-    fn note_trace_exit(&mut self, exit_pc: u32, cpu_type: CpuType) -> ExitSeed {
+    fn note_trace_exit(
+        &mut self,
+        exit_pc: u32,
+        cpu_type: CpuType,
+        entry_watched: bool,
+    ) -> ExitSeed {
         let idx = trace_cache_index(exit_pc);
         match &mut self.slots[idx] {
             TraceSlot::Compiled(CompiledTrace {
                 pc: compiled_pc,
                 cpu_type: compiled_type,
                 ..
-            }) if *compiled_pc == exit_pc && *compiled_type == cpu_type => ExitSeed::Chain,
+            }) if *compiled_pc == exit_pc && *compiled_type == cpu_type => {
+                if entry_watched {
+                    ExitSeed::None
+                } else {
+                    ExitSeed::Chain
+                }
+            }
             TraceSlot::Compiled(_) => ExitSeed::None,
             TraceSlot::Counting {
                 pc: counted_pc,
@@ -1120,7 +1129,7 @@ impl TraceJit {
                 adaptive_rerecords,
             } if *counted_pc == exit_pc && *counted_type == cpu_type => {
                 *hits = hits.saturating_add(1);
-                if *hits < TRACE_HOT_THRESHOLD || self.recording.is_some() {
+                if entry_watched || *hits < TRACE_HOT_THRESHOLD || self.recording.is_some() {
                     return ExitSeed::None;
                 }
                 let adaptive_rerecords = *adaptive_rerecords;
@@ -12600,11 +12609,11 @@ mod portable_tests {
         let mut jit = TraceJit::new();
         // First exit seeds a vacant slot; second promotes to recording.
         assert!(matches!(
-            jit.note_trace_exit(0x0100, CpuType::M68040),
+            jit.note_trace_exit(0x0100, CpuType::M68040, false),
             ExitSeed::None
         ));
         assert!(matches!(
-            jit.note_trace_exit(0x0100, CpuType::M68040),
+            jit.note_trace_exit(0x0100, CpuType::M68040, false),
             ExitSeed::StartRecording
         ));
         assert_eq!(
@@ -12615,11 +12624,11 @@ mod portable_tests {
         // While a recording is active, another hot exit defers rather than
         // stealing the recorder.
         assert!(matches!(
-            jit.note_trace_exit(0x0200, CpuType::M68040),
+            jit.note_trace_exit(0x0200, CpuType::M68040, false),
             ExitSeed::None
         ));
         assert!(matches!(
-            jit.note_trace_exit(0x0200, CpuType::M68040),
+            jit.note_trace_exit(0x0200, CpuType::M68040, false),
             ExitSeed::None
         ));
         // A rejected slot blocks re-seeding.
@@ -12629,7 +12638,7 @@ mod portable_tests {
             cpu_type: CpuType::M68040,
         };
         assert!(matches!(
-            jit.note_trace_exit(0x0300, CpuType::M68040),
+            jit.note_trace_exit(0x0300, CpuType::M68040, false),
             ExitSeed::None
         ));
         assert!(matches!(
@@ -12749,5 +12758,76 @@ mod portable_tests {
             !touched,
             "a memory bail must not seed candidacy at its target in any form: {dump}"
         );
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn watched_exit_targets_never_seed_a_recording_across_the_boundary() {
+        // Unit contract: a watched exit target still counts candidacy but
+        // never installs a recording or chains; the candidate promotes on
+        // a later unwatched exit.
+        let mut jit = TraceJit::new();
+        assert!(matches!(
+            jit.note_trace_exit(0x0100, CpuType::M68040, false),
+            ExitSeed::None
+        ));
+        // Hot now -- but watched: no promotion, no recording installed.
+        assert!(matches!(
+            jit.note_trace_exit(0x0100, CpuType::M68040, true),
+            ExitSeed::None
+        ));
+        assert!(
+            jit.recording.is_none(),
+            "a watched exit must not install a recording"
+        );
+        // The same slot promotes on the next unwatched exit: candidacy
+        // (including the watched hit) was preserved.
+        assert!(matches!(
+            jit.note_trace_exit(0x0100, CpuType::M68040, false),
+            ExitSeed::StartRecording
+        ));
+
+        // System invariant (the reviewed leak): a watched run_batch return
+        // never leaves a recording active, no matter where exit seeding
+        // stood when the watch fired. Sweep the mixed-path rig -- whose
+        // head trace guard-exits to the loop body every other iteration --
+        // through compile/seed/promote transitions with the continuation
+        // pcs watched, checking the boundary after every return.
+        const CODE_BASE: u32 = 0x7000;
+        let words = [
+            0x0A01, 0x0001, // EORI.B #1,D1
+            0x6602, // BNE.S +2
+            0x5282, // ADDQ.L #1,D2
+            0x1ADC, // MOVE.B (A4)+,(A5)+
+            0x5283, // ADDQ.L #1,D3
+            0x51C8, 0xFFF2, // DBRA D0,head
+            0x60EE, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(4, 0x3000);
+        cpu.set_a(5, 0x4000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        let watches = [CODE_BASE + 6, CODE_BASE + 8];
+        for _ in 0..200 {
+            cpu.run_batch(&mut bus, 500, &watches);
+            assert!(
+                !cpu.trace_recording,
+                "no recording survives a watched run_batch return"
+            );
+            TRACE_JIT.with_borrow(|jit| {
+                assert!(
+                    jit.recording.is_none(),
+                    "no recorder state survives a watched run_batch return"
+                );
+            });
+        }
     }
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -48,6 +48,20 @@ const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
 /// memory-ALU, and memory-heavy mixes.
 const TRACE_MIN_INDIRECT_JSR_OPS: usize = 7;
 const TRACE_HOT_THRESHOLD: u8 = 2;
+/// How many compiled continuations one guest entry may chain through after
+/// guard exits. Bounds recursion; each level also shrinks the instruction
+/// budget by what the parent retired.
+const TRACE_EXIT_CHAIN_BUDGET: u8 = 3;
+
+/// Outcome of guard-exit candidacy bookkeeping.
+enum ExitSeed {
+    /// A compiled trace exists at the exit target: execute it from here.
+    Chain,
+    /// The exit target just went hot: the interpreter records from the
+    /// next instruction.
+    StartRecording,
+    None,
+}
 const TRACE_ADAPT_WINDOW: u8 = 64;
 const TRACE_ADAPT_MISMATCHES: u8 = 48;
 const TRACE_MAX_ADAPTIVE_RERECORDS: u8 = 1;
@@ -661,6 +675,7 @@ impl TraceJit {
     /// retired instructions, always within the CPU's remaining cycle
     /// budget, and only one iteration when `single_iter` is set (callers
     /// that must observe the PC between iterations, e.g. watchpoints).
+    #[allow(clippy::too_many_arguments)] // one over; a params struct would obscure the recursion
     fn try_execute<B: AddressBus>(
         &mut self,
         cpu: &mut CpuCore,
@@ -669,6 +684,7 @@ impl TraceJit {
         instr_budget: u32,
         single_iter: bool,
         watch_pcs: &[u32],
+        chain_budget: u8,
     ) -> Option<(CachedRunResult, u32)> {
         #[cfg(all(feature = "jit", not(target_family = "wasm")))]
         self.module.as_ref()?;
@@ -957,6 +973,42 @@ impl TraceJit {
                 #[cfg(feature = "trace-profile")]
                 super::trace_profile::note_adaptive_rerecord(pc, cpu_type);
             }
+            // A guard exit landed the interpreter mid-continuation. Treat
+            // the exit target as a trace-head candidate: hot fall-through
+            // continuations then form their own traces, and once compiled
+            // they run directly from here (bounded chaining) instead of
+            // waiting for a backward-branch probe that never comes.
+            if partial_call_this_entry && !single_iter && chain_budget > 0 && cpu.pc != pc {
+                match self.note_trace_exit(cpu.pc, cpu_type) {
+                    ExitSeed::Chain => {
+                        // The callee excludes its entry pc from its own
+                        // watch check (run_batch semantics: watches fire
+                        // before an interpreted instruction, and the head
+                        // was reached by ordinary execution). A chained
+                        // entry is not observed by the runner, so a watch
+                        // on the chain target must fall back to the
+                        // interpreter instead.
+                        let entry_watched = watch_pcs
+                            .iter()
+                            .any(|&watched| cpu.address(watched) == cpu.address(cpu.pc));
+                        if !entry_watched
+                            && let Some((CachedRunResult::Ran, chained)) = self.try_execute(
+                                cpu,
+                                bus,
+                                cpu_type,
+                                instr_budget.saturating_sub(retired),
+                                false,
+                                watch_pcs,
+                                chain_budget - 1,
+                            )
+                        {
+                            retired += chained;
+                        }
+                    }
+                    ExitSeed::StartRecording => cpu.trace_recording = true,
+                    ExitSeed::None => {}
+                }
+            }
             return Some((CachedRunResult::Ran, retired));
         }
 
@@ -1025,6 +1077,56 @@ impl TraceJit {
                     adaptive_rerecords: 0,
                 };
                 TRACE_JIT_HAS_CANDIDATES.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Candidacy bookkeeping for a guard-exit target. Unlike
+    /// `record_trace_target`, an exit seed never evicts a compiled trace on
+    /// a cache-index collision: backward-branch targets are proven loop
+    /// heads, exit targets are speculative.
+    fn note_trace_exit(&mut self, exit_pc: u32, cpu_type: CpuType) -> ExitSeed {
+        let idx = trace_cache_index(exit_pc);
+        match &mut self.slots[idx] {
+            TraceSlot::Compiled(CompiledTrace {
+                pc: compiled_pc,
+                cpu_type: compiled_type,
+                ..
+            }) if *compiled_pc == exit_pc && *compiled_type == cpu_type => ExitSeed::Chain,
+            TraceSlot::Compiled(_) => ExitSeed::None,
+            TraceSlot::Counting {
+                pc: counted_pc,
+                cpu_type: counted_type,
+                hits,
+                adaptive_rerecords,
+            } if *counted_pc == exit_pc && *counted_type == cpu_type => {
+                *hits = hits.saturating_add(1);
+                if *hits < TRACE_HOT_THRESHOLD || self.recording.is_some() {
+                    return ExitSeed::None;
+                }
+                let adaptive_rerecords = *adaptive_rerecords;
+                self.recording = Some(TraceRecording {
+                    start_pc: exit_pc,
+                    cpu_type,
+                    ops: Vec::with_capacity(TRACE_MAX_OPS),
+                    adaptive_rerecords,
+                });
+                #[cfg(feature = "trace-profile")]
+                super::trace_profile::note_recording(exit_pc, cpu_type);
+                ExitSeed::StartRecording
+            }
+            TraceSlot::Rejected {
+                pc: rejected_pc,
+                cpu_type: rejected_type,
+            } if *rejected_pc == exit_pc && *rejected_type == cpu_type => ExitSeed::None,
+            slot => {
+                *slot = TraceSlot::Counting {
+                    pc: exit_pc,
+                    cpu_type,
+                    hits: 1,
+                    adaptive_rerecords: 0,
+                };
+                ExitSeed::None
             }
         }
     }
@@ -1977,7 +2079,15 @@ pub(crate) fn try_execute_trace<B: AddressBus>(
     }
 
     TRACE_JIT.with_borrow_mut(|jit| {
-        jit.try_execute(cpu, bus, cpu_type, instr_budget, single_iter, watch_pcs)
+        jit.try_execute(
+            cpu,
+            bus,
+            cpu_type,
+            instr_budget,
+            single_iter,
+            watch_pcs,
+            TRACE_EXIT_CHAIN_BUDGET,
+        )
     })
 }
 
@@ -12372,156 +12482,117 @@ mod portable_tests {
         assert_eq!(p.a(7), 0x0800);
     }
 
-    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
     #[test]
-    fn blocked_recording_salvages_the_prefix_through_the_last_branch() {
-        // Nine admissible ops (the last a recorded interior branch), then
-        // the A7 LINK/UNLK pair -- refused by documented design, so no
-        // future coverage can admit this blocker -- then a loop tail. Without
-        // salvage the whole head rejects; with it the prefix through the
-        // branch compiles and the tail stays interpreted.
-        const A: u32 = 0x0100;
-        let words = [
-            0x5282, // head: ADDQ.L #1,D2
-            0x5283, // ADDQ.L #1,D3
-            0x5284, // ADDQ.L #1,D4
-            0x5285, // ADDQ.L #1,D5
-            0x5286, // ADDQ.L #1,D6
-            0x5287, // ADDQ.L #1,D7
-            0x5281, // ADDQ.L #1,D1
-            0x4A41, // TST.W D1
-            0x6602, // BNE.S +2 (always taken: D1 counts up)
-            0x4E71, // NOP (skipped)
-            0x4A42, // TST.W D2 -- past the branch: no terminal to stop at
-            0x4A42, // TST.W D2
-            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
-            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
-            0x51C8, 0xFFE0, // DBRA D0,head
-            0x707F, // MOVEQ #127,D0
-            0x60DA, // BRA.S head
-        ];
-        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
-        for (index, word) in words.iter().enumerate() {
-            bus.write_word_at(A + index as u32 * 2, *word);
-        }
-        let mut cpu = CpuCore::new();
-        cpu.set_cpu_type(CpuType::M68040);
-        cpu.set_sr(0x2700);
-        cpu.pc = A;
-        cpu.set_a(6, 0x3000);
-        cpu.set_a(7, 0x9000);
-        cpu.set_d(0, 0x7F);
-        let result = cpu.run_batch(&mut bus, 40_000, &[0]);
-        assert_eq!(result.instructions, 40_000, "loop runs to budget");
-        // Every iteration bumps D2..D7 and D1 exactly once each.
-        assert!(cpu.d(2) > 2_000, "the loop actually iterated");
-        assert!(
-            cpu.d(2).abs_diff(cpu.d(3)) <= 1 && cpu.d(2).abs_diff(cpu.d(7)) <= 1,
-            "counters advance in lockstep"
+    fn exit_seeding_counts_promotes_and_respects_slot_owners() {
+        let mut jit = TraceJit::new();
+        // First exit seeds a vacant slot; second promotes to recording.
+        assert!(matches!(
+            jit.note_trace_exit(0x0100, CpuType::M68040),
+            ExitSeed::None
+        ));
+        assert!(matches!(
+            jit.note_trace_exit(0x0100, CpuType::M68040),
+            ExitSeed::StartRecording
+        ));
+        assert_eq!(
+            jit.recording.as_ref().map(|r| r.start_pc),
+            Some(0x0100),
+            "recording starts at the exit target"
         );
-        let salvaged = TRACE_JIT.with_borrow(|jit| match &jit.slots[trace_cache_index(A)] {
-            TraceSlot::Compiled(trace) if trace.pc == A => Some((
-                trace.ops.len(),
-                matches!(
-                    trace.ops.last().map(|op| op.op),
-                    Some(JitTraceOp::Branch { .. })
-                ),
-                trace
-                    .ops
-                    .iter()
-                    .all(|op| op.opcode != 0x4E57 && op.opcode != 0x4E5F),
-            )),
-            _ => None,
-        });
-        let (ops, ends_in_branch, excludes_blocked_tail) =
-            salvaged.expect("the blocked head compiles its salvageable prefix");
-        assert_eq!(ops, 9, "trimmed at the recorded branch");
-        assert!(ends_in_branch, "the trimmed terminal is the branch");
-        assert!(
-            excludes_blocked_tail,
-            "the unsupported tail is not recorded"
-        );
+        // While a recording is active, another hot exit defers rather than
+        // stealing the recorder.
+        assert!(matches!(
+            jit.note_trace_exit(0x0200, CpuType::M68040),
+            ExitSeed::None
+        ));
+        assert!(matches!(
+            jit.note_trace_exit(0x0200, CpuType::M68040),
+            ExitSeed::None
+        ));
+        // A rejected slot blocks re-seeding.
+        let idx = trace_cache_index(0x0300);
+        jit.slots[idx] = TraceSlot::Rejected {
+            pc: 0x0300,
+            cpu_type: CpuType::M68040,
+        };
+        assert!(matches!(
+            jit.note_trace_exit(0x0300, CpuType::M68040),
+            ExitSeed::None
+        ));
+        assert!(matches!(
+            &jit.slots[idx],
+            TraceSlot::Rejected { pc: 0x0300, .. }
+        ));
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
     #[test]
-    fn short_blocked_recordings_still_reject() {
-        // A five-op prefix whose last terminal sits at op four: below
-        // SALVAGE_MIN_OPS the head must reject exactly as before. (The
-        // blocker must not directly follow the branch: a recording whose
-        // last op is already a terminal compiles today without salvage.)
-        const A: u32 = 0x0100;
+    fn guard_exits_seed_and_chain_a_continuation_trace() {
+        // Mixed-path loop: EORI.B #1,D1 flips Z every iteration, so the
+        // head trace guard-exits on ~half of all calls forever -- the shape
+        // adaptive re-recording cannot settle. Exit seeding must form a
+        // second compiled trace inside the loop body.
+        const CODE_BASE: u32 = 0x7000;
         let words = [
-            0x5282, // head: ADDQ.L #1,D2
-            0x5283, // ADDQ.L #1,D3
-            0x4A42, // TST.W D2
-            0x6602, // BNE.S +2 (always taken)
-            0x4E71, // NOP (skipped)
-            0x5284, // ADDQ.L #1,D4
-            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
-            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
-            0x51C8, 0xFFEC, // DBRA D0,head
-            0x707F, // MOVEQ #127,D0
-            0x60E6, // BRA.S head
+            0x0A01, 0x0001, // EORI.B #1,D1
+            0x6602, // BNE.S +2
+            0x5282, // ADDQ.L #1,D2
+            0x1ADC, // MOVE.B (A4)+,(A5)+
+            0x5283, // ADDQ.L #1,D3 (keeps both continuations >= 3 ops)
+            0x51C8, 0xFFF2, // DBRA D0,head
+            0x60EE, // BRA.S head (outer restart to keep it hot)
         ];
         let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
         for (index, word) in words.iter().enumerate() {
-            bus.write_word_at(A + index as u32 * 2, *word);
+            bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
         }
         let mut cpu = CpuCore::new();
         cpu.set_cpu_type(CpuType::M68040);
         cpu.set_sr(0x2700);
-        cpu.pc = A;
-        cpu.set_a(6, 0x3000);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(4, 0x3000);
+        cpu.set_a(5, 0x4000);
         cpu.set_a(7, 0x9000);
         cpu.set_d(0, 0x7F);
-        cpu.run_batch(&mut bus, 40_000, &[0]);
-        TRACE_JIT.with_borrow(|jit| {
-            assert!(
-                matches!(
-                    &jit.slots[trace_cache_index(A)],
-                    TraceSlot::Rejected { pc, .. } if *pc == A
-                ),
-                "a four-op prefix is below the salvage bar"
-            );
-        });
-    }
+        let result = cpu.run_batch(&mut bus, 50_000, &[0]);
+        assert_eq!(result.instructions, 50_000, "loop runs to budget");
 
-    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
-    #[test]
-    fn blocked_recording_without_a_branch_still_rejects() {
-        // A straight-line prefix has no terminal to trim to; the head
-        // must reject exactly as before regardless of length.
-        const A: u32 = 0x0100;
-        let words = [
-            0x5282, 0x5283, 0x5284, 0x5285, 0x5286, 0x5287, 0x5281, 0x5280,
-            0x4A41, // nine straight-line ops, no branch
-            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
-            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
-            0x51C8, 0xFFE6, // DBRA D0,head
-            0x707F, // MOVEQ #127,D0
-            0x60E0, // BRA.S head
-        ];
-        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
-        for (index, word) in words.iter().enumerate() {
-            bus.write_word_at(A + index as u32 * 2, *word);
-        }
-        let mut cpu = CpuCore::new();
-        cpu.set_cpu_type(CpuType::M68040);
-        cpu.set_sr(0x2700);
-        cpu.pc = A;
-        cpu.set_a(6, 0x3000);
-        cpu.set_a(7, 0x9000);
-        cpu.set_d(0, 0x7F);
-        cpu.run_batch(&mut bus, 40_000, &[0]);
-        TRACE_JIT.with_borrow(|jit| {
-            assert!(
-                matches!(
-                    &jit.slots[trace_cache_index(A)],
-                    TraceSlot::Rejected { pc, .. } if *pc == A
-                ),
-                "no recorded branch means nothing to salvage"
-            );
+        let loop_pcs: Vec<u32> = (0..8).map(|w| CODE_BASE + w * 2).collect();
+        let compiled = TRACE_JIT.with_borrow(|jit| {
+            loop_pcs
+                .iter()
+                .filter(|&&pc| {
+                    matches!(
+                        &jit.slots[trace_cache_index(pc)],
+                        TraceSlot::Compiled(CompiledTrace { pc: cpc, .. }) if *cpc == pc
+                    )
+                })
+                .count()
         });
+        let dump = TRACE_JIT.with_borrow(|jit| {
+            loop_pcs
+                .iter()
+                .map(|&pc| {
+                    let slot = &jit.slots[trace_cache_index(pc)];
+                    let desc = match slot {
+                        TraceSlot::Compiled(CompiledTrace { pc: c, ops, .. }) if *c == pc => {
+                            format!("Compiled({} ops)", ops.len())
+                        }
+                        TraceSlot::Counting { pc: c, hits, .. } if *c == pc => {
+                            format!("Counting(hits={hits})")
+                        }
+                        TraceSlot::Rejected { pc: c, .. } if *c == pc => "Rejected".into(),
+                        _ => "-".into(),
+                    };
+                    format!("{pc:05X}:{desc}")
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        });
+        assert!(
+            compiled >= 2,
+            "exit seeding should compile a continuation inside the loop \
+             body in addition to the head trace (found {compiled}): {dump}"
+        );
     }
 }

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1223,6 +1223,32 @@ fn mem_trace_memcpy_loop_matches_step() {
     });
 }
 
+/// A mixed-path loop: the comparison alternates every iteration, so the
+/// conditional branch never settles and whichever path the head trace
+/// records, it guard-exits on ~half of all calls forever -- the shape
+/// adaptive re-recording cannot fix. Exit-seeded candidacy forms a second
+/// trace at the exit target and chains into it; everything must still
+/// match step() exactly through recording, promotion, and chaining.
+#[test]
+fn mixed_path_loop_with_exit_seeded_continuation_matches_step() {
+    let words = &[
+        0x0A01, 0x0001, // $1000: EORI.B #1,D1   (Z flips every iteration)
+        0x6602, // $1004: BNE.S $1008
+        0x5282, // $1006: ADDQ.L #1,D2
+        0x1ADC, // $1008: MOVE.B (A4)+,(A5)+
+        0x5283, // $100A: ADDQ.L #1,D3 (keeps both continuations >= 3 ops)
+        0x51C8, 0xFFF2, // $100C: DBRA D0,$1000
+        0xA000, // $1010: sentinel
+    ];
+    assert_fastmem_matches_step("mixed-path exit seed", words, CpuType::M68040, |cpu| {
+        cpu.set_a(4, 0x3000);
+        cpu.set_a(5, 0x4000);
+        cpu.set_d(0, 255);
+        cpu.set_d(1, 0);
+        cpu.set_d(2, 0);
+    });
+}
+
 /// A memory operation followed immediately by DBRA is a common 68k copy-loop
 /// shape. It must remain exact when admitted as the minimum two-op self-loop.
 #[test]

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1249,6 +1249,41 @@ fn mixed_path_loop_with_exit_seeded_continuation_matches_step() {
     });
 }
 
+/// Self-modifying code aimed at a chained continuation: the outer section
+/// rewrites the continuation's first opcode every round (EORI toggles
+/// ADDQ.L #1,D2 and ADDQ.L #2,D2), so the parent trace side-exits into a
+/// compiled continuation whose first opcode changed. The chain must
+/// surface that miss so the rewritten opcode is dispatched -- silently
+/// dropping it would skip the instruction and diverge D2 from step().
+#[test]
+fn rewritten_continuation_head_after_side_exit_matches_step() {
+    let words = &[
+        0x0A01, 0x0001, // $1000: EORI.B #1,D1  (Z flips every iteration)
+        0x6602, // $1004: BNE.S $1008
+        0x5282, // $1006: ADDQ.L #1,D2   <- rewritten between rounds
+        0x1ADC, // $1008: MOVE.B (A4)+,(A5)+
+        0x5283, // $100A: ADDQ.L #1,D3
+        0x51C8, 0xFFF2, // $100C: DBRA D0,$1000
+        0x0A78, 0x0600, 0x1006, // $1010: EORI.W #$0600,($1006).W
+        0x707F, // $1016: MOVEQ #127,D0
+        0x5347, // $1018: SUBQ.W #1,D7
+        0x66E4, // $101A: BNE.S $1000
+        0xA000, // $101C: sentinel
+    ];
+    assert_fastmem_matches_step(
+        "rewritten continuation head",
+        words,
+        CpuType::M68040,
+        |cpu| {
+            cpu.set_a(4, 0x3000);
+            cpu.set_a(5, 0x4000);
+            cpu.set_d(0, 127);
+            cpu.set_d(1, 0);
+            cpu.set_d(7, 6);
+        },
+    );
+}
+
 /// A memory operation followed immediately by DBRA is a common 68k copy-loop
 /// shape. It must remain exact when admitted as the minimum two-op self-loop.
 #[test]


### PR DESCRIPTION
Implements the second proposal of #100 (exit-seeded candidacy); the
other two remain open design questions there.

## Summary

Traces only ever start at backward-branch targets, so a loop whose
conditional branch never settles leaves its off-spine path interpreted
forever: the head trace guard-exits on a fixed fraction of calls, the
adaptive re-record ratio never trips, and the continuation between the
exit and the loop latch is invisible to candidacy — it is neither a
rejected hit nor a blocker, so it doesn't even appear in the
opportunity ranking.

This PR makes guard exits themselves the discovery signal:

- **Seed**: a guard exit counts the exit target as a trace-head
  candidate (same hot threshold as backward targets). Unlike
  backward-target candidacy, an exit seed never evicts a compiled trace
  on a cache-index collision — backward targets are proven loop heads,
  exit targets are speculative.
- **Record**: when the exit target goes hot, the interpreter records
  the continuation from there; the existing close conditions already
  handle a mid-loop head (flow re-reaching the start pc from any
  direction, or the DBcc region boundary).
- **Chain**: once compiled, the parent executes the continuation
  directly from its exit, bounded by a chain budget
  (`TRACE_EXIT_CHAIN_BUDGET = 3`) and by the caller's instruction
  budget, which shrinks by what the parent retired.

## Why (measured motivation)

In the 2026-08-09 capped gameplay session (2.53B guest instructions),
pre-existing compiled traces exit through guards on up to 97.5% of
calls (`00EF8D92`: 122,966 exits / 126,111 calls) with adaptive
re-recording exhausted, while every recently admitted store-family
trace runs at zero exits — the thrash is a property of formation, not
of trace execution. The volume those exits strand is invisible to the
opcode-opportunity ranking, which is exactly why no admission has ever
recovered it.

## The chaining cost, stated plainly

A parent→continuation transition is not seamless native-to-native: the
parent's exit returns to the Rust driver, which performs slot lookup,
budget checks, and the child's own entry validation before the second
native call — the same per-entry boundary every trace already pays,
once per exit, amortized by the continuation's ops-per-call. Direct
side-exit linking (patching the parent's exit stub to jump straight
into the child) would remove that boundary and is left as explicit
future work; this PR is deliberately policy-only.

## Focused benchmark

`benches/microbench.rs mixed-path`: a loop whose branch alternates
every iteration (`EORI #1` flips Z), so the head trace guard-exits on
half of all calls forever — below the adaptive re-record ratio, above
any useful coverage — with a field-shaped 14-op continuation between
the join and the DBRA. Seven alternating runs of the **review-fixed**
code against current master carrying an identical copy: per-pair
ratios 1.78–1.97, **median 1.86×** (median 107.5 → 194.7 M instr/s).

One negative result kept in the record: with a 3-op continuation the
same A/B is flat (ratios scattered around 1.0×) — the chain boundary
costs about what interpreting three cheap ops costs, consistent with
the 2026-08-03 hot-leaf finding. The mechanism pays in proportion to
continuation length, which is what the stranded field continuations
have and short ones don't; direct side-exit linking would recover the
short-continuation case and is left as future work.

## Whole-application acceptance

- **Headless** (deterministic A/B of the review-fixed code vs current
  master with #95/#96/#97 merged, 900M instructions): `native_calls`
  65,322 → **59,141 (−6,181)** while `jit_retired` rose 15,986,450 →
  **16,050,628 (+64,178)** and ops-per-native-call rose 244.7 → 271.4 —
  chaining consolidates boundary crossings (continuations execute
  inside chained entries instead of separate probes) while retiring
  more. Rejected hits flat. An earlier headless figure measured the
  pre-fix gate and is superseded by this one.
- **Capped gameplay session: PENDING** — the motivating traces
  (guard exits on up to 97.5% of calls) are gameplay-side; the session
  verdict is guard-exit ratios dropping on those existing traces plus
  new compiled heads at mid-loop pcs, observables disjoint from the
  store-admission PRs riding the same session.

## Review fixes (both findings were real)

- **Chained miss surfaced**: a continuation whose first opcode changed
  returned `Miss` with the opcode already consumed; the parent dropped
  it, skipping a guest instruction. The parent now propagates the miss
  with every instruction retired so far, and `run_batch`'s miss arm
  accounts those before dispatching the missed opcode. Regression: a
  three-phase step()-twin (head compiled on the taken spine, predicate
  flipped externally so the continuation forms and chains under the
  adaptive window, continuation head rewritten in both twins) — the
  chain miss fires exactly once, and dropping it diverges D2 by the
  skipped ADDQ.
- **Seeding gated on guarded branch exits**, not any partial call:
  memory bails (window/alignment/SMC) no longer create candidacy at
  an access the trace cannot execute. Negative regression: a loop
  whose store idempotently hits its own code memory-bails every call,
  and the bail target's slot must stay completely untouched — counting,
  compiled, **or rejected** all fail the assert (under the old gate the
  seed left a `Rejected` slot after a wasted record, which a weaker
  assertion misses).

## Correctness

- The mixed-path integration test drives the full pipeline — seed,
  record, compile, chain — through `run_batch` and must match `step()`
  exactly (registers, SR, PC, memory, instruction counts).
- The behavior test asserts a second compiled trace forms inside the
  loop body; setting the chain budget to zero fails it (mutation-
  tested), so the test detects the mechanism, not just exactness.
- The unit test pins the slot rules: promotion at the threshold,
  deferral while another recording is active, rejected slots blocking
  re-seeds, and no eviction of compiled traces by speculative seeds.
- **Watch semantics preserved**: seeding is bookkeeping and always
  safe; a chained entry is not observed by the runner, so chaining
  falls back to the interpreter whenever the chain target is watched.
- Recursion is doubly bounded (chain budget and strictly shrinking
  instruction budget); `single_iter` callers never chain.

## Validation

- 192 lib tests (all-features), the full `run_batch` integration
  suite, clippy clean, wasm32 check green, `cargo fmt` clean.



