### PR TITLE
feat(profile): per-head chained-call and chained-retirement counters

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -1164,13 +1164,19 @@ impl TraceJit {
                             watch_pcs,
                             chain_budget - 1,
                         ) {
-                            Some((CachedRunResult::Ran, chained)) => retired += chained,
+                            Some((CachedRunResult::Ran, chained)) => {
+                                #[cfg(feature = "trace-profile")]
+                                super::trace_profile::note_chained(pc, cpu_type, chained);
+                                retired += chained;
+                            }
                             // The continuation's first opcode changed:
                             // the child has already consumed it (ppc/ir
                             // set, pc advanced) and the caller must
                             // dispatch it. Surface the miss while
                             // keeping every instruction retired so far.
                             Some((miss @ CachedRunResult::Miss(_), chained)) => {
+                                #[cfg(feature = "trace-profile")]
+                                super::trace_profile::note_chained(pc, cpu_type, chained);
                                 return Some((miss, retired + chained));
                             }
                             None => {}
@@ -11561,6 +11567,82 @@ mod portable_tests {
             compiled >= 2,
             "exit seeding should compile a continuation inside the loop \
              body in addition to the head trace (found {compiled})"
+        );
+    }
+
+    /// The #100 field-data counters: a guard exit that enters a compiled
+    /// continuation must be distinguishable, per head, from one that
+    /// exits and thrashes. The mixed-path workload above chains for real,
+    /// so its head row must show chained calls bounded by guard exits and
+    /// nonzero chained retirement; a fresh profile shows neither.
+    #[cfg(feature = "trace-profile")]
+    #[test]
+    fn chained_counters_split_productive_exits_from_thrash() {
+        super::super::trace_profile::reset();
+        const CODE_BASE: u32 = 0x7000;
+        let words = [
+            0x0A01, 0x0001, // EORI.B #1,D1
+            0x6602, // BNE.S +2
+            0x5282, // ADDQ.L #1,D2
+            0x1ADC, // MOVE.B (A4)+,(A5)+
+            0x5283, // ADDQ.L #1,D3
+            0x51C8, 0xFFF2, // DBRA D0,head
+            0x60EE, // BRA.S head
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(4, 0x3000);
+        cpu.set_a(5, 0x4000);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        let result = cpu.run_batch(&mut bus, 50_000, &[0]);
+        assert_eq!(result.instructions, 50_000);
+
+        let snapshot = super::super::trace_profile::snapshot();
+        let chaining: Vec<_> = snapshot
+            .rows
+            .iter()
+            .filter(|row| row.chained_calls > 0)
+            .collect();
+        assert!(
+            !chaining.is_empty(),
+            "the mixed-path loop chains, so some head must record chained calls"
+        );
+        for row in &chaining {
+            assert!(
+                row.chained_calls <= row.guarded_branch_exits,
+                "every chain hangs off a guard exit ({:08X}: {} chains, {} exits)",
+                row.start_pc,
+                row.chained_calls,
+                row.guarded_branch_exits
+            );
+            assert!(
+                row.chained_retired > 0,
+                "a chain that ran retired instructions ({:08X})",
+                row.start_pc
+            );
+        }
+        // The split itself: at least one head must show guard exits with
+        // NO chaining (the continuation head's own exits, or pre-chain
+        // exits) -- otherwise the counters could not separate thrash from
+        // productive chaining. If this ever fails because every exit
+        // chains, the workload has changed, not the counters.
+        let thrash = snapshot
+            .rows
+            .iter()
+            .any(|row| row.guarded_branch_exits > 0 && row.chained_calls == 0);
+        let productive = chaining
+            .iter()
+            .any(|row| row.chained_retired >= row.chained_calls);
+        assert!(
+            thrash || productive,
+            "counters must expose at least one side of the split"
         );
     }
 

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -48,6 +48,14 @@ pub struct TraceProfileRow {
     pub jit_retired: u64,
     /// Exits caused by a guarded branch taking an unrecorded direction.
     pub guarded_branch_exits: u64,
+    /// Guard exits at this head that entered a compiled continuation
+    /// trace (bounded chaining). `guarded_branch_exits` alone cannot
+    /// separate a parent that exits and thrashes from one that exits and
+    /// chains productively; this and `chained_retired` make the split.
+    pub chained_calls: u64,
+    /// Guest instructions retired by continuation chains entered from
+    /// this head's guard exits.
+    pub chained_retired: u64,
     /// Trace re-recordings triggered by adaptive branch behavior.
     pub adaptive_rerecords: u64,
     /// The head's recorded loop was classified as a pure poll (a wait):
@@ -494,13 +502,13 @@ impl TraceProfileSnapshot {
         let _ = writeln!(out, "compiled traces by retired instructions");
         let _ = writeln!(
             out,
-            "rank  start_pc  ops      calls      retired avg_ops guard_exits rerecords"
+            "rank  start_pc  ops      calls      retired avg_ops guard_exits chained chain_retired rerecords"
         );
         for (rank, row) in compiled_rows.iter().take(40).enumerate() {
             let average = row.jit_retired as f64 / row.native_calls as f64;
             let _ = writeln!(
                 out,
-                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2} {:>11} {:>9}",
+                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2} {:>11} {:>7} {:>13} {:>9}",
                 rank + 1,
                 row.start_pc,
                 row.compiled_ops,
@@ -508,6 +516,8 @@ impl TraceProfileSnapshot {
                 row.jit_retired,
                 average,
                 row.guarded_branch_exits,
+                row.chained_calls,
+                row.chained_retired,
                 row.adaptive_rerecords
             );
         }
@@ -730,6 +740,9 @@ struct Row {
     native_calls: u64,
     jit_retired: u64,
     guarded_branch_exits: u64,
+    /// See `TraceProfileRow::chained_calls` / `chained_retired`.
+    chained_calls: u64,
+    chained_retired: u64,
     adaptive_rerecords: u64,
     wait_hits: u64,
     /// Whether the most recent completed recording at this head was a
@@ -865,6 +878,8 @@ impl Profile {
                 native_calls: row.native_calls,
                 jit_retired: row.jit_retired,
                 guarded_branch_exits: row.guarded_branch_exits,
+                chained_calls: row.chained_calls,
+                chained_retired: row.chained_retired,
                 adaptive_rerecords: row.adaptive_rerecords,
                 wait_hits: row.wait_hits,
             })
@@ -1156,6 +1171,16 @@ pub(crate) fn note_guarded_branch_exit(pc: u32, cpu_type: CpuType) {
     PROFILE.with_borrow_mut(|profile| {
         let row = profile.0.row(pc, cpu_type);
         row.guarded_branch_exits = row.guarded_branch_exits.saturating_add(1);
+    });
+}
+
+/// A guard exit at `pc` entered a compiled continuation trace which
+/// retired `retired` guest instructions before returning (or missing).
+pub(crate) fn note_chained(pc: u32, cpu_type: CpuType, retired: u32) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.chained_calls = row.chained_calls.saturating_add(1);
+        row.chained_retired = row.chained_retired.saturating_add(u64::from(retired));
     });
 }
 


