### PR TITLE
perf(jit): skip cranelift's IR verifier in release builds

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -691,9 +691,40 @@ impl fmt::Debug for TraceJit {
 }
 
 impl TraceJit {
+    /// Flags for the JIT module.
+    ///
+    /// Cranelift's default leaves the IR verifier on. A CPU profile of EV
+    /// Override puts trace compilation at ~7% of the process, several
+    /// times what executing the compiled traces costs, with the verifier a
+    /// large part of it.
+    ///
+    /// The verifier checks IR this crate emits, so it earns its keep in
+    /// debug and test builds -- where a malformed emission should fail
+    /// loudly and near its cause -- and is overhead in release, which runs
+    /// the same emitters the suite already covers.
+    ///
+    /// `opt_level` is deliberately left at cranelift's default. Raising it
+    /// to `speed` trades compile time for code quality, and on this
+    /// workload compilation costs several times what execution does, so it
+    /// measured as a wash-to-regression: verifier-off alone is -7.3% CPU
+    /// (t=-2.85, 7 of 8 paired runs), and adding `opt_level=speed` gives
+    /// back the whole win.
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    const JIT_FLAGS: &'static [(&'static str, &'static str)] = if cfg!(debug_assertions) {
+        &[("enable_verifier", "true")]
+    } else {
+        &[("enable_verifier", "false")]
+    };
+
     fn new() -> Self {
         #[cfg(all(feature = "jit", not(target_family = "wasm")))]
-        let module = JITBuilder::new(default_libcall_names())
+        // Cranelift defaults leave the IR verifier on and optimisation off.
+        // A CPU profile of EV Override puts trace compilation at ~7% of the
+        // process -- several times what executing the compiled traces costs
+        // -- with the verifier and register allocator the largest parts. The
+        // verifier checks IR this crate generates, so it earns its keep in
+        // debug and test builds and is pure overhead in release.
+        let module = JITBuilder::with_flags(Self::JIT_FLAGS, default_libcall_names())
             .ok()
             .map(JITModule::new);
         Self {


### PR DESCRIPTION
Cranelift's defaults leave its IR verifier enabled. The verifier checks that generated IR is well formed — value types against each instruction's signature, exactly one terminator per block, block arguments matching predecessors, dominance for every value use — and its cost is proportional to function size, paid on every trace compiled. It exists to catch bugs in code that *generates* IR, which is what `trace_jit.rs` does.

This PR turns it off in release builds only, via `cfg!(debug_assertions)`: debug and test builds keep verifying every emission the suite exercises. `opt_level` is deliberately left at Cranelift's default — see the measurements.

## What we benchmarked

**1. Whole-application CPU on fixed work (the headline number).** EV Override 1.0.1 running on `benletchford/systemless`, driven headless by a scripted input replay whose events are keyed to *retired instruction count*, so every run performs exactly the same 400,000,000 guest instructions — boot, dialogs, menu, pilot creation, and gameplay — from a pristine copy of the save directory. Metric: child-process CPU seconds (user+sys) for the fixed work. Arms are separate binaries with verified-distinct hashes, alternated within each repetition; the statistic is the within-pair ratio, which cancels machine-load drift (the host was not quiet, which is precisely why the design is paired). 8 pairs:

> **verifier-off vs master: −7.3% CPU (95% CI ±5.0), t = −2.85, faster in 7 of 8 pairs.**

**2. A three-arm control for `opt_level`.** The same instrument with a third arm adding `opt_level=speed` on top of verifier-off measured **+2.7% vs master (t = +0.72, unresolved)** — the optimizer's extra compile time gives back the verifier win. That is why this PR flips only the verifier: on this workload, trace *compilation* costs several times what trace *execution* costs, so trading compile time for code quality is the wrong direction.

**3. Profile attribution (why compilation is worth this attention).** Sampler profiles put trace compilation at ~7% of process CPU on the headless workload and ~5% of active CPU in live GUI flight, versus ~1–3% for executing the compiled traces.

**4. Compile-event counters** (added to `trace-profile` locally for this investigation): a 400M-instruction session performs ~4,000 successful compiles with zero cache evictions, zero recompiles of the same head, zero codegen-stage failures, and ~360 executions per compiled trace. There is no wasteful compilation to eliminate — every trip through Cranelift produces a well-used trace — so the only lever on compile cost is making each compile cheaper, which is what this change does.

Scope: one application, one scripted route, one host; the claim is CPU draw on fixed work, not frame rate (the application is frame-limited).

## The design question

**Turning the verifier off in release trades a safety property for speed, and that call is yours rather than ours.** With it on, a malformed emission fails loudly at compile time, adjacent to its cause. With it off in release, the same bug lowers to incorrect machine code and surfaces as wrong guest behavior, potentially far from its cause. Our reasoning for the split: the verifier checks IR this crate itself constructs, and every emitter is exercised under `debug_assertions` by the test suite, where verification stays on — so the check still runs everywhere it can catch a bug during development, and is dropped only where it re-validates code paths the suite already covers. The counter-argument is real: an emitter bug reachable only in release (or only by a guest shape no test reproduces) would now produce silent corruption instead of a clean failure. If you would rather keep the verifier unconditionally and decline the win, or gate it behind a feature so a release build can re-enable it during debugging, say which and we will restack accordingly.

## Verification

Full local workflow on this head (0.10.14 base): rustfmt clean; `clippy --all-targets --all-features -D warnings` clean; lib (`--features jit`), default, and all-features suites all passing; `cargo doc` clean. Behavior is unchanged by construction in debug and test profiles.
