### PR TITLE
perf: admit absolute-addressed TST into the memory-TST family

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1818,6 +1818,55 @@ fn bench_set<B: BenchBus>(label: &str) {
     );
 }
 
+/// Exercise the absolute-addressed TST forms the gameplay census
+/// flagged (4A39/4A79 heads): all three widths against fixed targets.
+fn bench_tst_abs_loop() {
+    // Outer cycles of 514 instructions end exactly at the outer label
+    // with the targets untouched (TST writes nothing).
+    const CYCLES: u32 = 408_560;
+    const INSTRS: u32 = CYCLES * 514;
+    const CODE_BASE: u32 = 0x7000;
+    let words = [
+        0x727F, // outer: MOVEQ #127,D1
+        0x4A78, 0x4000, // inner: TST.W ($4000).W
+        0x4AB9, 0x0000, 0x4004, // TST.L ($4004).L
+        0x4A39, 0x0000, 0x4003, // TST.B ($4003).L
+        0x51C9, 0xFFEE, // DBRA D1,inner
+        0x60E8, // BRA.S outer
+    ];
+    let mut bus = LinearMemoryBus::new(0x10000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    for address in 0x4000..0x4008 {
+        bus.write_byte(address, 0xAA);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu
+    };
+    let mut warm_cpu = prepare_cpu();
+    assert_eq!(
+        warm_cpu.run_batch(&mut bus, 5_000_000, &[0]).instructions,
+        5_000_000
+    );
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    assert_eq!(cpu.run_batch(&mut bus, INSTRS, &[0]).instructions, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert_eq!(cpu.pc, CODE_BASE, "the run ends exactly at the outer label");
+    for address in 0x4000..0x4008 {
+        assert_eq!(bus.read_byte(address), 0xAA, "TST writes nothing");
+    }
+    println!(
+        "batch     absolute TST loop       {:8.1} M instr/s",
+        f64::from(INSTRS) / elapsed / 1_000_000.0
+    );
+}
+
 fn main() {
     println!("m68k microbench");
     let only = std::env::args().nth(1);
@@ -1895,6 +1944,10 @@ fn main() {
     }
     if only.as_deref() == Some("far-call-through") {
         bench_far_call_through_leaf();
+        return;
+    }
+    if only.as_deref() == Some("tst-abs") {
+        bench_tst_abs_loop();
         return;
     }
     if only.as_deref() == Some("clr-abs") {

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -2750,13 +2750,14 @@ impl JitTraceOp {
             Self::CmpiWordMem { .. } => 18,
             // TST is a four-cycle operation plus the indexed EA read
             // (M68000UM); byte and word reads have the same EA cost.
-            Self::TstMem { size, .. } => {
-                if size == Size::Long {
-                    18
-                } else {
-                    14
-                }
-            }
+            Self::TstMem { size, src } => match (size, src) {
+                (Size::Long, JitEa::AbsWord(_)) => 16,
+                (_, JitEa::AbsWord(_)) => 12,
+                (Size::Long, JitEa::AbsLong(_)) => 20,
+                (_, JitEa::AbsLong(_)) => 16,
+                (Size::Long, _) => 18,
+                _ => 14,
+            },
             // CLR is the M68000UM store cost (8, or 12 for long) plus the
             // EA calculation: indexed as in the read above, predecrement
             // per Table 8-2.
@@ -3254,6 +3255,35 @@ fn decode_an_disp_trace_op<B: AddressBus>(
             let extension = read_ext(2, bus)?;
             let src = decode_jit_ea(6, u16::from(reg), extension, cpu_type)?;
             (Some(extension), None, JitTraceOp::TstMem { size, src })
+        }
+        DecodedMemOp::Tst {
+            size,
+            ea: FastEa::AbsW,
+        } => {
+            let extension = read_ext(2, bus)?;
+            (
+                Some(extension),
+                None,
+                JitTraceOp::TstMem {
+                    size,
+                    src: JitEa::AbsWord(extension as i16 as i32 as u32),
+                },
+            )
+        }
+        DecodedMemOp::Tst {
+            size,
+            ea: FastEa::AbsL,
+        } => {
+            let hi = read_ext(2, bus)?;
+            let lo = read_ext(4, bus)?;
+            (
+                Some(hi),
+                Some(lo),
+                JitTraceOp::TstMem {
+                    size,
+                    src: JitEa::AbsLong((u32::from(hi) << 16) | u32::from(lo)),
+                },
+            )
         }
         DecodedMemOp::Clr {
             size,
@@ -4232,6 +4262,8 @@ fn execute_portable_tst_mem(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i3
     };
     let ea = match src {
         JitEa::Index { base, .. } => FastEa::AnIndex(base),
+        JitEa::AbsWord(_) => FastEa::AbsW,
+        JitEa::AbsLong(_) => FastEa::AbsL,
         _ => return None,
     };
     let old_pc = cpu.pc;
@@ -6156,19 +6188,8 @@ fn emit_tst_mem(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::TstMem {
-        size,
-        src:
-            JitEa::Index {
-                base,
-                index,
-                index_long,
-                scale,
-                displacement,
-            },
-    } = trace.op
-    else {
-        unreachable!("memory TST decoder admitted an unsupported EA")
+    let JitTraceOp::TstMem { size, src } = trace.op else {
+        unreachable!("emit_tst_mem called for a non-TST op")
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -6177,21 +6198,33 @@ fn emit_tst_mem(
         at,
     });
 
-    let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
-    let raw_index = load_reg(builder, cpu, index);
-    let index = if index_long {
-        raw_index
-    } else {
-        let word = builder.ins().ireduce(types::I16, raw_index);
-        builder.ins().sextend(types::I32, word)
+    let address = match src {
+        JitEa::Index {
+            base,
+            index,
+            index_long,
+            scale,
+            displacement,
+        } => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
+            let raw_index = load_reg(builder, cpu, index);
+            let index = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index = if scale == 0 {
+                index
+            } else {
+                builder.ins().ishl_imm(index, i64::from(scale))
+            };
+            let address = builder.ins().iadd(base, index);
+            builder.ins().iadd_imm(address, displacement as i64)
+        }
+        JitEa::AbsWord(address) | JitEa::AbsLong(address) => iconst_u32(builder, address),
+        _ => unreachable!("memory TST decoder admitted an unsupported EA"),
     };
-    let index = if scale == 0 {
-        index
-    } else {
-        builder.ins().ishl_imm(index, i64::from(scale))
-    };
-    let address = builder.ins().iadd(base, index);
-    let address = builder.ins().iadd_imm(address, displacement as i64);
     let (off, _) = checked_window_off(builder, env, bail, address, size);
     let value = window_load(builder, env, off, size);
     set_logic_flags(builder, cpu, value, size);
@@ -15220,5 +15253,249 @@ mod portable_tests {
         jit.grant_call_permission(COLLIDER);
         assert!(jit.has_call_permission(HEAD));
         assert!(jit.has_call_permission(COLLIDER));
+    }
+
+    #[test]
+    fn tst_from_absolute_decodes_with_exact_extents() {
+        let dcpu = cpu();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        // 4AB8 = TST.L (xxx).W with a negative address: sign-extends.
+        bus.write_word(0x0100, 0x4AB8);
+        bus.write_word(0x0102, 0x8100);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("TST.L (xxx).W should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::TstMem {
+                size: Size::Long,
+                src: JitEa::AbsWord(0xFFFF_8100),
+            }
+        ));
+        assert_eq!(trace.extension, Some(0x8100));
+        assert!(trace.extension2.is_none(), "abs.W carries one extension");
+
+        // 4A79 = TST.W (xxx).L assembles the address from both words.
+        bus.write_word(0x0100, 0x4A79);
+        bus.write_word(0x0102, 0x0001);
+        bus.write_word(0x0104, 0x4208);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("TST.W (xxx).L should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::TstMem {
+                size: Size::Word,
+                src: JitEa::AbsLong(0x0001_4208),
+            }
+        ));
+        assert_eq!(trace.extension, Some(0x0001));
+        assert_eq!(trace.extension2, Some(0x4208));
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_tst_from_absolute_matches_portable_with_exact_flags() {
+        // Case 0: TST.W (xxx).W of a negative word (N). Case 1: TST.L
+        // (xxx).L of zero (Z). Case 2: TST.B (xxx).L — the census head
+        // (4A39) — of a positive byte (neither). X stays set throughout.
+        let cases: [(u16, u16, Option<u16>, JitTraceOp, u8); 3] = [
+            (
+                0x4A78,
+                0x0320,
+                None,
+                JitTraceOp::TstMem {
+                    size: Size::Word,
+                    src: JitEa::AbsWord(0x0320),
+                },
+                0x18,
+            ),
+            (
+                0x4AB9,
+                0x0000,
+                Some(0x0328),
+                JitTraceOp::TstMem {
+                    size: Size::Long,
+                    src: JitEa::AbsLong(0x0328),
+                },
+                0x14,
+            ),
+            (
+                0x4A39,
+                0x0000,
+                Some(0x0327),
+                JitTraceOp::TstMem {
+                    size: Size::Byte,
+                    src: JitEa::AbsLong(0x0327),
+                },
+                0x10,
+            ),
+        ];
+        for (case, (opcode, ext, ext2, op, want_ccr)) in cases.iter().enumerate() {
+            let tst_len: u32 = if ext2.is_some() { 6 } else { 4 };
+            let branch_pc = 0x0100 + tst_len;
+            let displacement = -(tst_len as i32) - 2;
+            let branch_opcode = 0x6000 | (displacement as u8 as u16);
+            let tst = TraceBuildOp {
+                opcode: *opcode,
+                extension: Some(*ext),
+                extension2: *ext2,
+                pc: 0x0100,
+                op: *op,
+            };
+            let branch = TraceBuildOp {
+                opcode: branch_opcode,
+                extension: None,
+                extension2: None,
+                pc: branch_pc,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement,
+                    length: 2,
+                    expected_taken: None,
+                },
+            };
+            let ops = vec![tst, branch];
+            let trace_end = branch_pc + 2;
+            let prepare = |mem: &mut Vec<u8>| {
+                mem[0x0100..0x0102].copy_from_slice(&opcode.to_be_bytes());
+                mem[0x0102..0x0104].copy_from_slice(&ext.to_be_bytes());
+                if let Some(ext2) = ext2 {
+                    mem[0x0104..0x0106].copy_from_slice(&ext2.to_be_bytes());
+                }
+                mem[0x0300..0x0400].fill(0xAA);
+                mem[0x0320..0x0322].copy_from_slice(&0x8001u16.to_be_bytes());
+                mem[0x0328..0x032C].fill(0x00);
+                mem[0x0327] = 0x7F;
+                let mut c = cpu();
+                c.set_cpu_type(CpuType::M68040);
+                c.set_ccr(0x10);
+                attach_window(&mut c, mem);
+                c
+            };
+            let mut emem = vec![0u8; 0x1000];
+            let mut expected = prepare(&mut emem);
+            let expected_packed =
+                execute_portable_trace(&mut expected, &ops, CodeSpans::caller(0x0100, trace_end));
+            let mut amem = vec![0u8; 0x1000];
+            let mut actual = prepare(&mut amem);
+            let before_mem = amem.clone();
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(&actual, 0x0100, CpuType::M68040, ops.clone(), Some(0x0100))
+                .expect("absolute TST loop should compile");
+            let actual_packed = unsafe { compiled.call_native(&mut actual, 1) };
+            assert_eq!(
+                actual_packed, expected_packed,
+                "case {case}: cycles/retired"
+            );
+            assert_ne!(expected_packed, 0, "case {case}: the trace ran");
+            assert_eq!(actual.dar, expected.dar, "case {case}: registers");
+            assert_eq!(
+                actual.get_ccr(),
+                expected.get_ccr(),
+                "case {case}: ccr parity"
+            );
+            assert_eq!(
+                actual.get_ccr() & 0x1F,
+                *want_ccr,
+                "case {case}: exact flags with X preserved"
+            );
+            assert_eq!(amem, emem, "case {case}: memory parity");
+            assert_eq!(amem, before_mem, "case {case}: TST writes nothing");
+        }
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn tst_from_absolute_cycles_match_the_interpreter_on_a_68000() {
+        // One loop pass over all three widths, compiled for a 68000,
+        // against the step interpreter's charge for the same sequence.
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x4A78,
+                extension: Some(0x0320),
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::TstMem {
+                    size: Size::Word,
+                    src: JitEa::AbsWord(0x0320),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x4AB9,
+                extension: Some(0x0000),
+                extension2: Some(0x0328),
+                pc: 0x0104,
+                op: JitTraceOp::TstMem {
+                    size: Size::Long,
+                    src: JitEa::AbsLong(0x0328),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x4A39,
+                extension: Some(0x0000),
+                extension2: Some(0x0327),
+                pc: 0x010A,
+                op: JitTraceOp::TstMem {
+                    size: Size::Byte,
+                    src: JitEa::AbsLong(0x0327),
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x60EE,
+                extension: None,
+                extension2: None,
+                pc: 0x0110,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -18,
+                    length: 2,
+                    expected_taken: None,
+                },
+            },
+        ];
+        let words: [u16; 9] = [
+            0x4A78, 0x0320, 0x4AB9, 0x0000, 0x0328, 0x4A39, 0x0000, 0x0327, 0x60EE,
+        ];
+        let prepare = |mem: &mut Vec<u8>| {
+            for (index, word) in words.iter().enumerate() {
+                let at = 0x0100 + index * 2;
+                mem[at..at + 2].copy_from_slice(&word.to_be_bytes());
+            }
+            mem[0x0300..0x0400].fill(0xAA);
+            let mut c = cpu();
+            c.set_cpu_type(CpuType::M68000);
+            attach_window(&mut c, mem);
+            c
+        };
+        let mut nmem = vec![0u8; 0x1000];
+        let mut ncpu = prepare(&mut nmem);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&ncpu, 0x0100, CpuType::M68000, ops, Some(0x0100))
+            .expect("absolute TST sequence should compile for a 68000");
+        let packed = unsafe { compiled.call_native(&mut ncpu, 1) };
+        assert_eq!((packed >> 32) as u32, 4, "all four ops retired");
+        let native_cycles = packed as u32;
+
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word(0x0100 + index as u32 * 2, *word);
+        }
+        let mut scpu = CpuCore::new();
+        scpu.set_cpu_type(CpuType::M68000);
+        scpu.set_sr(0x2700);
+        scpu.pc = 0x0100;
+        let mut step_cycles: u32 = 0;
+        for _ in 0..4 {
+            match scpu.step(&mut bus) {
+                crate::StepResult::Ok { cycles } => step_cycles += cycles as u32,
+                other => panic!("unexpected step result {other:?}"),
+            }
+        }
+        assert_eq!(scpu.pc, 0x0100, "step run wrapped back to the head");
+        assert_eq!(
+            native_cycles, step_cycles,
+            "native charge equals the 68000 interpreter's"
+        );
     }
 }

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1221,6 +1221,24 @@ fn mem_trace_clr_absolute_matches_step() {
     });
 }
 