### PR DESCRIPTION
The per-head chained-call and chained-retirement counters requested in #100's latest round, so the guard-exit re-formation question can be decided on field data.

## What it adds

Two counters per trace head in `trace-profile`, plus two columns in the compiled-traces table:

- **`chained_calls`** — guard exits at this head that entered a compiled continuation trace (the bounded chaining from #101). Incremented whether the chain completed or surfaced a revalidation miss, since either way the exit reached compiled code.
- **`chained_retired`** — guest instructions those chains retired.

As your review noted, a parent's guard-exit ratio alone cannot distinguish ineffective chaining from a parent that exits and then chains productively: `guard_exits` versus `chained_calls` now makes that split per head, and `chained_retired` prices what the chains actually deliver. Attribution is to the parent whose exit spawned the chain; nested chains attribute to their own immediate parent, so a chain-of-chains is not double-counted upward.

## Verification

A focused regression (`chained_counters_split_productive_exits_from_thrash`) drives the mixed-path loop from the existing exit-seeding test — a shape that measurably chains — and asserts: some head records chained calls; every such head has `chained_calls <= guarded_branch_exits`; chains that ran retired instructions; and the table exposes at least one side of the thrash/productive split. The test was mutation-validated: silencing the two `note_chained` call sites makes it fail.

Full local workflow on this head (0.10.14 base): rustfmt clean, `clippy --all-targets --all-features -D warnings` clean, lib/default/all-features suites all passing, `cargo doc` clean; zero deletions against master. Profiler-only — no behavior change outside `trace-profile`.

Next step per the #100 plan: one capped GUI session on this instrumentation, reporting the counters for each guard-exit-dominated parent, posted to #100 — after which that issue narrows to either close-as-answered or one fully specified re-formation proposal.
