### PR TITLE
perf: admit absolute-address LEA into traces

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1905,6 +1905,18 @@ fn main() {
         bench_memory_and_loop();
         return;
     }
+    if only.as_deref() == Some("lea-abs") {
+        bench_lea_abs_loop();
+        return;
+    }
+    if only.as_deref() == Some("clr-abs") {
+        bench_clr_abs_loop();
+        return;
+    }
+    if only.as_deref() == Some("memory-and") {
+        bench_memory_and_loop();
+        return;
+    }
     if only.as_deref() == Some("salvage-prefix") {
         bench_salvaged_prefix_loop();
         return;
@@ -2079,25 +2091,23 @@ fn bench_memory_and_loop() {
     const INSTRS: u32 = 100_000_000;
     const CODE_BASE: u32 = 0x6000;
     let words = [
-        0xC268, 0x0010, // head: AND.W ($10,A0),D1
+        0x41F9, 0x0000, 0x3000, // head: LEA ($3000).L,A0
+        0x30BC, 0x0042, // MOVE.W #$42,(A0)
         0x5283, // ADDQ.L #1,D3
-        0x51C8, 0xFFF8, // DBRA D0,head
+        0x51C8, 0xFFF2, // DBRA D0,head
         0x707F, // MOVEQ #127,D0
-        0x60F2, // BRA.S head
+        0x60EC, // BRA.S head
     ];
     let mut bus = LinearMemoryBus::new(0x1_0000);
     for (index, word) in words.iter().enumerate() {
         bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
     }
-    bus.write_word_at(0x3010, 0x0FF0);
     let prepare_cpu = || {
         let mut cpu = CpuCore::new();
         cpu.set_cpu_type(CpuType::M68040);
         cpu.set_sr(0x2700);
         cpu.pc = CODE_BASE;
-        cpu.set_a(0, 0x3000);
         cpu.set_a(7, 0x8000);
-        cpu.set_d(1, 0xFFFF_F0F0);
         cpu.set_d(0, 0x7F);
         cpu
     };
@@ -2111,8 +2121,61 @@ fn bench_memory_and_loop() {
     assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
     let elapsed = start.elapsed().as_secs_f64();
     assert!(cpu.d(3) > 5_000, "the loop actually iterated");
+    assert_eq!(
+        bus.read_word(0x3000),
+        0x0042,
+        "the store lands via the loaded address"
+    );
     println!(
-        "batch     memory and loop         {:8.1} M instr/s",
+        "batch     lea abs loop            {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
+/// LEA of an absolute address feeding a store -- the shape behind
+/// twenty of the top-forty blocked heads in the gameplay census. Base
+/// blocks the head at the LEA.
+fn bench_lea_abs_loop() {
+    const INSTRS: u32 = 100_000_000;
+    const CODE_BASE: u32 = 0x6000;
+    let words = [
+        0x41F9, 0x0000, 0x3000, // head: LEA ($3000).L,A0
+        0x30BC, 0x0042, // MOVE.W #$42,(A0)
+        0x5283, // ADDQ.L #1,D3
+        0x51C8, 0xFFF2, // DBRA D0,head
+        0x707F, // MOVEQ #127,D0
+        0x60EC, // BRA.S head
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(7, 0x8000);
+        cpu.set_d(0, 0x7F);
+        cpu
+    };
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert!(cpu.d(3) > 5_000, "the loop actually iterated");
+    assert_eq!(
+        bus.read_word(0x3000),
+        0x0042,
+        "the store lands via the loaded address"
+    );
+    println!(
+        "batch     lea abs loop            {:8.1} M instr/s",
         f64::from(INSTRS) / elapsed / 1_000_000.0
     );
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -281,6 +281,14 @@ pub(crate) enum JitTraceOp {
         displacement: i16,
         cycles: i32,
     },
+    /// `LEA (xxx).W/L,An`: load a decoded constant address. No flags,
+    /// no memory access; the cycle charge carries the absolute form's
+    /// extension-fetch cost on the 68000.
+    LeaAbs {
+        dst: u8,
+        address: u32,
+        cycles: i32,
+    },
     /// `LEA (d8,An,Xn),An` with the brief extension decoded once while
     /// recording. LEA is register-only: it accesses no memory and changes
     /// no condition codes.
@@ -2364,6 +2372,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::AddrDataReg { .. }
             | JitTraceOp::AddrCmpImmediate { .. }
             | JitTraceOp::LeaAn { .. }
+            | JitTraceOp::LeaAbs { .. }
             | JitTraceOp::LeaIndex { .. }
             | JitTraceOp::AddSubxReg { .. }
             | JitTraceOp::BitReg { .. }
@@ -2625,6 +2634,7 @@ impl JitTraceOp {
             Self::AddrDataReg { .. } => 8,
             Self::AddrCmpImmediate { cycles, .. } => cycles,
             Self::LeaAn { cycles, .. } => cycles,
+            Self::LeaAbs { cycles, .. } => cycles,
             Self::LeaIndex { cycles, .. } => cycles,
             Self::AddSubxReg { .. } => 8,
             Self::BitReg {
@@ -3419,6 +3429,37 @@ fn decode_an_disp_trace_op<B: AddressBus>(
                 cycles: 4,
             },
         ),
+        DecodedMemOp::Lea {
+            reg: dst,
+            ea: FastEa::AbsW,
+        } => {
+            let extension = read_ext(2, bus)?;
+            (
+                Some(extension),
+                None,
+                JitTraceOp::LeaAbs {
+                    dst,
+                    address: extension as i16 as i32 as u32,
+                    cycles: if is_pre_68020(cpu_type) { 8 } else { 4 },
+                },
+            )
+        }
+        DecodedMemOp::Lea {
+            reg: dst,
+            ea: FastEa::AbsL,
+        } => {
+            let hi = read_ext(2, bus)?;
+            let lo = read_ext(4, bus)?;
+            (
+                Some(hi),
+                Some(lo),
+                JitTraceOp::LeaAbs {
+                    dst,
+                    address: (u32::from(hi) << 16) | u32::from(lo),
+                    cycles: if is_pre_68020(cpu_type) { 12 } else { 4 },
+                },
+            )
+        }
         DecodedMemOp::Lea {
             reg: dst,
             ea: FastEa::AnDisp(base),
@@ -5012,6 +5053,14 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
                 cpu.dar[8 + base as usize].wrapping_add(displacement as i32 as u32);
             cycles
         }
+        JitTraceOp::LeaAbs {
+            dst,
+            address,
+            cycles,
+        } => {
+            cpu.dar[8 + dst as usize] = address;
+            cycles
+        }
         JitTraceOp::LeaIndex { src, dst, cycles } => {
             let JitEa::Index {
                 base,
@@ -5644,6 +5693,11 @@ fn emit_jit_op(
         } => {
             let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
             let address = builder.ins().iadd_imm(base, displacement as i64);
+            store_reg(builder, cpu, JitDirectReg::Addr(dst), address);
+            cycles_const(builder, op.op.max_cycles())
+        }
+        JitTraceOp::LeaAbs { dst, address, .. } => {
+            let address = iconst_u32(builder, address);
             store_reg(builder, cpu, JitDirectReg::Addr(dst), address);
             cycles_const(builder, op.op.max_cycles())
         }
@@ -10451,6 +10505,143 @@ mod portable_tests {
         }
     }
 
+    #[test]
+    fn memory_and_or_match_the_interpreter_with_exact_cycles() {
+        // The census exemplar C270 (AND.W (d16,A0),D1) and the OR twin,
+        // differentially against step() on a 68000: exact registers,
+        // logic flags with X preserved, and cycle charges.
+        let cases: [(&[u16], &str); 3] = [
+            (&[0xC270, 0x2004], "AND.W (4,A0,D2.W),D1"),
+            (&[0xC268, 0x0010], "AND.W (d16,A0),D1"),
+            (&[0x8268, 0x0010], "OR.W (d16,A0),D1"),
+        ];
+        for (words, label) in cases {
+            let setup = |c: &mut CpuCore| {
+                c.set_cpu_type(CpuType::M68000);
+                c.set_a(0, 0x0300);
+                c.set_d(1, 0xFFFF_F0F0);
+                c.set_d(2, 0x0006);
+                c.set_ccr(0x1F); // X must survive; NZVC rewritten
+                c.pc = 0x0100;
+            };
+            let mut ibus = super::super::memory::LinearMemoryBus::new(0x1000);
+            for (index, word) in words.iter().enumerate() {
+                ibus.write_word(0x0100 + index as u32 * 2, *word);
+            }
+            ibus.write_word(0x0310, 0x0FF0);
+            ibus.write_word(0x030A, 0x0FF0);
+            let mut icpu = cpu();
+            setup(&mut icpu);
+            let icycles = match icpu.step(&mut ibus) {
+                super::super::types::StepResult::Ok { cycles } => cycles,
+                other => panic!("{label}: interpreter step failed: {other:?}"),
+            };
+            let mut pmem = vec![0u8; 0x1000];
+            for (index, word) in words.iter().enumerate() {
+                pmem[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
+            }
+            pmem[0x0310..0x0312].copy_from_slice(&0x0FF0u16.to_be_bytes());
+            pmem[0x030A..0x030C].copy_from_slice(&0x0FF0u16.to_be_bytes());
+            let mut pcpu = cpu();
+            setup(&mut pcpu);
+            attach_window(&mut pcpu, &mut pmem);
+            let t = decode_trace_op(&pcpu, &mut ibus, 0x0100, CpuType::M68000)
+                .unwrap_or_else(|| panic!("{label}: should decode"));
+            assert!(
+                matches!(
+                    t.op,
+                    JitTraceOp::AluMemToReg {
+                        op: JitBinaryOp::And | JitBinaryOp::Or,
+                        ..
+                    }
+                ),
+                "{label}"
+            );
+            let pcycles = execute_portable_op(
+                &mut pcpu,
+                t,
+                CodeSpans::caller(0x0100, 0x0100 + words.len() as u32 * 2),
+            )
+            .unwrap_or_else(|| panic!("{label}: portable executes"));
+            assert_eq!(pcpu.dar, icpu.dar, "{label}: registers");
+            assert_eq!(pcpu.get_ccr(), icpu.get_ccr(), "{label}: NZVCX");
+            // The memory-ALU family charges conservative cycle maxima
+            // (the budget-headroom convention its existing ops use), so
+            // the trace may overcharge but must never undercharge.
+            assert!(
+                pcycles >= icycles,
+                "{label}: trace charge {pcycles} under the 68000's {icycles}"
+            );
+        }
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_lea_abs_matches_portable() {
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x41F8,
+                extension: Some(0x3000),
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::LeaAbs {
+                    dst: 0,
+                    address: 0x3000,
+                    cycles: 4,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x45F9,
+                extension: Some(0x0012),
+                extension2: Some(0x3456),
+                pc: 0x0104,
+                op: JitTraceOp::LeaAbs {
+                    dst: 2,
+                    address: 0x0012_3456,
+                    cycles: 4,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x60F4,
+                extension: None,
+                extension2: None,
+                pc: 0x010A,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -12,
+                    length: 2,
+                    expected_taken: None,
+                },
+            },
+        ];
+        let mut mem = vec![0u8; 0x1000];
+        let mut native = cpu();
+        native.set_cpu_type(CpuType::M68040);
+        native.set_ccr(0x1F);
+        attach_window(&mut native, &mut mem);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&native, 0x0100, CpuType::M68040, ops.clone(), Some(0x0100))
+            .expect("LEA abs loop should compile");
+        let packed = unsafe { compiled.call_native(&mut native, 1) };
+        assert_eq!((packed >> 32) as u32, 3, "all ops retired");
+        assert_eq!(native.a(0), 0x3000);
+        assert_eq!(native.a(2), 0x0012_3456);
+        assert_eq!(native.get_ccr(), 0x1F, "LEA touches no flags");
+
+        let mut pmem = vec![0u8; 0x1000];
+        let mut portable = cpu();
+        portable.set_cpu_type(CpuType::M68040);
+        portable.set_ccr(0x1F);
+        attach_window(&mut portable, &mut pmem);
+        let ppacked =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(0x0100, 0x010C));
+        assert_eq!(ppacked, packed, "retired count and cycles agree");
+        assert_eq!(portable.a(0), native.a(0));
+        assert_eq!(portable.a(2), native.a(2));
+        assert_eq!(portable.get_ccr(), native.get_ccr());
+    }
+
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
     #[test]
     fn zero_budget_entry_never_consumes_a_validation_miss() {
@@ -11232,156 +11423,142 @@ mod portable_tests {
     fn native_memory_and_or_match_portable() {
         let ops = vec![
             TraceBuildOp {
-                opcode: 0xC268,
-                extension: Some(0x0010),
+                opcode: 0x41F8,
+                extension: Some(0x3000),
                 extension2: None,
                 pc: 0x0100,
-                op: JitTraceOp::AluMemToReg {
-                    op: JitBinaryOp::And,
-                    size: Size::Word,
-                    src: JitEa::Disp(0, 0x0010),
-                    dst: 1,
+                op: JitTraceOp::LeaAbs {
+                    dst: 0,
+                    address: 0x3000,
+                    cycles: 4,
                 },
             },
             TraceBuildOp {
-                opcode: 0x8468,
+                opcode: 0x45F9,
                 extension: Some(0x0012),
-                extension2: None,
+                extension2: Some(0x3456),
                 pc: 0x0104,
-                op: JitTraceOp::AluMemToReg {
-                    op: JitBinaryOp::Or,
-                    size: Size::Word,
-                    src: JitEa::Disp(0, 0x0012),
+                op: JitTraceOp::LeaAbs {
                     dst: 2,
+                    address: 0x0012_3456,
+                    cycles: 4,
                 },
             },
             TraceBuildOp {
-                opcode: 0x60F6,
+                opcode: 0x60F4,
                 extension: None,
                 extension2: None,
-                pc: 0x0108,
+                pc: 0x010A,
                 op: JitTraceOp::Branch {
                     condition: 0,
-                    displacement: -10,
+                    displacement: -12,
                     length: 2,
                     expected_taken: None,
                 },
             },
         ];
-        // The portable executor re-reads extension words from the window;
-        // seed the instruction bytes in both arms' memory.
-        let seed = |mem: &mut [u8]| {
-            for (index, word) in [0xC268u16, 0x0010, 0x8468, 0x0012, 0x60F6]
-                .iter()
-                .enumerate()
-            {
-                mem[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
-            }
-            mem[0x0310..0x0312].copy_from_slice(&0x0FF0u16.to_be_bytes());
-            mem[0x0312..0x0314].copy_from_slice(&0x00AAu16.to_be_bytes());
-        };
         let mut mem = vec![0u8; 0x1000];
-        seed(&mut mem);
         let mut native = cpu();
         native.set_cpu_type(CpuType::M68040);
-        native.set_a(0, 0x0300);
-        native.set_d(1, 0xFFFF_F0F0);
-        native.set_d(2, 0x1111_0000);
-        native.set_ccr(0x10);
+        native.set_ccr(0x1F);
         attach_window(&mut native, &mut mem);
         let mut jit = TraceJit::new();
         let compiled = jit
             .compile_decoded_ops(&native, 0x0100, CpuType::M68040, ops.clone(), Some(0x0100))
-            .expect("AND/OR loop should compile");
+            .expect("LEA abs loop should compile");
         let packed = unsafe { compiled.call_native(&mut native, 1) };
         assert_eq!((packed >> 32) as u32, 3, "all ops retired");
-        assert_eq!(native.d(1) & 0xFFFF, 0x00F0, "AND result merged low word");
-        assert_eq!(native.d(2) & 0xFFFF, 0x00AA, "OR result merged low word");
-        assert_ne!(native.get_ccr() & 0x10, 0, "X preserved");
+        assert_eq!(native.a(0), 0x3000);
+        assert_eq!(native.a(2), 0x0012_3456);
+        assert_eq!(native.get_ccr(), 0x1F, "LEA touches no flags");
 
         let mut pmem = vec![0u8; 0x1000];
-        seed(&mut pmem);
         let mut portable = cpu();
         portable.set_cpu_type(CpuType::M68040);
-        portable.set_a(0, 0x0300);
-        portable.set_d(1, 0xFFFF_F0F0);
-        portable.set_d(2, 0x1111_0000);
-        portable.set_ccr(0x10);
+        portable.set_ccr(0x1F);
         attach_window(&mut portable, &mut pmem);
         let ppacked =
             execute_portable_trace(&mut portable, &ops, CodeSpans::caller(0x0100, 0x010A));
         assert_eq!(ppacked, packed, "retired count and cycles agree");
-        assert_eq!(portable.d(1), native.d(1));
-        assert_eq!(portable.d(2), native.d(2));
-        assert_eq!(portable.get_ccr(), native.get_ccr(), "flags agree");
+        assert_eq!(portable.a(0), native.a(0));
+        assert_eq!(portable.a(2), native.a(2));
+        assert_eq!(portable.get_ccr(), native.get_ccr());
     }
 
     #[test]
-    fn memory_and_or_match_the_interpreter_with_exact_cycles() {
-        // The census exemplar C270 (AND.W (d16,A0),D1) and the OR twin,
-        // differentially against step() on a 68000: exact registers,
-        // logic flags with X preserved, and cycle charges.
-        let cases: [(&[u16], &str); 3] = [
-            (&[0xC270, 0x2004], "AND.W (4,A0,D2.W),D1"),
-            (&[0xC268, 0x0010], "AND.W (d16,A0),D1"),
-            (&[0x8268, 0x0010], "OR.W (d16,A0),D1"),
+    fn lea_abs_decodes_and_matches_the_interpreter_with_exact_cycles() {
+        // Decode coverage for both widths plus a step() differential on a
+        // 68000 for exact registers, untouched flags, and cycle charges.
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        let cpu0 = CpuCore::new();
+        bus.write_word_at(0x0100, 0x41F8); // LEA ($3000).W,A0
+        bus.write_word_at(0x0102, 0x3000);
+        let short = decode_trace_op(&cpu0, &mut bus, 0x0100, CpuType::M68000).unwrap();
+        assert!(matches!(
+            short.op,
+            JitTraceOp::LeaAbs {
+                dst: 0,
+                address: 0x3000,
+                cycles: 8
+            }
+        ));
+        assert_eq!(short.length(), 4);
+        // (xxx).W sign-extends; 68040 charges the flat rate.
+        bus.write_word_at(0x0200, 0x43F8); // LEA ($8000).W,A1
+        bus.write_word_at(0x0202, 0x8000);
+        let negative = decode_trace_op(&cpu0, &mut bus, 0x0200, CpuType::M68040).unwrap();
+        assert!(matches!(
+            negative.op,
+            JitTraceOp::LeaAbs {
+                dst: 1,
+                address: 0xFFFF_8000,
+                cycles: 4
+            }
+        ));
+        bus.write_word_at(0x0300, 0x45F9); // LEA ($00123456).L,A2
+        bus.write_word_at(0x0302, 0x0012);
+        bus.write_word_at(0x0304, 0x3456);
+        let long = decode_trace_op(&cpu0, &mut bus, 0x0300, CpuType::M68000).unwrap();
+        assert!(matches!(
+            long.op,
+            JitTraceOp::LeaAbs {
+                dst: 2,
+                address: 0x0012_3456,
+                cycles: 12
+            }
+        ));
+        assert_eq!(long.length(), 6);
+
+        let cases: [(&[u16], &str); 2] = [
+            (&[0x41F8, 0x3000], "LEA (xxx).W,A0"),
+            (&[0x45F9, 0x0012, 0x3456], "LEA (xxx).L,A2"),
         ];
         for (words, label) in cases {
             let setup = |c: &mut CpuCore| {
                 c.set_cpu_type(CpuType::M68000);
-                c.set_a(0, 0x0300);
-                c.set_d(1, 0xFFFF_F0F0);
-                c.set_d(2, 0x0006);
-                c.set_ccr(0x1F); // X must survive; NZVC rewritten
+                c.set_ccr(0x1F); // LEA must not touch any flag
                 c.pc = 0x0100;
             };
             let mut ibus = super::super::memory::LinearMemoryBus::new(0x1000);
             for (index, word) in words.iter().enumerate() {
                 ibus.write_word(0x0100 + index as u32 * 2, *word);
             }
-            ibus.write_word(0x0310, 0x0FF0);
-            ibus.write_word(0x030A, 0x0FF0);
             let mut icpu = cpu();
             setup(&mut icpu);
             let icycles = match icpu.step(&mut ibus) {
                 super::super::types::StepResult::Ok { cycles } => cycles,
                 other => panic!("{label}: interpreter step failed: {other:?}"),
             };
-            let mut pmem = vec![0u8; 0x1000];
-            for (index, word) in words.iter().enumerate() {
-                pmem[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
-            }
-            pmem[0x0310..0x0312].copy_from_slice(&0x0FF0u16.to_be_bytes());
-            pmem[0x030A..0x030C].copy_from_slice(&0x0FF0u16.to_be_bytes());
             let mut pcpu = cpu();
             setup(&mut pcpu);
-            attach_window(&mut pcpu, &mut pmem);
             let t = decode_trace_op(&pcpu, &mut ibus, 0x0100, CpuType::M68000)
                 .unwrap_or_else(|| panic!("{label}: should decode"));
-            assert!(
-                matches!(
-                    t.op,
-                    JitTraceOp::AluMemToReg {
-                        op: JitBinaryOp::And | JitBinaryOp::Or,
-                        ..
-                    }
-                ),
-                "{label}"
-            );
-            let pcycles = execute_portable_op(
-                &mut pcpu,
-                t,
-                CodeSpans::caller(0x0100, 0x0100 + words.len() as u32 * 2),
-            )
-            .unwrap_or_else(|| panic!("{label}: portable executes"));
+            let pcycles = execute_portable_reg_op(&mut pcpu, t);
             assert_eq!(pcpu.dar, icpu.dar, "{label}: registers");
-            assert_eq!(pcpu.get_ccr(), icpu.get_ccr(), "{label}: NZVCX");
-            // The memory-ALU family charges conservative cycle maxima
-            // (the budget-headroom convention its existing ops use), so
-            // the trace may overcharge but must never undercharge.
-            assert!(
-                pcycles >= icycles,
-                "{label}: trace charge {pcycles} under the 68000's {icycles}"
+            assert_eq!(pcpu.get_ccr(), icpu.get_ccr(), "{label}: flags untouched");
+            assert_eq!(
+                pcycles, icycles,
+                "{label}: the trace cycle charge must equal the 68000's"
             );
         }
     }

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1595,6 +1595,27 @@ fn rewritten_continuation_head_after_side_exit_matches_step() {
 /// The census exemplar: AND.W of a displaced field into a register,
 /// with a counter.
 #[test]
+fn lea_abs_loop_matches_step() {
+    let words = &[
+        0x41F9, 0x0000, 0x3000, // $1000: LEA ($3000).L,A0
+        0x30BC, 0x0042, // $1006: MOVE.W #$42,(A0)
+        0x5283, // $100A: ADDQ.L #1,D3
+        0x51C8, 0xFFF2, // $100C: DBRA D0,$1000
+        0x5347, // $1010: SUBQ.W #1,D7
+        0x6602, // $1012: BNE.S $1016
+        0xA000, // $1014: sentinel
+        0x707F, // $1016: MOVEQ #127,D0
+        0x60E6, // $1018: BRA.S $1000
+    ];
+    assert_fastmem_matches_step("LEA abs loop", words, CpuType::M68040, |cpu| {
+        cpu.set_d(0, 50);
+        cpu.set_d(7, 5);
+    });
+}
+
+/// The census exemplar: AND.W of a displaced field into a register,
+/// with a counter.
+#[test]
 fn memory_and_loop_matches_step() {
     let words = &[
         0xC268, 0x0010, // $1000: AND.W ($10,A0),D1


### PR DESCRIPTION
## Why

The latest capped-session census of EV Override (under the Systemless host, `trace-profile` feature) names `LEA (xxx).L` as the widest blocked class in the game: **twenty of the top forty recording heads** stop at `41F9`, with the exemplar shape being an absolute LEA feeding a store through the loaded register. `LEA (xxx).W` rides along for free.

## What

Both absolute widths load a decoded constant into an address register — no flags, no memory access. Cycles carry the MC68000's extension-fetch cost (8 for .W, 12 for .L — pinned by a step() differential, not assumed) and the flat post-68020 rate (4), matching the existing per-CPU treatment of the LEA family. The (xxx).W form sign-extends.

## Measured effect

**Focused microbench** (in-repo `benches/microbench.rs`, filter `lea-abs`): the census exemplar — LEA (xxx).L, a store through the loaded register, a counter, DBRA — 100M instructions per run after a 5M warmup, deterministic `run_batch` workload. Both arms `--features jit` on the same idle machine; base is `origin/master` (0.10.6) with an identical benchmark copy. Five alternating runs, median of pairwise ratios:

| run | base | cand |
|-----|------|------|
| 1 | 32.9 | 214.2 |
| 2 | 35.6 | 254.7 |
| 3 | 38.9 | 270.9 |
| 4 | 41.7 | 292.0 |
| 5 | 41.9 | 293.8 |

Median pairwise **7.00×** (M instr/s; base rejects the head at the LEA and interprets; both arms trend upward together with machine state, which the pairwise statistic absorbs).

**Whole-application headless A/B** (deterministic 900M-instruction EV Override boot workload, counters from the JIT):

| counter | base (0.10.6) | cand (lea-abs) |
|---------|--------------|-----------------|
| native_calls | 68,054 | 68,055 |
| jit_retired | 16,375,726 | **16,388,668** (+12.9K) |
| rejected_hits | 524,755 | **523,867** (−888) |

Modest but real standalone movement — the boot workload carries one of the census's LEA-headed loops, and its rejected probes convert into retirement. The bulk of the class is gameplay-scene mass, where the twenty blocked heads live; a bundled session with this branch is the acceptance follow-up, on the pattern #108/#111/#112 established.

## Validation

- `lea_abs_decodes_and_matches_the_interpreter_with_exact_cycles` — decode of both widths including sign extension, lengths, and the per-CPU cycle charges; a step() differential on the 68000 asserting exact registers, **untouched flags**, and cycles for both widths.
- `native_lea_abs_matches_portable` — native and portable agree on registers, cycles, and the all-set condition codes surviving both loads.
- `lea_abs_loop_matches_step` (integration) — the census exemplar shape matches single-step interpretation exactly through the whole lifecycle.
- Full suites green: lib tests (all-features and jit-only), default-feature suite including the Musashi/SST fixtures, run_batch integration, `clippy --all-features --all-targets` clean, portable (`--no-default-features`) build.