+/// Absolute-addressed TST (the 4A39/4A79 gameplay census heads) must stay
+/// exact through the whole record/compile/execute lifecycle, with the
+/// tested word re-dirtied every pass so the flags keep changing.
+#[test]
+fn mem_trace_tst_absolute_matches_step() {
+    let words = &[
+        0x4A78, 0x2000, // $1000: TST.W ($2000).W
+        0x4AB9, 0x0000, 0x2004, // $1004: TST.L ($2004).L
+        0x4A39, 0x0000, 0x2003, // $100A: TST.B ($2003).L
+        0x31C0, 0x2000, // $1010: MOVE.W D0,($2000).W  (re-dirty the target)
+        0x51C8, 0xFFEA, // $1014: DBRA D0,$1000
+        0xA000, // $1018: sentinel
+    ];
+    assert_fastmem_matches_step("tst absolute", words, CpuType::M68000, |cpu| {
+        cpu.set_d(0, 300);
+    });
+}
+
 #[test]
 fn mem_trace_memcpy_loop_matches_step() {
     let words = &[


### PR DESCRIPTION
## Why

The latest capped-session census of EV Override (Systemless host, `trace-profile`) — the first with the absolute-CLR heads cleared — surfaces the next absolute-EA class behind them: **four of the top forty rejected recording heads** (ranked by rejected hits) block at absolute-addressed TST, three at `4A39` (`TST.B (xxx).L`) and one at `4A79` (`TST.W (xxx).L`), together ~460K projected instructions. The memory-TST family already handles indexed sources; the absolute forms need only a constant-address arm.

Two census neighbours are explicitly *not* in this PR: `0C79` (`CMPI.W #imm,(xxx).L`, three extension words) and `33F9` (`MOVE.W (xxx).L,(xxx).L`, four) exceed the recorder's two-extension-word shape and stay deferred with `2D7C` until that structural change happens.

## What

`TST.B/W/L (xxx).W` and `(xxx).L` join the family. TST reads and writes nothing, so no store guard is involved — the pieces are:

- **Exact cycle entries.** The family's flat charge was the indexed cost (14/18) and would have *overcharged* the absolute forms; the new entries are exact — 12/16 for abs.W, 16/20 for abs.L (word-or-byte/long) — and pinned against the 68000 step interpreter by test.
- **Constant-address emit** through the same window-checked load path as the indexed form.
- **Portable delegation** onto the interpreter's decoded-EA path.

## Measured effect

**Focused microbench** (filter `tst-abs`): all three widths against fixed absolute targets in a DBRA loop, 210M instructions per run after a 5M warmup, deterministic `run_batch` workload; both arms `--features jit` on the same idle machine; base is `origin/master` (0.10.6) with an identical benchmark copy; five alternating runs, median of pairwise ratios:

| run | base | cand |
|-----|------|------|
| 1 | 33.3 | 390.1 |
| 2 | 35.5 | 404.3 |
| 3 | 35.5 | 429.5 |
| 4 | 36.4 | 432.8 |
| 5 | 36.6 | 437.5 |

Median pairwise **11.89×** (M instr/s; base rejects the head at the TST and interprets — and TST's native form is a guard-free load, hence the larger ratio than the store families).

**Whole-application headless A/B** (deterministic 900M-instruction EV Override boot workload): exactly flat — every total identical between arms (backward_hits 553,701; rejected_hits 524,755; native_calls 68,054; jit_retired 16,375,726). The boot workload contains no absolute-TST heads; the four blocked heads are gameplay-scene mass, on the same acceptance pattern as #108/#111/#112/#113/#115/#116 — a bundled session with this branch is the follow-up.

## Validation

- `tst_from_absolute_decodes_with_exact_extents` — abs.W sign-extension (negative addresses), two-word abs.L assembly, extension-word bookkeeping.
- `native_tst_from_absolute_matches_portable_with_exact_flags` — all three widths with the flag matrix pinned per case (negative word → N; zero long → Z; positive byte → neither; X preserved throughout); registers, memory, and charge agree between engines, and memory is bit-identical before and after (TST writes nothing).
- `tst_from_absolute_cycles_match_the_interpreter_on_a_68000` — one pass over all three widths compiled for a 68000 charges exactly what four step() calls charge.
- `mem_trace_tst_absolute_matches_step` (integration) — the whole record/compile/execute lifecycle with the tested word re-dirtied every pass matches single-step interpretation exactly.
- Mutation-checked: removing the exact cycle arms fails the cycle pin (56 vs 58), removing the portable delegation fails parity, removing the sign-extension fails decode.
- Full suites green: lib tests (jit-only and all-features), default-feature suite including the Musashi/SST fixtures, run_batch integration, `clippy --all-features --all-targets` clean, portable (`--no-default-features`) build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ28utnrHwacwzpZnVUbUx
