### PR TITLE
perf(jit): compile trap-punctuated segments via TrapExit terminals

### DIFF
--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -1923,6 +1923,153 @@ fn bench_movem_frame_loop() {
     );
 }
 
+/// A trap-punctuated loop, a dominant profiled gameplay shape: short
+/// straight-line runs separated by A-lines the host emulates. The bench's
+/// dispatch loop plays the host (each A-line is a no-op that costs one
+/// batch round trip), so the number reflects segment execution plus the
+/// per-segment boundary -- the stage-1 trap-crossing question.
+fn bench_trap_segment_loop() {
+    const INSTRS: u64 = 50_000_000;
+    const CODE_BASE: u32 = 0x6000;
+    let words = [
+        0x5282, // head: ADDQ.L #1,D2
+        0x5283, // ADDQ.L #1,D3
+        0xD682, // ADD.L D2,D3
+        0x2003, // MOVE.L D3,D0- scratch
+        0x4A41, // TST.W D1
+        0xA123, // trap 1
+        0x5285, // ADDQ.L #1,D5
+        0xDA83, // ADD.L D3,D5
+        0x2005, // MOVE.L D5,D0
+        0x4A42, // TST.W D2
+        0xA124, // trap 2
+        0x5281, // ADDQ.L #1,D1
+        0x4A43, // TST.W D3
+        0x51CF, 0xFFE4, // DBRA D7,head
+        0x707F, // MOVEQ #127,D7
+        0x60DE, // BRA.S head
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(7, 0x8000);
+        cpu.set_d(7, 0x7F);
+        cpu
+    };
+    let drive = |cpu: &mut CpuCore, bus: &mut LinearMemoryBus, budget: u64| -> u64 {
+        let mut retired = 0u64;
+        while retired < budget {
+            let chunk = (budget - retired).min(4_096) as u32;
+            let result = cpu.run_batch(bus, chunk, &[]);
+            retired += u64::from(result.instructions);
+            match result.exit {
+                m68k::BatchExit::BudgetExhausted => {}
+                m68k::BatchExit::AlineTrap { .. } => {} // host no-op dispatch
+                other => panic!("unexpected exit {other:?}"),
+            }
+        }
+        retired
+    };
+    let mut warm_cpu = prepare_cpu();
+    drive(&mut warm_cpu, &mut bus, 5_000_000);
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    let retired = drive(&mut cpu, &mut bus, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert!(cpu.d(2) > 5_000, "the loop actually iterated");
+    assert!(
+        cpu.d(1).abs_diff(cpu.d(2)) <= 1,
+        "the two per-iteration counters advance in lockstep"
+    );
+    println!(
+        "batch     trap segment loop       {:8.1} M instr/s",
+        retired as f64 / elapsed / 1_000_000.0
+    );
+}
+
+/// The measured real-world segment shape: ~9-op straight-line runs between
+/// A-lines (a dominant profiled gameplay pattern), so the boundary
+/// cost amortizes over twice the work of the short variant above.
+fn bench_trap_segment_loop_long() {
+    const INSTRS: u64 = 50_000_000;
+    const CODE_BASE: u32 = 0x6000;
+    let words = [
+        0x5282, // head: ADDQ.L #1,D2
+        0x5283, // ADDQ.L #1,D3
+        0xD682, // ADD.L D2,D3
+        0x2003, // MOVE.L D3,D0 - scratch
+        0x4A41, // TST.W D1
+        0x5284, // ADDQ.L #1,D4
+        0xD883, // ADD.L D3,D4
+        0x2004, // MOVE.L D4,D0
+        0x4A42, // TST.W D2
+        0xA123, // trap 1
+        0x5285, // ADDQ.L #1,D5
+        0xDA83, // ADD.L D3,D5
+        0x2005, // MOVE.L D5,D0
+        0x4A44, // TST.W D4
+        0x5286, // ADDQ.L #1,D6
+        0xDC85, // ADD.L D5,D6
+        0x2006, // MOVE.L D6,D0
+        0x4A45, // TST.W D5
+        0x5287, // ADDQ.L #1,D7 - clobbered by the DBRA counter reload path
+        0xA124, // trap 2
+        0x5281, // ADDQ.L #1,D1
+        0x4A43, // TST.W D3
+        0x51CF, 0xFFD2, // DBRA D7,head
+        0x7E7F, // MOVEQ #127,D7
+        0x60CC, // BRA.S head
+    ];
+    let mut bus = LinearMemoryBus::new(0x1_0000);
+    for (index, word) in words.iter().enumerate() {
+        bus.write_word_at(CODE_BASE + index as u32 * 2, *word);
+    }
+    let prepare_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = CODE_BASE;
+        cpu.set_a(7, 0x8000);
+        cpu.set_d(7, 0x7F);
+        cpu
+    };
+    let drive = |cpu: &mut CpuCore, bus: &mut LinearMemoryBus, budget: u64| -> u64 {
+        let mut retired = 0u64;
+        while retired < budget {
+            let chunk = (budget - retired).min(4_096) as u32;
+            let result = cpu.run_batch(bus, chunk, &[]);
+            retired += u64::from(result.instructions);
+            match result.exit {
+                m68k::BatchExit::BudgetExhausted => {}
+                m68k::BatchExit::AlineTrap { .. } => {} // host no-op dispatch
+                other => panic!("unexpected exit {other:?}"),
+            }
+        }
+        retired
+    };
+    let mut warm_cpu = prepare_cpu();
+    drive(&mut warm_cpu, &mut bus, 5_000_000);
+    let mut cpu = prepare_cpu();
+    let start = Instant::now();
+    let retired = drive(&mut cpu, &mut bus, INSTRS);
+    let elapsed = start.elapsed().as_secs_f64();
+    assert!(cpu.d(2) > 5_000, "the loop actually iterated");
+    assert!(
+        cpu.d(1).abs_diff(cpu.d(2)) <= 1,
+        "the two per-iteration counters advance in lockstep"
+    );
+    println!(
+        "batch     trap segment loop long  {:8.1} M instr/s",
+        retired as f64 / elapsed / 1_000_000.0
+    );
+}
+
 /// PEA of an absolute address, rebalanced -- the profile's second-widest
 /// blocked head class after MOVEM. Base blocks the head at the PEA.
 fn bench_pea_abs_loop() {
@@ -2142,6 +2289,14 @@ fn main() {
     }
     if only.as_deref() == Some("movem") {
         bench_movem_frame_loop();
+        return;
+    }
+    if only.as_deref() == Some("trap-segments") {
+        bench_trap_segment_loop();
+        return;
+    }
+    if only.as_deref() == Some("trap-segments-long") {
+        bench_trap_segment_loop_long();
         return;
     }
     if only.as_deref() == Some("pea-abs") {

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -367,6 +367,11 @@ pub struct CpuCore {
     // trace, so eviction can't wedge them.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) trace_record_skip: [u32; 4],
+    /// Expected resume PC after an A-line that closed a trap-boundary
+    /// recording; consumed at the next batch entry to seed the
+    /// continuation segment's head candidacy. Transient host-side state.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) pending_trap_resume: Option<u32>,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) trace_probe_skip: [u32; 4],
     #[cfg_attr(feature = "serde", serde(skip))]
@@ -526,6 +531,7 @@ impl CpuCore {
             fm_base: 0,
             fm_len: 0,
             trace_record_skip: [super::trace_jit::TRACE_PC_NONE; 4],
+            pending_trap_resume: None,
             trace_probe_skip: [super::trace_jit::TRACE_PC_NONE; 4],
             trace_record_skip_at: 0,
             trace_probe_skip_at: 0,

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -620,6 +620,18 @@ impl CpuCore {
         let mut retired: u32 = 0;
         let mut probe_on_entry = true;
 
+        // A recording that closed at an A-line on the previous batch named
+        // its expected continuation; if the host resumed exactly there, the
+        // continuation becomes a trace-head candidate (counting, then
+        // recording, like any backward-branch target). A host that resumed
+        // anywhere else silently drops the hint.
+        if let Some(expected) = self.pending_trap_resume.take()
+            && expected == self.pc
+        {
+            trace_jit::record_trace_target(self.pc, self.cpu_type);
+            probe_on_entry = true;
+        }
+
         loop {
             // The trace JIT's headroom guard compares against
             // `cycles_remaining`; keep it topped up so it can never gate a
@@ -715,10 +727,36 @@ impl CpuCore {
                 }
             };
             if let Some(exit) = exit {
-                // The caller may emulate a surfaced trap and resume at an
-                // unrelated guest PC. Never let an in-progress path recording
-                // cross that host-controlled execution boundary.
-                trace_jit::stop_recording(self, trace_jit::RecordingStop::TrapOrException);
+                // An A-line reached by falling through a recorded region is
+                // a trap-boundary terminal: the region compiles ending at
+                // the trap and the expected resume point (the word after
+                // the A-line) gains head candidacy on the next batch entry,
+                // so segments chain themselves down a trap-punctuated run
+                // (docs/trap-crossing-traces-design.md). Everything else --
+                // F-line, TRAP #n, exceptions, non-sequential arrival --
+                // keeps the previous behavior: the caller may resume at an
+                // unrelated guest PC, so the recording is discarded rather
+                // than allowed to cross a host-controlled boundary.
+                if matches!(exit, BatchExit::AlineTrap { .. }) {
+                    match trace_jit::finish_recording_at_trap(self) {
+                        // Chain quality gate: only a segment the compiler
+                        // accepted right up to this boundary earns a seeded
+                        // continuation; a rejected closure must not extend
+                        // the head chain past code that will never pay.
+                        trace_jit::TrapFinish::Compiled => {
+                            self.pending_trap_resume = Some(self.ppc.wrapping_add(2));
+                        }
+                        trace_jit::TrapFinish::Closed => {}
+                        trace_jit::TrapFinish::None => {
+                            trace_jit::stop_recording(
+                                self,
+                                trace_jit::RecordingStop::TrapOrException,
+                            );
+                        }
+                    }
+                } else {
+                    trace_jit::stop_recording(self, trace_jit::RecordingStop::TrapOrException);
+                }
                 return BatchResult {
                     instructions: retired,
                     exit,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -48,6 +48,15 @@ const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
 /// memory-ALU, and memory-heavy mixes.
 const TRACE_MIN_INDIRECT_JSR_OPS: usize = 7;
 const TRACE_HOT_THRESHOLD: u8 = 2;
+
+/// Hits a head must re-accumulate after its first trap-boundary closure was
+/// deferred (see `finish_recording_at_trap`): the value only needs to sit
+/// between how often one-shot startup code repeats (once or twice through
+/// boot) and how often a gameplay loop repeats (unbounded), with margin on
+/// both sides -- any small multiple of the base hot threshold satisfies
+/// that, so the deferral is expressed as one rather than as a tuned
+/// constant of its own.
+const TRACE_TRAP_SEGMENT_HOT_THRESHOLD: u8 = 8 * TRACE_HOT_THRESHOLD;
 /// How many compiled continuations one guest entry may chain through after
 /// guard exits. Bounds recursion; each level also shrinks the instruction
 /// budget by what the parent retired.
@@ -212,6 +221,12 @@ pub(crate) enum JitBitSource {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum JitTraceOp {
+    /// Trap-boundary terminal: the recorded op is the A-line word itself
+    /// (so SMC validation covers it); executing it sets `pc` to the trap's
+    /// address, retires no guest instruction, charges no cycles, and ends
+    /// the trace. The batch loop then fetches the A-line and surfaces it
+    /// to the host exactly as an interpreted run would.
+    TrapExit,
     Nop,
     MoveReg {
         src: JitDirectReg,
@@ -582,6 +597,9 @@ enum RecordingEnd {
     /// The region closed on its own terms: a back edge, a recorded branch,
     /// or an operation limit.
     Region,
+    /// The region ran into an A-line trap; the `TrapExit` terminal has
+    /// already been appended and the region compiles ending there.
+    TrapBoundary,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -699,6 +717,10 @@ enum TraceSlot {
         /// that ended at a qualifying call boundary so the head's next
         /// recording attempts to record through it.
         allow_call_through: bool,
+        /// A recording from this head closed at an A-line boundary and was
+        /// deferred instead of compiled; the head must re-reach
+        /// `TRACE_TRAP_SEGMENT_HOT_THRESHOLD` hits before recording again.
+        deferred_trap: bool,
     },
     Rejected {
         pc: u32,
@@ -1126,6 +1148,7 @@ impl TraceJit {
                     hits: 0,
                     adaptive_rerecords,
                     allow_call_through,
+                    deferred_trap: false,
                 };
                 cpu.trace_record_skip = [TRACE_PC_NONE; 4];
                 cpu.trace_probe_skip = [TRACE_PC_NONE; 4];
@@ -1196,9 +1219,15 @@ impl TraceJit {
                 hits,
                 adaptive_rerecords,
                 allow_call_through,
+                deferred_trap,
             } if *counted_pc == pc && *counted_type == cpu_type => {
                 *hits = hits.saturating_add(1);
-                if *hits < TRACE_HOT_THRESHOLD {
+                let threshold = if *deferred_trap {
+                    TRACE_TRAP_SEGMENT_HOT_THRESHOLD
+                } else {
+                    TRACE_HOT_THRESHOLD
+                };
+                if *hits < threshold {
                     return None;
                 }
                 self.recording = Some(TraceRecording {
@@ -1384,6 +1413,7 @@ impl TraceJit {
                         hits: 1,
                         adaptive_rerecords: 0,
                         allow_call_through: self.has_call_permission(pc),
+                        deferred_trap: false,
                     };
                     TRACE_JIT_HAS_CANDIDATES.store(true, Ordering::Relaxed);
                 }
@@ -1401,6 +1431,7 @@ impl TraceJit {
                     hits: 1,
                     adaptive_rerecords: 0,
                     allow_call_through: self.has_call_permission(pc),
+                    deferred_trap: false,
                 };
                 TRACE_JIT_HAS_CANDIDATES.store(true, Ordering::Relaxed);
             }
@@ -1442,9 +1473,15 @@ impl TraceJit {
                 hits,
                 adaptive_rerecords,
                 allow_call_through,
+                deferred_trap,
             } if *counted_pc == exit_pc && *counted_type == cpu_type => {
                 *hits = hits.saturating_add(1);
-                if entry_watched || *hits < TRACE_HOT_THRESHOLD || self.recording.is_some() {
+                let threshold = if *deferred_trap {
+                    TRACE_TRAP_SEGMENT_HOT_THRESHOLD
+                } else {
+                    TRACE_HOT_THRESHOLD
+                };
+                if entry_watched || *hits < threshold || self.recording.is_some() {
                     return ExitSeed::None;
                 }
                 let adaptive_rerecords = *adaptive_rerecords;
@@ -1480,6 +1517,7 @@ impl TraceJit {
                     hits: 1,
                     adaptive_rerecords: 0,
                     allow_call_through: permission,
+                    deferred_trap: false,
                 };
                 ExitSeed::None
             }
@@ -1547,6 +1585,94 @@ impl TraceJit {
     #[cfg_attr(not(feature = "trace-profile"), allow(unused_variables))]
     fn finish_recording(&mut self, cpu: &mut CpuCore, exit_pc: u32, end: RecordingEnd) {
         self.finish_recording_with_retry(cpu, exit_pc, end, false);
+    }
+
+    /// Close the current recording at the A-line whose word is in `cpu.ir`
+    /// at `cpu.ppc`, appending the `TrapExit` terminal, when the trap is
+    /// the region's sequential continuation. Returns false (leaving the
+    /// recording for the ordinary discard path) when there is no recording,
+    /// nothing was recorded yet, or execution arrived at the trap by a jump
+    /// rather than by falling through from the recorded tail.
+    fn finish_recording_at_trap(&mut self, cpu: &mut CpuCore) -> TrapFinish {
+        let trap_pc = cpu.ppc;
+        let opcode = cpu.ir as u16;
+        let Some(recording) = self.recording.as_ref() else {
+            cpu.trace_recording = false;
+            return TrapFinish::None;
+        };
+        let sequential = recording
+            .ops
+            .last()
+            .is_some_and(|op| op.pc.wrapping_add(op.length() as u32) == trap_pc);
+        if !sequential || opcode & 0xF000 != 0xA000 {
+            return TrapFinish::None;
+        }
+        let start_pc = recording.start_pc;
+        let cpu_type = recording.cpu_type;
+        let adaptive_rerecords = recording.adaptive_rerecords;
+        let allow_call_through = recording.allow_call_through;
+        // Deferred compilation: most trap-terminal regions in boot-like
+        // phases close once or twice and never repay a compile (measured
+        // over a profiled headless boot: +31.6K native calls bought
+        // +0.27M retired). Length cannot separate those from the
+        // trap-punctuated gameplay loops this terminal exists for --
+        // repetition can. The first closure therefore compiles nothing:
+        // it re-arms the head to count with the raised trap-segment
+        // threshold, and only a head that comes back that hot records
+        // again and compiles here.
+        let idx = trace_cache_index(start_pc);
+        let proven = matches!(
+            &self.slots[idx],
+            TraceSlot::Counting {
+                pc,
+                cpu_type: slot_type,
+                deferred_trap: true,
+                ..
+            } if *pc == start_pc && *slot_type == cpu_type
+        );
+        if !proven {
+            self.recording = None;
+            cpu.trace_recording = false;
+            self.slots[idx] = TraceSlot::Counting {
+                pc: start_pc,
+                cpu_type,
+                hits: 0,
+                adaptive_rerecords,
+                allow_call_through,
+                deferred_trap: true,
+            };
+            return TrapFinish::Closed;
+        }
+        let Some(recording) = self.recording.as_mut() else {
+            unreachable!("recording checked above");
+        };
+        recording.ops.push(TraceBuildOp {
+            opcode,
+            extension: None,
+            extension2: None,
+            pc: trap_pc,
+            op: JitTraceOp::TrapExit,
+        });
+        self.finish_recording(cpu, trap_pc, RecordingEnd::TrapBoundary);
+        // Seed the continuation only when a trace now really ends at this
+        // trap. A closure that rejected (or salvaged back to an interior
+        // branch) yields no compiled segment reaching the boundary, and
+        // seeding past it would extend head chains through code the
+        // compiler has already refused -- planting probe candidates that
+        // alias-thrash the direct-mapped slot array without ever paying.
+        let compiled_to_trap = matches!(
+            &self.slots[trace_cache_index(start_pc)],
+            TraceSlot::Compiled(t) if t.pc == start_pc
+                && t.cpu_type == cpu_type
+                && t.ops.last().is_some_and(
+                    |op| matches!(op.op, JitTraceOp::TrapExit) && op.pc == trap_pc,
+                )
+        );
+        if compiled_to_trap {
+            TrapFinish::Compiled
+        } else {
+            TrapFinish::Closed
+        }
     }
 
     /// `call_retry_pending` marks the one case where a rescued prefix is
@@ -1882,6 +2008,7 @@ impl TraceJit {
                         hits: 0,
                         adaptive_rerecords: 0,
                         allow_call_through: true,
+                        deferred_trap: false,
                     };
                     // The reject pushed the head into the probe-skip
                     // filter; clear it so the retry can be probed.
@@ -2014,7 +2141,10 @@ impl TraceJit {
         // Short checked memory ALU regions do not amortize trace validation
         // and the native/Rust boundary. Keep those on the decoded-memory path
         // unless the measured indirect-call length threshold above provides
-        // enough independent work to cover the fixed cost.
+        // enough independent work to cover the fixed cost. Trap-boundary
+        // segments get NO exemption here: a TrapExit ending adds trap
+        // dispatch and re-entry on top of the fixed costs, so the
+        // amortisation economics only tighten.
         if !self_loop
             && !ends_in_indirect_jsr
             && ops.iter().any(|op| {
@@ -2260,6 +2390,23 @@ impl TraceJit {
                     cycles_before: cycles_value,
                 };
                 let op_cycles = match op.op {
+                    JitTraceOp::TrapExit => {
+                        // Trap boundary: unconditionally take a bail exit --
+                        // `pc` lands on the A-line, retired counts only the
+                        // ops before it. The continuation block is dead
+                        // (TrapExit is always the final op) but keeps the
+                        // emit loop's shape uniform.
+                        let bail = builder.create_block();
+                        bails.push(BailReq {
+                            block: bail,
+                            pc: op.pc,
+                            at: bail_at,
+                        });
+                        builder.ins().jump(bail, &[]);
+                        let cont = builder.create_block();
+                        builder.switch_to_block(cont);
+                        builder.ins().iconst(types::I32, 0)
+                    }
                     JitTraceOp::Branch {
                         condition,
                         displacement,
@@ -2602,6 +2749,9 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
     let mut mem_written_flags: u8 = 0;
     for op in body {
         match op.op {
+            // A trap boundary never appears inside a self-loop body; if it
+            // somehow did, the loop is not a pure poll.
+            JitTraceOp::TrapExit => return false,
             // No-ops mutate nothing.
             JitTraceOp::Nop => {}
             // Interior branches make the recorded path non-unique for
@@ -2798,6 +2948,34 @@ pub(crate) fn try_execute_trace<B: AddressBus>(
     })
 }
 
+/// Finish an in-progress recording at an A-line trap: the trap word itself
+/// becomes the region's `TrapExit` terminal and the region compiles ending
+/// there (docs/trap-crossing-traces-design.md). Returns whether a recording
+/// was closed this way; the caller falls back to the ordinary discard
+/// otherwise. `cpu.ppc` must be the A-line's address and `cpu.ir` its word,
+/// as the batch loop's miss contract guarantees.
+pub(crate) fn finish_recording_at_trap(cpu: &mut CpuCore) -> TrapFinish {
+    if !cpu.trace_recording {
+        return TrapFinish::None;
+    }
+    with_trace_jit(|jit| jit.finish_recording_at_trap(cpu))
+}
+
+/// How a recording responded to an A-line at its sequential continuation.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TrapFinish {
+    /// No recording, nothing recorded, or non-sequential arrival: the
+    /// caller applies the ordinary discard path.
+    None,
+    /// The recording closed at the trap but no compiled segment reaches
+    /// the boundary (rejected, or salvaged back to an interior branch).
+    Closed,
+    /// A compiled segment now ends exactly at this trap; the boundary
+    /// has proven worth crossing, so the caller may seed the post-trap
+    /// continuation as a head candidate.
+    Compiled,
+}
+
 pub(crate) fn record_trace_target(pc: u32, cpu_type: CpuType) {
     with_trace_jit(|jit| jit.record_trace_target(pc, cpu_type));
 }
@@ -2874,6 +3052,8 @@ fn push_probe_skip(cpu: &mut CpuCore, pc: u32) {
 impl JitTraceOp {
     fn max_cycles(self) -> i32 {
         match self {
+            // The A-line itself is not executed by the trace.
+            Self::TrapExit => 0,
             Self::Nop => 4,
             Self::MoveReg { .. } => 4,
             Self::Moveq { .. } => 4,
@@ -3102,7 +3282,7 @@ impl JitTraceOp {
     fn ends_trace(self) -> bool {
         matches!(
             self,
-            Self::Branch { .. } | Self::Dbcc { .. } | Self::IndirectJsr { .. }
+            Self::Branch { .. } | Self::Dbcc { .. } | Self::IndirectJsr { .. } | Self::TrapExit
         )
     }
 
@@ -4329,6 +4509,11 @@ fn execute_portable_trace(cpu: &mut CpuCore, ops: &[TraceBuildOp], spans: CodeSp
 /// from this op was committed.
 #[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
 fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) -> Option<i32> {
+    if matches!(op.op, JitTraceOp::TrapExit) {
+        // Trap boundary: exit with `pc` on the A-line and nothing retired
+        // for this op -- the bail convention already does exactly that.
+        return None;
+    }
     if let JitTraceOp::MoveMem { size, src, dst } = op.op {
         return execute_portable_move_mem(cpu, size, src, dst, spans);
     }
@@ -5265,6 +5450,9 @@ fn execute_portable_move_mem(
 #[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
 fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
     match op.op {
+        JitTraceOp::TrapExit => {
+            unreachable!("TrapExit bails in execute_portable_op before reaching the register path")
+        }
         JitTraceOp::Nop => 4,
         JitTraceOp::Moveq { reg, data } => {
             cpu.dar[reg as usize] = data;
@@ -5850,6 +6038,9 @@ fn emit_jit_op(
 ) -> Value {
     let trace_pc = op.pc;
     match op.op {
+        JitTraceOp::TrapExit => {
+            unreachable!("TrapExit is emitted as an unconditional bail in the main emit loop")
+        }
         JitTraceOp::Nop => cycles_const(builder, 4),
         JitTraceOp::MoveImmReg { reg, size, value } => {
             let imm = iconst_u32(builder, value);
@@ -15622,6 +15813,234 @@ mod portable_tests {
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    /// The stage-1 trap-crossing shape (docs/trap-crossing-traces-design.md):
+    /// a DBRA loop whose body is punctuated by two A-lines. Segment heads
+    /// must chain themselves down the run -- the loop head compiles ending
+    /// at trap 1, the seeded post-trap heads compile ending at trap 2 and at
+    /// the closing DBRA -- and executing the segments must land `pc` on each
+    /// A-line with only the real instructions retired.
+    #[test]
+    fn trap_punctuated_loop_compiles_and_executes_as_chained_segments() {
+        const A: u32 = 0x0100;
+        const TRAP1: u32 = 0x0106;
+        const CONT: u32 = 0x0108;
+        const TRAP2: u32 = 0x010E;
+        const TAIL: u32 = 0x0110;
+        let words = [
+            0x5282, // head: ADDQ.L #1,D2
+            0x5283, // ADDQ.L #1,D3
+            0x5284, // ADDQ.L #1,D4
+            0xA123, // trap 1
+            0x5285, // cont: ADDQ.L #1,D5
+            0x5286, // ADDQ.L #1,D6
+            0x5287, // ADDQ.L #1,D7
+            0xA124, // trap 2
+            0x4A41, // tail: TST.W D1
+            0x5281, // ADDQ.L #1,D1
+            0x51C8, 0xFFEA, // DBRA D0, head
+            0xA000, // sentinel
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in words.iter().enumerate() {
+            bus.write_word_at(A + index as u32 * 2, *word);
+        }
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = A;
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 400);
+
+        // Drive the loop the way a host does: emulate every A-line as a
+        // no-op (pc has already advanced past the word) and stop at the
+        // sentinel.
+        let mut batches = 0;
+        loop {
+            let result = cpu.run_batch(&mut bus, 65_536, &[]);
+            match result.exit {
+                crate::BatchExit::AlineTrap { opcode: 0xA000 } => break,
+                crate::BatchExit::AlineTrap { .. } => {}
+                crate::BatchExit::BudgetExhausted => {}
+                other => panic!("unexpected exit {other:?}"),
+            }
+            batches += 1;
+            assert!(batches < 100_000, "loop diverged");
+        }
+        // 401 iterations, three counters each.
+        assert_eq!(cpu.d(2), 401);
+        assert_eq!(cpu.d(5), 401);
+        assert_eq!(cpu.d(1), 401);
+
+        // All three segments compiled, each ending at its boundary.
+        for (head, terminal, kind) in [
+            (A, Some(TRAP1), "loop head -> trap 1"),
+            (CONT, Some(TRAP2), "post-trap-1 -> trap 2"),
+            (TAIL, None, "post-trap-2 -> DBRA"),
+        ] {
+            with_trace_jit(|jit| match &jit.slots[trace_cache_index(head)] {
+                TraceSlot::Compiled(trace) => {
+                    assert_eq!(trace.pc, head, "{kind}: compiled at its head");
+                    let last = trace.ops.last().expect("ops");
+                    match terminal {
+                        Some(trap_pc) => {
+                            assert_eq!(
+                                last.op,
+                                JitTraceOp::TrapExit,
+                                "{kind}: must end in the trap terminal"
+                            );
+                            assert_eq!(last.pc, trap_pc, "{kind}: terminal at the A-line");
+                        }
+                        None => assert!(
+                            matches!(last.op, JitTraceOp::Dbcc { .. }),
+                            "{kind}: closes on the real branch"
+                        ),
+                    }
+                }
+                _ => panic!("{kind}: expected a compiled trace"),
+            });
+        }
+
+        // Executing the first segment retires exactly its three real ops
+        // and parks `pc` on the A-line, ready for host dispatch.
+        cpu.pc = A;
+        let before = (cpu.d(2), cpu.d(3), cpu.d(4));
+        let (result, retired) =
+            try_execute_trace(&mut cpu, &mut bus, CpuType::M68040, 1_000, false, &[])
+                .expect("compiled segment executes");
+        assert!(matches!(result, CachedRunResult::Ran));
+        assert_eq!(retired, 3, "three real ops, the A-line not counted");
+        assert_eq!(cpu.pc, TRAP1, "pc parked on the trap for host dispatch");
+        assert_eq!(
+            (cpu.d(2), cpu.d(3), cpu.d(4)),
+            (before.0 + 1, before.1 + 1, before.2 + 1)
+        );
+
+        // Rewriting the trap word is self-modifying code over the recorded
+        // region: the segment must refuse to run stale semantics.
+        bus.write_word_at(TRAP1, 0xA125);
+        cpu.pc = A;
+        let after_smc = try_execute_trace(&mut cpu, &mut bus, CpuType::M68040, 1_000, false, &[]);
+        match after_smc {
+            None => {}
+            Some((CachedRunResult::Miss(opcode), 0)) => assert_eq!(opcode, 0x5282),
+            Some((CachedRunResult::Miss(_), _)) => {}
+            Some((CachedRunResult::Ran, _)) => {
+                panic!("a rewritten trap word must invalidate the segment")
+            }
+        }
+    }
+
+    /// finish_recording_at_trap refuses non-sequential arrival and non-A-line
+    /// words: the recording is left for the ordinary discard path.
+    #[test]
+    fn trap_boundary_finish_requires_sequential_aline() {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        with_trace_jit(|jit| {
+            jit.recording = Some(TraceRecording {
+                start_pc: 0x0100,
+                cpu_type: CpuType::M68040,
+                ops: vec![TraceBuildOp {
+                    opcode: 0x5282,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0100,
+                    op: JitTraceOp::AddqSubqReg {
+                        reg: 2,
+                        data: 1,
+                        size: Size::Long,
+                        is_sub: false,
+                    },
+                }],
+                allow_call_through: false,
+                pending_return: None,
+                adaptive_rerecords: 0,
+            });
+        });
+        cpu.trace_recording = true;
+        // Non-sequential: the A-line is not at 0x0102.
+        cpu.ppc = 0x0200;
+        cpu.ir = 0xA123;
+        assert_eq!(finish_recording_at_trap(&mut cpu), TrapFinish::None);
+        // Sequential but not an A-line word.
+        cpu.ppc = 0x0102;
+        cpu.ir = 0x4E71;
+        assert_eq!(finish_recording_at_trap(&mut cpu), TrapFinish::None);
+        // The recording is still open for the ordinary paths.
+        with_trace_jit(|jit| assert!(jit.recording.is_some()));
+        stop_recording(&mut cpu, RecordingStop::TrapOrException);
+        with_trace_jit(|jit| assert!(jit.recording.is_none()));
+    }
+
+    /// The first sequential trap-boundary closure at a head compiles
+    /// nothing: it is deferred, re-arming the head to count with the
+    /// raised trap-segment threshold. Only a head that comes back that
+    /// hot compiles at its second closure.
+    #[test]
+    fn trap_boundary_first_closure_defers_and_rearms_the_head() {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        let make_recording = || TraceRecording {
+            start_pc: 0x0100,
+            cpu_type: CpuType::M68040,
+            ops: vec![TraceBuildOp {
+                opcode: 0x5282,
+                extension: None,
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 2,
+                    data: 1,
+                    size: Size::Long,
+                    is_sub: false,
+                },
+            }],
+            allow_call_through: false,
+            pending_return: None,
+            adaptive_rerecords: 0,
+        };
+        with_trace_jit(|jit| {
+            jit.slots[trace_cache_index(0x0100)] = TraceSlot::Empty;
+            jit.recording = Some(make_recording());
+        });
+        cpu.trace_recording = true;
+        cpu.ppc = 0x0102;
+        cpu.ir = 0xA123;
+        // First closure: deferred, not compiled.
+        assert_eq!(finish_recording_at_trap(&mut cpu), TrapFinish::Closed);
+        assert!(!cpu.trace_recording);
+        with_trace_jit(|jit| {
+            assert!(jit.recording.is_none());
+            assert!(matches!(
+                &jit.slots[trace_cache_index(0x0100)],
+                TraceSlot::Counting {
+                    pc: 0x0100,
+                    hits: 0,
+                    deferred_trap: true,
+                    ..
+                }
+            ));
+            // The head must now re-reach the raised threshold before the
+            // probe path records again.
+            jit.recording = Some(make_recording());
+        });
+        cpu.trace_recording = true;
+        cpu.ppc = 0x0102;
+        cpu.ir = 0xA123;
+        // Second closure at the now-deferred head: single-op region, so the
+        // compile gate rejects it -- but it must NOT defer again (Closed
+        // comes from the too-short rejection, and the slot moves off
+        // Counting instead of re-arming).
+        assert_eq!(finish_recording_at_trap(&mut cpu), TrapFinish::Closed);
+        with_trace_jit(|jit| {
+            assert!(jit.recording.is_none());
+            assert!(matches!(
+                &jit.slots[trace_cache_index(0x0100)],
+                TraceSlot::Rejected { pc: 0x0100, .. }
+            ));
+        });
+    }
+
     #[test]
     fn blocked_recording_salvages_the_prefix_through_the_last_branch() {
         // Nine admissible ops (the last a recorded interior branch), then
@@ -16020,6 +16439,7 @@ mod portable_tests {
                 TraceSlot::Counting {
                     pc,
                     allow_call_through: true,
+                    deferred_trap: false,
                     ..
                 } if *pc == HEAD
             ),
@@ -16032,6 +16452,7 @@ mod portable_tests {
             TraceSlot::Counting {
                 pc,
                 allow_call_through: false,
+                    deferred_trap: false,
                 ..
             } if *pc == COLLIDER
         ));

--- a/tests/run_batch_tests.rs
+++ b/tests/run_batch_tests.rs
@@ -1632,6 +1632,82 @@ fn memory_and_loop_matches_step() {
     });
 }
 
+/// A trap-punctuated loop (a common gameplay shape): every segment
+/// between A-lines becomes a compiled trace under the stage-1 trap-crossing
+/// design, and the batched run must stay bit-identical to step() with the
+/// same host-emulated no-op traps.
+#[test]
+fn trap_punctuated_loop_matches_step_across_aline_dispatch() {
+    let words: &[u16] = &[
+        0x5282, // $1000: ADDQ.L #1,D2
+        0x5283, // ADDQ.L #1,D3
+        0xD682, // ADD.L D2,D3
+        0xA123, // trap 1
+        0x5285, // ADDQ.L #1,D5
+        0xDA83, // ADD.L D3,D5
+        0x3685, // MOVE.W D5,(A3)
+        0xA124, // trap 2
+        0x4A41, // TST.W D1
+        0x5281, // ADDQ.L #1,D1
+        0x51C8, 0xFFEA, // DBRA D0,$1000
+        0xA000, // sentinel
+    ];
+    let bytes = assemble(words);
+    let mk_cpu = || {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0x1000;
+        cpu.set_sr(0x2700);
+        cpu.set_a(7, 0x9000);
+        cpu.set_a(3, 0x4000);
+        cpu.set_d(0, 500);
+        cpu
+    };
+
+    let mut bus_a = FastRamBus::new(0x20000);
+    bus_a.fm_len = 0;
+    bus_a.load(0x1000, &bytes);
+    let mut cpu_a = mk_cpu();
+    let mut steps: u64 = 0;
+    loop {
+        match cpu_a.step(&mut bus_a) {
+            m68k::StepResult::Ok { .. } => steps += 1,
+            m68k::StepResult::AlineTrap { opcode: 0xA000 } => break,
+            m68k::StepResult::AlineTrap { .. } => {} // host no-op trap
+            other => panic!("unexpected step result {other:?}"),
+        }
+        assert!(steps < 10_000_000, "step run diverged");
+    }
+
+    let mut bus_b = FastRamBus::new(0x20000);
+    bus_b.load(0x1000, &bytes);
+    let mut cpu_b = mk_cpu();
+    let mut batched: u64 = 0;
+    loop {
+        let result = cpu_b.run_batch(&mut bus_b, 4_096, &[]);
+        batched += result.instructions as u64;
+        match result.exit {
+            BatchExit::BudgetExhausted => continue,
+            BatchExit::AlineTrap { opcode: 0xA000 } => break,
+            BatchExit::AlineTrap { .. } => continue, // host no-op trap
+            other => panic!("unexpected batch exit {other:?}"),
+        }
+    }
+
+    assert_eq!(steps, batched, "instruction count");
+    assert_eq!(cpu_a.pc, cpu_b.pc, "pc");
+    assert_eq!(cpu_a.get_sr(), cpu_b.get_sr(), "sr");
+    for i in 0..8 {
+        assert_eq!(cpu_a.d(i), cpu_b.d(i), "D{i}");
+        assert_eq!(cpu_a.a(i), cpu_b.a(i), "A{i}");
+    }
+    assert_eq!(bus_a.mem, bus_b.mem, "memory contents");
+    assert_eq!(cpu_b.d(1), 501, "the loop ran to completion");
+}
+
+/// The ROM caller-save idiom: MOVEM.L push, body, MOVEM.L pop, loop.
+/// The counters live outside the saved mask (the pop restores D2/D3/A2
+/// every iteration). Must match step() exactly through the lifecycle.
 /// PEA of an absolute address in a loop, rebalanced each iteration.
 #[test]
 fn pea_abs_loop_matches_step() {


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday. **Now a single commit directly on `master` v0.11.0 (`01a4f7b`)**: the original base PRs (#111 #112 #131 #133) have merged, #128 was closed, and the 2026-08-20 restack keeps the generic mechanism only — no verifier-off carry, no stacked work. Design doc: `trap-crossing-traces-design.md` (attached in a comment).

## Why

After the current round of optimizations, over half of EV Override's gameplay main-thread time is the interpreter executing **trap-punctuated straight-line code** — runs of ~9 instructions between A-line traps (66 M nine-instruction batches in one measured crawl session). Those runs contain no backward branch and no closing branch, so under the current rules they can never become traces: heads arise only at backward-branch targets, and a region only compiles if it ends in a branch. The admission census puts everything reachable by *widening admission* at ~2 % of guest dispatch; this shape is the other ~98 % of interpreted execution.

## What

A region may now end **at** an A-line:

- **`TrapExit` terminal.** The trap word itself is recorded as the region's final op — its two bytes are real guest memory, so SMC validation covers the boundary exactly (a rewritten trap word invalidates the trace). Executing the terminal takes the existing bail convention: `pc` lands on the A-line, the terminal is not retired, and the batch loop surfaces the trap to the host exactly as an interpreted run would. **Zero changes to the host protocol.**
- **Continuation seeding, quality-gated.** When a recording closes at a trap *and a compiled segment now really ends at that boundary* (`TrapFinish::Compiled`), the expected resume point (trap + 2) is remembered (`CpuCore::pending_trap_resume`) and granted head candidacy at the next batch entry *if the host resumed exactly there* — a host that resumes anywhere else (LoadSeg-style flow traps) silently drops the hint. Segments chain themselves down a trap-punctuated run: `[head..trap₁) [trap₁+2..trap₂) … [tail..branch]`. A closure the compiler rejected does **not** seed: chains stop at boundaries that don't pay, so head-candidate growth tracks compiled segments rather than every trap crossing (this gate was added after headless A/B showed ungated seeding churning the direct-mapped slot array).
- `TRACE_MIN_OPS` still gates tiny segments, and the `LinearMemoryAlu` amortization refusal now applies to trap-terminal regions like any other (an earlier draft waived it; the restack dropped that exemption per review — a `TrapExit` ending adds trap dispatch and re-entry on top of the fixed entry costs, so the amortization economics only tighten). F-line, `TRAP #n`, exceptions, and non-sequential arrival keep the previous discard-the-recording behavior.

## Evidence

**Focused** (`microbench trap-segments` / `trap-segments-long`: DBRA loops with segments separated by host-emulated A-lines; 50 M instructions per run; interleaved pairs, arms differ only in this commit; within-pair ratios are the metric):

| shape | base → this PR (M instr/s, 3 pairs) | win |
|---|---|---|
| 5/4/2-op segments | 28.5→35.4, 31.1→36.3, 32.1→39.8 | +17–24 % |
| 9-op segments (the measured gameplay shape) | 34.9→50.3, 38.6→54.3, 39.4→57.4 | **+41–46 %** |

This is the experiment the decoded-run tier (#130) failed: native segments plus one probe/entry beat interpreting the run, where decoded replay did not — and the win scales with segment length, so the ~9-op trap-punctuated gameplay runs sit in the +40 % regime.

**Restack re-verification (2026-08-23):** the tables above were measured on the original stacked tree. Re-run on the restacked head against `01a4f7b` directly (same protocol: 3 interleaved pairs per shape, alternating order, 50 M instructions per run), the 9-op gameplay shape reproduces at **+39–50 %** (49.6→71.1, 53.7→74.4, 49.3→74.1 M instr/s) and the 5/4/2-op shape shows +6–21 % (39.1→41.4, 39.4→44.6, 40.1→48.6) — same ordering, with the short-segment spread widened by background host load. The bench segments are register-only, so the dropped amortization exemption does not affect them.

**Whole-app** (EV Override under Systemless, real GUI): four interleaved sessions (launch → title crawl ~20 s → flight ~20 s → close), baseline = systemless at a fixed commit + the pending PRs, candidate = the same + this PR. Metric: host work per guest instruction (macOS `/usr/bin/time -l` counters divided by the emulator's own retired-instruction total at close), which cancels session length and phase mix:

| pair | host instr / guest instr | host cycles / guest instr |
|---|---|---|
| 1 | 377.06 → 376.44 (−0.17 %) | 195.54 → 192.57 (**−1.52 %**) |
| 2 | 381.69 → 374.45 (−1.90 %) | 195.23 → 192.67 (**−1.31 %**) |

The baseline's cycles ratio is stable to ±0.2 % across three same-day sessions (194.81/195.54/195.23), so the consistent −1.3…−1.5 % cycles delta is well outside session noise.

Provenance: the whole-app pairs were collected on the pre-restack stacked tree; both arms shared the identical base (including then-open #128), so the delta isolates this commit's mechanism, but the exact figures predate the restack's two policy changes (the dropped amortization exemption above, and the re-record threshold now derived as `8 × TRACE_HOT_THRESHOLD` — the same value, 16). The focused microbench has been re-verified on the restacked head (previous section); the GUI pairs have not been re-collected.

**Boot-phase cost, disclosed:** headless boot A/B (400 M guest instructions, interleaved 3 pairs, host counters) bounds the m68k-side cost at ≈ +0.8 % host instructions during boot — boot's trap-punctuated code compiles segments but barely repeats them (census: +31.6 K native calls bought only +269 K retired). Two policy responses are in the commit: a chain quality gate (only a boundary that compiled seeds the next continuation) and deferred compilation (a head's first trap-boundary closure compiles nothing; it re-arms the head to count to `TRACE_TRAP_SEGMENT_HOT_THRESHOLD` — derived as `8 × TRACE_HOT_THRESHOLD` = 16 since the restack, so only re-proven-hot heads compile). The GUI numbers above are net of this tax.

**Where the rest of the win lives:** the microbench asymptote is the host trap dispatch round trip stage 1 deliberately keeps. Eliminating it (dispatching simple HLE traps from inside a running trace) is the stage-2 design sketched in the design doc — posted for discussion rather than implemented here.

## Tests

- A DBRA loop punctuated by two A-lines: all three segments compile (each verified to end at its boundary — `TrapExit` at the A-line's address, the tail on its real branch); executing the first segment retires exactly its real ops with `pc` parked on the trap; rewriting the trap word refuses stale execution (SMC). Runs under both the native and portable executors.
- `finish_recording_at_trap` refuses non-sequential arrival and non-A-line words, leaving the recording for the ordinary discard path.
- A `run_batch`-vs-`step` differential with host-emulated no-op traps stays bit-identical (pc/sr/all registers/memory/instruction counts) across 501 iterations.
- Full suites at the restacked head (re-run 2026-08-23): 839 default / 936 all-features; clippy `-D warnings`; fmt; CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3pHH4jDhVuFn8ZeWwkKmA

