### PR TITLE
fix(m68000/m68010): issue MOVEM mem-to-reg discarded read after long transfers

### DIFF
--- a/src/core/instructions/data_movement.rs
+++ b/src/core/instructions/data_movement.rs
@@ -535,12 +535,14 @@ impl CpuCore {
                 self.set_a(reg as usize, addr);
             }
 
-            // 68000 MOVEM memory-to-register performs one discarded word
-            // read after the last operand, for both word and long
-            // transfers. The placement is observable: drivers such as
+            // 68000/68010 MOVEM memory-to-register performs one discarded
+            // word read after the last operand, for both word and long
+            // transfers (both CPUs' timing tables list 3+n / 3+2n reads,
+            // leaving exactly one read unaccounted for after the opcode,
+            // mask, and operands). The placement is observable: drivers such as
             // lide.device point MOVEM.L at the end of a read-sensitive
             // I/O window so that this extra access falls just outside it.
-            if self.cpu_type == CpuType::M68000 {
+            if matches!(self.cpu_type, CpuType::M68000 | CpuType::M68010) {
                 let _ = self.read_16(bus, addr);
             }
         }
@@ -911,6 +913,30 @@ mod tests {
         );
 
         assert_eq!(cycles, 20);
+        assert_eq!(
+            bus.events,
+            vec![
+                Event::ReadWord(0x1000),
+                Event::ReadWord(0x1002),
+                Event::ReadWord(0x1004),
+            ]
+        );
+    }
+
+    #[test]
+    fn m68010_movem_long_memory_to_register_dummies_after_last_transfer() {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68010);
+        let mut bus = TraceBus::default();
+        cpu.dar[10] = 0x1000;
+
+        cpu.exec_movem_to_reg(
+            &mut bus,
+            Size::Long,
+            AddressingMode::AddressIndirect(2),
+            0x0001,
+        );
+
         assert_eq!(
             bus.events,
             vec![

--- a/src/core/instructions/data_movement.rs
+++ b/src/core/instructions/data_movement.rs
@@ -517,10 +517,6 @@ impl CpuCore {
                 self.set_a(reg as usize, addr);
             }
         } else {
-            if self.cpu_type == CpuType::M68000 && size == Size::Long {
-                let _ = self.read_16(bus, addr);
-            }
-
             // Normal order: D0..D7, A0..A7
             for i in 0..16 {
                 if mask & (1 << i) != 0 {
@@ -539,9 +535,12 @@ impl CpuCore {
                 self.set_a(reg as usize, addr);
             }
 
-            // 68000 MOVEM memory-to-register has one discarded word read:
-            // before long transfers, after word transfers.
-            if self.cpu_type == CpuType::M68000 && size == Size::Word {
+            // 68000 MOVEM memory-to-register performs one discarded word
+            // read after the last operand, for both word and long
+            // transfers. The placement is observable: drivers such as
+            // lide.device point MOVEM.L at the end of a read-sensitive
+            // I/O window so that this extra access falls just outside it.
+            if self.cpu_type == CpuType::M68000 {
                 let _ = self.read_16(bus, addr);
             }
         }
@@ -898,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn m68000_movem_long_memory_to_register_dummies_before_first_transfer() {
+    fn m68000_movem_long_memory_to_register_dummies_after_last_transfer() {
         let mut cpu = CpuCore::new();
         cpu.set_cpu_type(CpuType::M68000);
         let mut bus = TraceBus::default();
@@ -916,8 +915,8 @@ mod tests {
             bus.events,
             vec![
                 Event::ReadWord(0x1000),
-                Event::ReadWord(0x1000),
                 Event::ReadWord(0x1002),
+                Event::ReadWord(0x1004),
             ]
         );
     }


### PR DESCRIPTION
## Summary

On a 68000, memory-to-register `MOVEM` performs one discarded extra word read **after the last operand**, for both `.W` and `.L` transfers. `exec_movem_to_reg` currently issues that read at the right place for word transfers, but for long transfers it issues it **before the first transfer, at the start address**.

For plain RAM the difference is invisible, but the placement is observable on read-sensitive hardware, and real Amiga software depends on it: [lide.device](https://github.com/LIV2/lide.device)'s fast sector transfer (`blockcopy.h`, `ata_read_long_movem`) reads the ATA data port — a 512-byte window where *every* read pops the next FIFO word — with `movem.l` sweeps aimed at `window_end - 52`, precisely so the 68000's extra access lands just past the window on the error register:

```c
/* NOTE!
 * The 68000 does an extra memory access at the end of a movem instruction!
 * With the src of end-52 the error reg will be harmlessly read instead. */
"lea.l   460(%0),%0                 \n\t"
".rep 9                             \n\t"
"movem.l (%0),d0-d7/a1-a4/a6        \n\t"
```

With the read issued at the start address instead, it lands *inside* the window and pops a FIFO word, so every 13-register sweep delivers data shifted by one word. Downstream effect (found while debugging the Copperline Amiga emulator, which uses this crate as its CPU core): the driver's RDB scan never sees `RDSK` and hard-disk boot fails on every 68000 machine, while 68020+ configurations work.

## The change

- Move the 68000 discarded word read for `Size::Long` after the transfer loop, unifying it with the (already correct) word-sized case. Cycle counts are unaffected.
- Update the unit test that encoded the early placement (`m68000_movem_long_memory_to_register_dummies_before_first_transfer` → `..._after_last_transfer`).

The trace JIT needs no change: it only admits `MOVEM.W (An)+` over checked fast-memory windows, so I/O-touching MOVEM always runs through the interpreter.

## Verification

- `access_sequence_gap_report` against the SingleStepTests/m68000 MAME transaction logs: MOVEM.l address-sequence mismatches drop from **664 of 1304 cases (50.9%) to zero**; all 2622 MOVEM.w + MOVEM.l cases now match the recorded bus-access sequence exactly.
- `singlestep_m68000_v1_tests` MOVEM.w / MOVEM.l fixture tests pass.
- `cargo test --lib`, `coverage_tests`, `run_batch_tests`, `cargo fmt --check`, `cargo clippy`: clean.
- End-to-end: an Amiga 500 (68000) + Kickstart 3.1 + lide RIDE IDE board under Copperline, patched to this branch, goes from an eternal "insert disk" screen to booting Workbench 3.1 from hard disk.

References: [prb28 MOVEM notes](https://github.com/prb28/m68k-instructions-documentation/blob/master/instructions/movem.md) ("extra memory access at the end"), Yacht timing tables.


## Update: 68010 included

The 68010 shares this behavior: the MC68010 timing tables also list **3+n / 3+2n** reads for memory-to-register MOVEM — after the opcode, mask, and operand words, exactly one read remains in both the `.W` and `.L` cases — and WinUAE's dedicated cycle-exact 68010 core issues that transaction as a discarded 16-bit data read immediately after the transferred block. The gate is now `M68000 | M68010`, with a 68010 long-transfer bus-trace test added. `SCC68070` is left unchanged for lack of documentation either way.
