### PR TITLE
perf: salvage a blocked recording's prefix through its last branch

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1051,7 +1051,8 @@ fn bench_salvaged_prefix_loop() {
         0x4E71, // NOP (skipped)
         0x4A42, // TST.W D2 -- past the branch: master has no terminal here
         0x4A42, // TST.W D2
-        0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0 -- the blocker
+        0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
+        0x4E5F, // UNLK A7
         0x51C8, 0xFFD2, // DBRA D0,head
         0x707F, // MOVEQ #127,D0
         0x60CC, // BRA.S head

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1028,9 +1028,10 @@ fn bench_link_unlk_frame_loop() {
 /// ROM regions the gameplay profile shows dying 14-26 ops deep. Base
 /// rejects the whole head and interprets; with salvage the twelve-op
 /// prefix through the branch compiles and only the tail stays
-/// interpreted. (A register-only nine-op variant measures ~1.0x -- the
-/// per-iteration trace entry/exit cost cancels the win on cheap ops; the
-/// salvage bar exists for exactly that reason.)
+/// interpreted. Two register tests sit between the branch and the
+/// blocker so the recording's last op is not a terminal: without salvage
+/// the whole head rejects. (A register-only nine-op variant measures
+/// ~1.0x -- trace entry/exit cost cancels the win on cheap ops.)
 fn bench_salvaged_prefix_loop() {
     const INSTRS: u32 = 100_000_000;
     const CODE_BASE: u32 = 0x6000;
@@ -1048,10 +1049,12 @@ fn bench_salvaged_prefix_loop() {
         0x4A41, // TST.W D1
         0x6602, // BNE.S +2 (taken until D1 wraps 16 bits)
         0x4E71, // NOP (skipped)
+        0x4A42, // TST.W D2 -- past the branch: master has no terminal here
+        0x4A42, // TST.W D2
         0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0 -- the blocker
-        0x51C8, 0xFFD6, // DBRA D0,head
+        0x51C8, 0xFFD2, // DBRA D0,head
         0x707F, // MOVEQ #127,D0
-        0x60D0, // BRA.S head
+        0x60CC, // BRA.S head
     ];
     let mut bus = LinearMemoryBus::new(0x1_0000);
     for (index, word) in words.iter().enumerate() {

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1023,6 +1023,73 @@ fn bench_link_unlk_frame_loop() {
     );
 }
 
+/// The field shape salvage targets: a store-heavy body with one interior
+/// branch, then an instruction the decoder refuses (LEA (abs).L) -- the
+/// ROM regions the gameplay profile shows dying 14-26 ops deep. Base
+/// rejects the whole head and interprets; with salvage the twelve-op
+/// prefix through the branch compiles and only the tail stays
+/// interpreted. (A register-only nine-op variant measures ~1.0x -- the
+/// per-iteration trace entry/exit cost cancels the win on cheap ops; the
+/// salvage bar exists for exactly that reason.)
+fn bench_salvaged_prefix_loop() {
+    const INSTRS: u32 = 100_000_000;
+    const CODE_BASE: u32 = 0x6000;
+    let words = [
+        0x3083, // head: MOVE.W D3,(A0)
+        0x5283, // ADDQ.L #1,D3
+        0x3143, 0x0002, // MOVE.W D3,2(A0)
+        0x5284, // ADDQ.L #1,D4
+        0x3144, 0x0004, // MOVE.W D4,4(A0)
+        0x5285, // ADDQ.L #1,D5
+        0x3145, 0x0006, // MOVE.W D5,6(A0)
+        0x5286, // ADDQ.L #1,D6
+        0x3146, 0x0008, // MOVE.W D6,8(A0)
+        0x5281, // ADDQ.L #1,D1
+        0x4A41, // TST.W D1
+        0x6602, // BNE.S +2 (taken until D1 wraps 16 bits)
+        0x4E71, // NOP (skipped)
+        0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0 -- the blocker
+        0x51C8, 0xFFD6, // DBRA D0,head
+        0x707F, // MOVEQ #127,D0
+        0x60D0, // BRA.S head
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(0, 0x4000);
+        cpu.set_a(7, 0x8000);
+        cpu.set_d(0, 0x7F);
+        cpu
+    };
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert!(cpu.d(3) > 5_000, "the loop actually iterated");
+    // After iteration one the interpreted LEA holds A0 at $3000, so the
+    // steady-state head store lands there.
+    assert!(
+        (cpu.d(3) & 0xFFFF).abs_diff(u32::from(bus.read_word(0x3000))) <= 1
+            || (cpu.d(3) & 0xFFFF).abs_diff(u32::from(bus.read_word(0x3000))) >= 0xFFFF,
+        "the head store lands every iteration"
+    );
+    println!(
+        "batch     salvaged prefix loop    {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 /// Reproduce a path-biased trace that is first recorded through an uncommon
 /// conditional edge before settling into a copy loop on the opposite edge.
 /// A first-path-only
@@ -1638,6 +1705,10 @@ fn main() {
     }
     if only.as_deref() == Some("link-unlk") {
         bench_link_unlk_frame_loop();
+        return;
+    }
+    if only.as_deref() == Some("salvage-prefix") {
+        bench_salvaged_prefix_loop();
         return;
     }
     if only.as_deref() == Some("clr-predec") {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -34,6 +34,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const TRACE_CACHE_SIZE: usize = 4096;
 pub(crate) const TRACE_MAX_OPS: usize = 128;
 pub(crate) const TRACE_MIN_OPS: usize = 3;
+
+/// Minimum recorded ops for a blocked recording to be worth salvaging as
+/// a trimmed region. Higher than `TRACE_MIN_OPS`: a salvaged trace exits
+/// to the interpreter at its trimmed terminal every pass, so short
+/// fragments would pay entry/exit costs without covering enough work.
+const SALVAGE_MIN_OPS: usize = 8;
 const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
 /// Indirect calls pay trace validation plus a native/Rust boundary on every
 /// visit. In same-binary paired 100-million-instruction runs, six-op register
@@ -1081,12 +1087,30 @@ impl TraceJit {
     }
 
     #[cfg_attr(not(feature = "trace-profile"), allow(unused_variables))]
-    fn finish_recording(&mut self, cpu: &mut CpuCore, exit_pc: u32, end: RecordingEnd) {
+    fn finish_recording(&mut self, cpu: &mut CpuCore, mut exit_pc: u32, end: RecordingEnd) {
         let Some(mut recording) = self.recording.take() else {
             cpu.trace_recording = false;
             return;
         };
         cpu.trace_recording = false;
+
+        // A recording stopped by an instruction the decoder refuses ends
+        // without a trace terminal, so compilation would reject the whole
+        // region. If the prefix already crossed a recorded branch, trim
+        // back to the last one and compile that instead: partial coverage
+        // of a long region beats none, and the guest re-enters full
+        // dispatch exactly where the trimmed tail began (the recorded op
+        // after the terminal names the true continuation, whichever way
+        // the branch went). Ops are execution-ordered, so the trimmed
+        // trace revalidates and runs exactly what the guest executed.
+        if end == RecordingEnd::Blocker
+            && !recording.ops.last().is_some_and(|op| op.op.ends_trace())
+            && let Some(last_terminal) = recording.ops.iter().rposition(|op| op.op.ends_trace())
+            && last_terminal + 1 >= SALVAGE_MIN_OPS
+        {
+            exit_pc = recording.ops[last_terminal + 1].pc;
+            recording.ops.truncate(last_terminal + 1);
+        }
 
         // An interior recorded branch becomes the region's ordinary final
         // branch when recording stops at its destination.
@@ -12346,5 +12370,155 @@ mod portable_tests {
         );
         assert_eq!(p.a(6), 0x0301);
         assert_eq!(p.a(7), 0x0800);
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn blocked_recording_salvages_the_prefix_through_the_last_branch() {
+        // Nine admissible ops (the last a recorded interior branch), then
+        // LINK -- which this decoder refuses -- then a loop tail. Without
+        // salvage the whole head rejects; with it the prefix through the
+        // branch compiles and the tail stays interpreted.
+        const A: u32 = 0x0100;
+        let words = [
+            0x5282, // head: ADDQ.L #1,D2
+            0x5283, // ADDQ.L #1,D3
+            0x5284, // ADDQ.L #1,D4
+            0x5285, // ADDQ.L #1,D5
+            0x5286, // ADDQ.L #1,D6
+            0x5287, // ADDQ.L #1,D7
+            0x5281, // ADDQ.L #1,D1
+            0x4A41, // TST.W D1
+            0x6602, // BNE.S +2 (always taken: D1 counts up)
+            0x4E71, // NOP (skipped)
+            0x4E56, 0x0000, // LINK A6,#0  -- the blocker
+            0x4E5E, // UNLK A6
+            0x51C8, 0xFFE4, // DBRA D0,head
+            0x707F, // MOVEQ #127,D0
+            0x60DE, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(A + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = A;
+        cpu.set_a(6, 0x3000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        let result = cpu.run_batch(&mut bus, 40_000, &[0]);
+        assert_eq!(result.instructions, 40_000, "loop runs to budget");
+        // Every iteration bumps D2..D7 and D1 exactly once each.
+        assert!(cpu.d(2) > 2_000, "the loop actually iterated");
+        assert!(
+            cpu.d(2).abs_diff(cpu.d(3)) <= 1 && cpu.d(2).abs_diff(cpu.d(7)) <= 1,
+            "counters advance in lockstep"
+        );
+        let salvaged = TRACE_JIT.with_borrow(|jit| match &jit.slots[trace_cache_index(A)] {
+            TraceSlot::Compiled(trace) if trace.pc == A => Some((
+                trace.ops.len(),
+                matches!(
+                    trace.ops.last().map(|op| op.op),
+                    Some(JitTraceOp::Branch { .. })
+                ),
+                trace
+                    .ops
+                    .iter()
+                    .all(|op| op.opcode != 0x4E56 && op.opcode != 0x4E5E),
+            )),
+            _ => None,
+        });
+        let (ops, ends_in_branch, excludes_blocked_tail) =
+            salvaged.expect("the blocked head compiles its salvageable prefix");
+        assert_eq!(ops, 9, "trimmed at the recorded branch");
+        assert!(ends_in_branch, "the trimmed terminal is the branch");
+        assert!(
+            excludes_blocked_tail,
+            "the unsupported tail is not recorded"
+        );
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn short_blocked_recordings_still_reject() {
+        // A five-op prefix whose last terminal sits at op four: below
+        // SALVAGE_MIN_OPS the head must reject exactly as before. (The
+        // blocker must not directly follow the branch: a recording whose
+        // last op is already a terminal compiles today without salvage.)
+        const A: u32 = 0x0100;
+        let words = [
+            0x5282, // head: ADDQ.L #1,D2
+            0x5283, // ADDQ.L #1,D3
+            0x4A42, // TST.W D2
+            0x6602, // BNE.S +2 (always taken)
+            0x4E71, // NOP (skipped)
+            0x5284, // ADDQ.L #1,D4
+            0x4E56, 0x0000, // LINK A6,#0  -- the blocker
+            0x4E5E, // UNLK A6
+            0x51C8, 0xFFEC, // DBRA D0,head
+            0x707F, // MOVEQ #127,D0
+            0x60E6, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(A + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = A;
+        cpu.set_a(6, 0x3000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        cpu.run_batch(&mut bus, 40_000, &[0]);
+        TRACE_JIT.with_borrow(|jit| {
+            assert!(
+                matches!(
+                    &jit.slots[trace_cache_index(A)],
+                    TraceSlot::Rejected { pc, .. } if *pc == A
+                ),
+                "a four-op prefix is below the salvage bar"
+            );
+        });
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn blocked_recording_without_a_branch_still_rejects() {
+        // A straight-line prefix has no terminal to trim to; the head
+        // must reject exactly as before regardless of length.
+        const A: u32 = 0x0100;
+        let words = [
+            0x5282, 0x5283, 0x5284, 0x5285, 0x5286, 0x5287, 0x5281, 0x5280,
+            0x4A41, // nine straight-line ops, no branch
+            0x4E56, 0x0000, // LINK A6,#0  -- the blocker
+            0x4E5E, // UNLK A6
+            0x51C8, 0xFFE6, // DBRA D0,head
+            0x707F, // MOVEQ #127,D0
+            0x60E0, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(A + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = A;
+        cpu.set_a(6, 0x3000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        cpu.run_batch(&mut bus, 40_000, &[0]);
+        TRACE_JIT.with_borrow(|jit| {
+            assert!(
+                matches!(
+                    &jit.slots[trace_cache_index(A)],
+                    TraceSlot::Rejected { pc, .. } if *pc == A
+                ),
+                "no recorded branch means nothing to salvage"
+            );
+        });
     }
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -12391,11 +12391,13 @@ mod portable_tests {
             0x4A41, // TST.W D1
             0x6602, // BNE.S +2 (always taken: D1 counts up)
             0x4E71, // NOP (skipped)
+            0x4A42, // TST.W D2 -- past the branch: no terminal to stop at
+            0x4A42, // TST.W D2
             0x4E56, 0x0000, // LINK A6,#0  -- the blocker
             0x4E5E, // UNLK A6
-            0x51C8, 0xFFE4, // DBRA D0,head
+            0x51C8, 0xFFE0, // DBRA D0,head
             0x707F, // MOVEQ #127,D0
-            0x60DE, // BRA.S head
+            0x60DA, // BRA.S head
         ];
         let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
         for (index, word) in words.iter().enumerate() {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -12376,7 +12376,7 @@ mod portable_tests {
     #[test]
     fn blocked_recording_salvages_the_prefix_through_the_last_branch() {
         // Nine admissible ops (the last a recorded interior branch), then
-        // LINK -- which this decoder refuses -- then a loop tail. Without
+        // LEA (abs).L -- which this decoder refuses -- then a loop tail. Without
         // salvage the whole head rejects; with it the prefix through the
         // branch compiles and the tail stays interpreted.
         const A: u32 = 0x0100;
@@ -12393,8 +12393,7 @@ mod portable_tests {
             0x4E71, // NOP (skipped)
             0x4A42, // TST.W D2 -- past the branch: no terminal to stop at
             0x4A42, // TST.W D2
-            0x4E56, 0x0000, // LINK A6,#0  -- the blocker
-            0x4E5E, // UNLK A6
+            0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0  -- the blocker
             0x51C8, 0xFFE0, // DBRA D0,head
             0x707F, // MOVEQ #127,D0
             0x60DA, // BRA.S head
@@ -12425,10 +12424,7 @@ mod portable_tests {
                     trace.ops.last().map(|op| op.op),
                     Some(JitTraceOp::Branch { .. })
                 ),
-                trace
-                    .ops
-                    .iter()
-                    .all(|op| op.opcode != 0x4E56 && op.opcode != 0x4E5E),
+                trace.ops.iter().all(|op| op.opcode != 0x41F9),
             )),
             _ => None,
         });
@@ -12457,8 +12453,7 @@ mod portable_tests {
             0x6602, // BNE.S +2 (always taken)
             0x4E71, // NOP (skipped)
             0x5284, // ADDQ.L #1,D4
-            0x4E56, 0x0000, // LINK A6,#0  -- the blocker
-            0x4E5E, // UNLK A6
+            0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0  -- the blocker
             0x51C8, 0xFFEC, // DBRA D0,head
             0x707F, // MOVEQ #127,D0
             0x60E6, // BRA.S head
@@ -12495,8 +12490,7 @@ mod portable_tests {
         let words = [
             0x5282, 0x5283, 0x5284, 0x5285, 0x5286, 0x5287, 0x5281, 0x5280,
             0x4A41, // nine straight-line ops, no branch
-            0x4E56, 0x0000, // LINK A6,#0  -- the blocker
-            0x4E5E, // UNLK A6
+            0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0  -- the blocker
             0x51C8, 0xFFE6, // DBRA D0,head
             0x707F, // MOVEQ #127,D0
             0x60E0, // BRA.S head

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -12376,7 +12376,8 @@ mod portable_tests {
     #[test]
     fn blocked_recording_salvages_the_prefix_through_the_last_branch() {
         // Nine admissible ops (the last a recorded interior branch), then
-        // LEA (abs).L -- which this decoder refuses -- then a loop tail. Without
+        // the A7 LINK/UNLK pair -- refused by documented design, so no
+        // future coverage can admit this blocker -- then a loop tail. Without
         // salvage the whole head rejects; with it the prefix through the
         // branch compiles and the tail stays interpreted.
         const A: u32 = 0x0100;
@@ -12393,7 +12394,8 @@ mod portable_tests {
             0x4E71, // NOP (skipped)
             0x4A42, // TST.W D2 -- past the branch: no terminal to stop at
             0x4A42, // TST.W D2
-            0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0  -- the blocker
+            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
+            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
             0x51C8, 0xFFE0, // DBRA D0,head
             0x707F, // MOVEQ #127,D0
             0x60DA, // BRA.S head
@@ -12424,7 +12426,10 @@ mod portable_tests {
                     trace.ops.last().map(|op| op.op),
                     Some(JitTraceOp::Branch { .. })
                 ),
-                trace.ops.iter().all(|op| op.opcode != 0x41F9),
+                trace
+                    .ops
+                    .iter()
+                    .all(|op| op.opcode != 0x4E57 && op.opcode != 0x4E5F),
             )),
             _ => None,
         });
@@ -12453,7 +12458,8 @@ mod portable_tests {
             0x6602, // BNE.S +2 (always taken)
             0x4E71, // NOP (skipped)
             0x5284, // ADDQ.L #1,D4
-            0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0  -- the blocker
+            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
+            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
             0x51C8, 0xFFEC, // DBRA D0,head
             0x707F, // MOVEQ #127,D0
             0x60E6, // BRA.S head
@@ -12490,7 +12496,8 @@ mod portable_tests {
         let words = [
             0x5282, 0x5283, 0x5284, 0x5285, 0x5286, 0x5287, 0x5281, 0x5280,
             0x4A41, // nine straight-line ops, no branch
-            0x41F9, 0x0000, 0x3000, // LEA $3000.L,A0  -- the blocker
+            0x4E57, 0x0000, // LINK A7,#0 -- refused by design (A7 exclusion)
+            0x4E5F, // UNLK A7 -- likewise; the pair nets zero stack motion
             0x51C8, 0xFFE6, // DBRA D0,head
             0x707F, // MOVEQ #127,D0
             0x60E0, // BRA.S head

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1420,3 +1420,39 @@ fn link_unlk_frame_loop_matches_step() {
         cpu.set_d(7, 5);
     });
 }
+
+/// The salvage shape end to end: a store-heavy prefix through an interior
+/// branch, an inadmissible LEA (abs).L, and a loop tail. The salvaged
+/// trace plus the interpreted tail must match step() exactly.
+#[test]
+fn salvaged_prefix_loop_matches_step() {
+    let words = &[
+        0x3083, // $1000: MOVE.W D3,(A0)
+        0x5283, // $1002: ADDQ.L #1,D3
+        0x3143, 0x0002, // $1004: MOVE.W D3,2(A0)
+        0x5284, // $1008: ADDQ.L #1,D4
+        0x3144, 0x0004, // $100A: MOVE.W D4,4(A0)
+        0x5285, // $100E: ADDQ.L #1,D5
+        0x3145, 0x0006, // $1010: MOVE.W D5,6(A0)
+        0x5286, // $1014: ADDQ.L #1,D6
+        0x3146, 0x0008, // $1016: MOVE.W D6,8(A0)
+        0x5281, // $101A: ADDQ.L #1,D1
+        0x4A41, // $101C: TST.W D1
+        0x6602, // $101E: BNE.S $1022
+        0x4E71, // $1020: NOP (skipped)
+        0x4A42, // $1022: TST.W D2 (past the branch: no terminal here)
+        0x4A42, // $1024: TST.W D2
+        0x41F9, 0x0000, 0x3000, // $1026: LEA $3000.L,A0 -- inadmissible
+        0x51C8, 0xFFD2, // $102C: DBRA D0,$1000
+        0x5347, // $1030: SUBQ.W #1,D7
+        0x6602, // $1032: BNE.S $1036
+        0xA000, // $1034: sentinel
+        0x707F, // $1036: MOVEQ #127,D0
+        0x60C6, // $1038: BRA.S $1000
+    ];
+    assert_fastmem_matches_step("salvaged prefix loop", words, CpuType::M68040, |cpu| {
+        cpu.set_a(0, 0x4000);
+        cpu.set_d(0, 50);
+        cpu.set_d(7, 5);
+    });
+}

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1442,7 +1442,8 @@ fn salvaged_prefix_loop_matches_step() {
         0x4E71, // $1020: NOP (skipped)
         0x4A42, // $1022: TST.W D2 (past the branch: no terminal here)
         0x4A42, // $1024: TST.W D2
-        0x41F9, 0x0000, 0x3000, // $1026: LEA $3000.L,A0 -- inadmissible
+        0x4E57, 0x0000, // $1026: LINK A7,#0 -- refused by design
+        0x4E5F, // $102A: UNLK A7
         0x51C8, 0xFFD2, // $102C: DBRA D0,$1000
         0x5347, // $1030: SUBQ.W #1,D7
         0x6602, // $1032: BNE.S $1036


### PR DESCRIPTION
## Why

Gameplay trace-opportunity profiling of EV Override (capped GUI sessions under the Systemless host, `trace-profile` feature) shows long recordings dying deep: regions record 14–26 admissible ops and then hit one instruction the decoder refuses (`LEA (abs).L`, `MOVEM.L`, wide multiplies, PC-relative jump tables), and the whole recording — good prefix included — is rejected. The head then re-probes forever. The failed-shape table's top entries are exactly these: multi-block prefixes crossing several recorded branches, terminated by a single inadmissible op.

## What

`finish_recording` already attempts compilation of whatever was recorded on every end; a recording stopped by an unsupported instruction fails only because its op list lacks a trace terminal. When such a recording's prefix already crossed a recorded branch, trim back to the last one and compile that instead:

- Ops are execution-ordered, so the recorded op *after* the trimmed terminal names the true continuation (whichever way the branch went); the guest re-enters full dispatch exactly where the trimmed tail began.
- The trimmed terminal branch is normalized to an ordinary final branch, exactly as when a recording stops at a branch destination today.
- The salvage bar is `SALVAGE_MIN_OPS = 8`, above `TRACE_MIN_OPS`: a salvaged trace exits to the interpreter at its terminal every pass, so short fragments would pay entry/exit costs without covering enough work.
- Recordings whose last op already is a terminal, blocked recordings with no recorded branch, and below-bar prefixes behave exactly as before.

## Measured effect

**Focused microbench** (in-repo `benches/microbench.rs`, filter `salvage-prefix`): a store-heavy loop — five MOVE.W stores interleaved with register counters, an interior conditional branch, two register tests past the branch (so the recording ends on a non-terminal), then the `LEA (abs).L` blocker and a DBRA tail — 100M instructions per run after a 5M warmup, deterministic `run_batch` workload. Both arms `--features jit` on the same idle machine; base is `origin/master` with an identical benchmark copy. Five alternating runs, median of pairwise ratios:

| run | base | cand |
|-----|------|------|
| 1 | 59.6 | 134.2 |
| 2 | 64.6 | 128.9 |
| 3 | 59.4 | 126.9 |
| 4 | 56.9 | 103.3 |
| 5 | 65.0 | 134.5 |

Median pairwise **2.07×** (M instr/s; base rejects the head — the recording's last op is not a terminal — and interprets the whole loop; the candidate natively retires the twelve-op salvaged prefix and interprets the five-op tail). A register-only nine-op variant of the shape measures ~1.0×: per-iteration trace entry/exit cost cancels the win on cheap ops, which is what the `SALVAGE_MIN_OPS` bar is for.

**Whole-application headless A/B**: deterministic 900M-instruction EV Override boot workload under the Systemless host (`--features jit,trace-profile`, identical assets both arms), counters from the JIT itself:

| counter | base (master) | cand (salvage) |
|---------|--------------|----------------|
| native_calls | 68,043 | **81,857** (+20.3%) |
| jit_retired | 16,375,668 | **16,495,136** (+119K) |
| rejected_hits | 524,768 | **510,921** (−13.8K) |
| avg ops per call | 240.67 | 201.51 |

Heads that re-probed and re-rejected forever now run compiled prefixes; the average ops per call drops because salvaged traces are short, while total retirement rises.

**Gameplay evidence (composed).** In a capped EV Override GUI session of a bundle carrying this PR with call-through (#107) and frame-op admission (#108), against the prior session of the same bundle without them (near-identical lengths): session-wide native retirement rose 43.72% → **46.65%**, unclassified memory-bail volume collapsed ~67K → ~13K, and heads that previously showed thousands of failed re-recordings now appear in the compiled table with trimmed shapes. The attribution to this PR specifically is the conversion of blocked-shape mass into short compiled traces; the retirement rise is shared with #108.

## Validation

- `blocked_recording_salvages_the_prefix_through_the_last_branch` — a blocked nine-op prefix compiles trimmed at its branch, the unsupported tail excluded from the recorded ops, lockstep counters across the salvaged-native + interpreted-tail iteration.
- `short_blocked_recordings_still_reject` — a five-op prefix whose last terminal sits at op four stays below the bar and rejects exactly as before.
- `blocked_recording_without_a_branch_still_rejects` — a branchless prefix has nothing to trim to.
- `salvaged_prefix_loop_matches_step` (integration) — the salvage shape matches single-step interpretation exactly through record/trim/compile/execute, including instruction counts, registers, and memory.
- Full suites green: lib tests (all-features and jit-only), default-feature suite including the Musashi/SST fixtures, run_batch integration, `clippy --all-features --all-targets` clean, portable (`--no-default-features`) build.

**Composition note**: if this lands alongside call-through (#107), the merge should keep the retry ahead of salvage at a BSR blocker — a first blocked-at-call recording must reject so the slot re-arms with call permission; the permitted retry's own blocked recording salvages normally. Without that ordering a salvaged prefix occupies the slot and the record-through retry never fires.
