### PR TITLE
perf(jit): re-record compiled-before heads instead of durably poisoning them

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -672,6 +672,20 @@ pub(crate) struct TraceJit {
     /// beyond two -- losing an entry only costs the one extra blocked
     /// attempt that was the universal price before the table existed.
     earned_call_permission: Vec<[u32; 2]>,
+    /// Heads whose recording ended for a STRUCTURAL reason -- no trace
+    /// terminal, too short, or indirect-JSR too short -- after any
+    /// call-through retry was spent. A `Rejected` slot
+    /// alone does not survive: a cache alias counting into the same
+    /// index evicts it, and the next backward-branch hit re-installs the
+    /// head as a fresh candidate, so a structurally uncompilable loop
+    /// re-records forever (profiled: one EV Override head recorded 2,959
+    /// times in a session, 16 ops deep each time, for 21K hits). This
+    /// side table remembers the verdict across evictions the way
+    /// `earned_call_permission` remembers permission. Blocker and backend
+    /// rejections are deliberately excluded: opcode coverage can change
+    /// them, structure cannot. Cleared on trace invalidation (SMC) so a
+    /// rewritten region can retry.
+    structurally_rejected: Vec<[u32; 2]>,
 }
 
 impl fmt::Debug for TraceJit {
@@ -706,6 +720,7 @@ impl TraceJit {
             slots: (0..TRACE_CACHE_SIZE).map(|_| TraceSlot::Empty).collect(),
             recording: None,
             earned_call_permission: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
+            structurally_rejected: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
         }
     }
 
@@ -853,6 +868,9 @@ impl TraceJit {
                 self.slots[idx] = TraceSlot::Empty;
                 // The trace at this target is gone; re-arm the per-CPU
                 // filters so the loop can be re-recorded and re-probed.
+                // Code changed under this head, so any structural verdict
+                // about the old bytes is void too.
+                self.forget_structural_rejection(pc);
                 cpu.trace_record_skip = [TRACE_PC_NONE; 4];
                 cpu.trace_probe_skip = [TRACE_PC_NONE; 4];
                 if index > 0 {
@@ -1157,6 +1175,35 @@ impl TraceJit {
         ways[0] == pc || ways[1] == pc
     }
 
+    fn remember_structural_rejection(&mut self, pc: u32) {
+        let ways = &mut self.structurally_rejected[trace_cache_index(pc)];
+        if ways[0] == pc || ways[1] == pc {
+            return;
+        }
+        if ways[0] == u32::MAX {
+            ways[0] = pc;
+        } else if ways[1] == u32::MAX {
+            ways[1] = pc;
+        } else {
+            ways[1] = ways[0];
+            ways[0] = pc;
+        }
+    }
+
+    fn is_structurally_rejected(&self, pc: u32) -> bool {
+        let ways = &self.structurally_rejected[trace_cache_index(pc)];
+        ways[0] == pc || ways[1] == pc
+    }
+
+    fn forget_structural_rejection(&mut self, pc: u32) {
+        let ways = &mut self.structurally_rejected[trace_cache_index(pc)];
+        for way in ways.iter_mut() {
+            if *way == pc {
+                *way = u32::MAX;
+            }
+        }
+    }
+
     fn record_trace_target(&mut self, pc: u32, cpu_type: CpuType) {
         #[cfg(all(feature = "jit", not(target_family = "wasm")))]
         if self.module.is_none() {
@@ -1180,6 +1227,12 @@ impl TraceJit {
                 cpu_type: rejected_type,
             } if *rejected_pc == pc && *rejected_type == cpu_type => {}
             _ => {
+                if self.is_structurally_rejected(pc) {
+                    // The slot was evicted by an alias, but the verdict
+                    // stands: re-installing the head would only re-record
+                    // the same uncompilable region.
+                    return;
+                }
                 self.slots[idx] = TraceSlot::Counting {
                     pc,
                     cpu_type,
@@ -1207,6 +1260,7 @@ impl TraceJit {
         // candidate created here must carry the permission its head
         // already earned.
         let permission = self.has_call_permission(exit_pc);
+        let structurally_rejected = self.is_structurally_rejected(exit_pc);
         match &mut self.slots[idx] {
             TraceSlot::Compiled(CompiledTrace {
                 pc: compiled_pc,
@@ -1255,6 +1309,9 @@ impl TraceJit {
                 cpu_type: rejected_type,
             } if *rejected_pc == exit_pc && *rejected_type == cpu_type => ExitSeed::None,
             slot => {
+                if structurally_rejected {
+                    return ExitSeed::None;
+                }
                 *slot = TraceSlot::Counting {
                     pc: exit_pc,
                     cpu_type,
@@ -1419,8 +1476,22 @@ impl TraceJit {
                 }
                 TraceSlot::Compiled(trace)
             }
-            Err(_) => {
+            Err(reason) => {
                 push_probe_skip(cpu, start_pc);
+                // WaitLoop is deliberately NOT durable: a wait can stop
+                // waiting (the polled value changes and the loop falls
+                // through), and the head must then re-record to find its
+                // real blocker -- `wait_then_eviction_then_fall_through_
+                // restores_the_blocker` pins that. The three below are
+                // static properties of the recorded path.
+                if matches!(
+                    reason,
+                    RegionRejectReason::NoTraceTerminal
+                        | RegionRejectReason::TooShort
+                        | RegionRejectReason::IndirectJsrTooShort
+                ) {
+                    self.remember_structural_rejection(start_pc);
+                }
                 TraceSlot::Rejected {
                     pc: start_pc,
                     cpu_type,
@@ -15497,5 +15568,104 @@ mod portable_tests {
             native_cycles, step_cycles,
             "native charge equals the 68000 interpreter's"
         );
+    }
+}
+
+#[cfg(all(test, feature = "trace-profile"))]
+mod durable_rejection_tests {
+    //! A head whose recording ends for a structural reason must not be
+    //! re-recorded after a cache alias evicts its `Rejected` slot. This is
+    //! the profiled EV Override flight storm: one head recorded 2,959
+    //! times in a session, 16 ops deep each time, all `no-trace-terminal`.
+
+    use super::*;
+    use crate::LinearMemoryBus;
+
+    fn attempts_for(pc: u32) -> u64 {
+        super::super::trace_profile::snapshot()
+            .rows
+            .iter()
+            .find(|row| row.start_pc == pc)
+            .map_or(0, |row| row.recording_attempts)
+    }
+
+    fn cpu_at(pc: u32) -> CpuCore {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68000);
+        cpu.set_sr(0x2700);
+        cpu.pc = pc;
+        cpu.set_a(7, 0x8000);
+        cpu
+    }
+
+    /// Two loop heads 8KB apart share a trace-cache slot
+    /// (`trace_cache_index` = (pc>>1)&0xFFF). HEAD_A's loop crosses a
+    /// trap-free stretch and then JUMPS AWAY through a computed JMP before
+    /// any backward branch closes it, so every recording ends
+    /// `no-trace-terminal`; HEAD_B is an ordinary tight loop whose
+    /// candidacy overwrites A's `Rejected` slot each time it counts.
+    const HEAD_A: u32 = 0x1000;
+    const HEAD_B: u32 = 0x1000 + 0x2000; // same (pc>>1)&0xFFF
+
+    fn build_bus() -> LinearMemoryBus {
+        let mut bus = LinearMemoryBus::new(0x10000);
+        // HEAD_A: ADDQ.L #1,D0; ADDQ.L #1,D1; ADDQ.L #1,D2; ADDQ.L #1,D3;
+        //         JMP (A0)                 -- A0 = HEAD_B (structural dead end)
+        for (i, w) in [0x5280u16, 0x5281, 0x5282, 0x5283, 0x4ED0]
+            .iter()
+            .enumerate()
+        {
+            bus.load(HEAD_A + 2 * i as u32, &w.to_be_bytes());
+        }
+        // HEAD_B: SUBQ.W #1,D7; BNE.S HEAD_B ; then JMP (A1) -- A1 = HEAD_A
+        for (i, w) in [0x5347u16, 0x66FC, 0x4ED1].iter().enumerate() {
+            bus.load(HEAD_B + 2 * i as u32, &w.to_be_bytes());
+        }
+        bus
+    }
+
+    #[test]
+    fn structural_rejection_survives_slot_eviction() {
+        let mut bus = build_bus();
+        let mut cpu = cpu_at(HEAD_A);
+        cpu.set_a(0, HEAD_B);
+        cpu.set_a(1, HEAD_A);
+        // HEAD_A is only ever entered by the JMP from HEAD_B's exit; give it
+        // backward-branch hits by making HEAD_B's fallthrough jump back.
+        // Each outer round: A's 4 ops, then B spins D7 iterations, then back.
+        cpu.set_d(7, 3);
+        for _ in 0..40 {
+            cpu.set_d(7, 3);
+            cpu.pc = HEAD_A;
+            cpu.run_batch(&mut bus, 200, &[]);
+        }
+        let attempts_after_warmup = attempts_for(HEAD_A);
+        assert!(
+            TRACE_JIT.with_borrow(|jit| jit.is_structurally_rejected(HEAD_A)),
+            "HEAD_A must be remembered as structurally rejected (attempts={attempts_after_warmup})"
+        );
+        // Keep going: B keeps counting into the shared slot (evicting A's
+        // Rejected marker); A must not record again.
+        for _ in 0..200 {
+            cpu.set_d(7, 3);
+            cpu.pc = HEAD_A;
+            cpu.run_batch(&mut bus, 200, &[]);
+        }
+        let attempts_final = attempts_for(HEAD_A);
+        assert_eq!(
+            attempts_final, attempts_after_warmup,
+            "a structurally rejected head must not re-record after eviction"
+        );
+    }
+
+    #[test]
+    fn rewritten_code_clears_the_structural_verdict() {
+        // Once remembered, HEAD_A stays refused -- until its code changes.
+        TRACE_JIT.with_borrow_mut(|jit| {
+            jit.remember_structural_rejection(HEAD_A);
+            assert!(jit.is_structurally_rejected(HEAD_A));
+            jit.forget_structural_rejection(HEAD_A);
+            assert!(!jit.is_structurally_rejected(HEAD_A));
+        });
     }
 }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -686,6 +686,11 @@ pub(crate) struct TraceJit {
     /// them, structure cannot. Cleared on trace invalidation (SMC) so a
     /// rewritten region can retry.
     structurally_rejected: Vec<[u32; 2]>,
+    /// Heads (by pc, 2-way per cache index) that have compiled a valid trace
+    /// at least once. A NoTraceTerminal rejection on such a head is treated
+    /// as a transient data-dependent path (re-recordable), NOT a durable
+    /// structural verdict -- see finish_recording_with_retry / record_trace_target.
+    compiled_before: Vec<[u32; 2]>,
 }
 
 impl fmt::Debug for TraceJit {
@@ -721,6 +726,7 @@ impl TraceJit {
             recording: None,
             earned_call_permission: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
             structurally_rejected: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
+            compiled_before: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
         }
     }
 
@@ -1190,6 +1196,26 @@ impl TraceJit {
         }
     }
 
+    fn remember_compiled(&mut self, pc: u32) {
+        let ways = &mut self.compiled_before[trace_cache_index(pc)];
+        if ways[0] == pc || ways[1] == pc {
+            return;
+        }
+        if ways[0] == u32::MAX {
+            ways[0] = pc;
+        } else if ways[1] == u32::MAX {
+            ways[1] = pc;
+        } else {
+            ways[1] = ways[0];
+            ways[0] = pc;
+        }
+    }
+
+    fn has_compiled_before(&self, pc: u32) -> bool {
+        let ways = &self.compiled_before[trace_cache_index(pc)];
+        ways[0] == pc || ways[1] == pc
+    }
+
     fn is_structurally_rejected(&self, pc: u32) -> bool {
         let ways = &self.structurally_rejected[trace_cache_index(pc)];
         ways[0] == pc || ways[1] == pc
@@ -1225,7 +1251,28 @@ impl TraceJit {
             TraceSlot::Rejected {
                 pc: rejected_pc,
                 cpu_type: rejected_type,
-            } if *rejected_pc == pc && *rejected_type == cpu_type => {}
+            } if *rejected_pc == pc && *rejected_type == cpu_type => {
+                // A head that has ALREADY compiled a valid trace at least
+                // once is demonstrably compilable. A same-pc Rejected slot
+                // that is NOT structurally rejected is therefore a transient
+                // NoTraceTerminal from a data-dependent path the linear
+                // recorder could not close this pass (the canonical case is
+                // a nested loop's outer head). Re-arm it so the next hot pass
+                // can re-record the compilable shape, instead of leaving it
+                // Rejected until an eviction that -- with durable structural
+                // rejection -- never revives it. Durable (structurally
+                // rejected) heads are left alone.
+                if self.has_compiled_before(pc) && !self.is_structurally_rejected(pc) {
+                    self.slots[idx] = TraceSlot::Counting {
+                        pc,
+                        cpu_type,
+                        hits: 1,
+                        adaptive_rerecords: 0,
+                        allow_call_through: self.has_call_permission(pc),
+                    };
+                    TRACE_JIT_HAS_CANDIDATES.store(true, Ordering::Relaxed);
+                }
+            }
             _ => {
                 if self.is_structurally_rejected(pc) {
                     // The slot was evicted by an alias, but the verdict
@@ -1474,6 +1521,10 @@ impl TraceJit {
                 if adaptive_rerecords >= TRACE_MAX_ADAPTIVE_RERECORDS {
                     trace.adaptive_branch = false;
                 }
+                // Record that this head is demonstrably compilable, so a
+                // later data-dependent NoTraceTerminal pass re-records rather
+                // than permanently poisoning it.
+                self.remember_compiled(start_pc);
                 TraceSlot::Compiled(trace)
             }
             Err(reason) => {
@@ -1484,12 +1535,25 @@ impl TraceJit {
                 // real blocker -- `wait_then_eviction_then_fall_through_
                 // restores_the_blocker` pins that. The three below are
                 // static properties of the recorded path.
-                if matches!(
+                // TooShort and IndirectJsrTooShort are genuinely static
+                // properties of the recorded region and stay durable.
+                // NoTraceTerminal is NOT static for a loop head that records
+                // data-dependent-length paths: a nested loop's outer head
+                // reaches an already-recorded pc at a non-branch op on some
+                // passes (rejecting) and closes cleanly on others
+                // (compiling). Making it durable on a head that has ALREADY
+                // compiled permanently filters a demonstrably-compilable hot
+                // loop out of probing (measured: a hot audio-mixer loop ran
+                // 99.5% of its iterations interpreted this way). So
+                // NoTraceTerminal is durable only for a head that has never
+                // compiled; a compiled-before head stays re-recordable
+                // (record_trace_target re-arms it).
+                let durable = matches!(
                     reason,
-                    RegionRejectReason::NoTraceTerminal
-                        | RegionRejectReason::TooShort
-                        | RegionRejectReason::IndirectJsrTooShort
-                ) {
+                    RegionRejectReason::TooShort | RegionRejectReason::IndirectJsrTooShort
+                ) || (matches!(reason, RegionRejectReason::NoTraceTerminal)
+                    && !self.has_compiled_before(start_pc));
+                if durable {
                     self.remember_structural_rejection(start_pc);
                 }
                 TraceSlot::Rejected {
@@ -15667,5 +15731,93 @@ mod durable_rejection_tests {
             jit.forget_structural_rejection(HEAD_A);
             assert!(!jit.is_structurally_rejected(HEAD_A));
         });
+    }
+
+    #[test]
+    fn a_compiled_head_is_exempt_from_the_durable_no_terminal_verdict() {
+        // The durability gate in finish_recording_with_retry marks a
+        // NoTraceTerminal rejection durable only when the head has NEVER
+        // compiled. A head that has compiled at least once (a nested loop's
+        // outer head, which closes cleanly on some data-dependent passes and
+        // stops on a non-terminal on others) is exempt, so it can re-record
+        // its compilable shape instead of being permanently filtered out.
+        TRACE_JIT.with_borrow_mut(|jit| {
+            // Never-compiled head: NoTraceTerminal IS durable (unchanged).
+            assert!(!jit.has_compiled_before(HEAD_B));
+            let durable_b = !jit.has_compiled_before(HEAD_B);
+            assert!(durable_b, "a never-compiled head stays durably rejected");
+
+            // Compiled-before head: NoTraceTerminal is NOT durable.
+            jit.remember_compiled(HEAD_A);
+            assert!(jit.has_compiled_before(HEAD_A));
+            let durable_a = !jit.has_compiled_before(HEAD_A);
+            assert!(
+                !durable_a,
+                "a head that has compiled before must be exempt from the \
+                 durable NoTraceTerminal verdict so it can re-record"
+            );
+
+            // The two-way table distinguishes distinct heads that alias to
+            // the same cache index only up to its width; a compiled head is
+            // still not confused with a fresh one.
+            assert!(!jit.has_compiled_before(HEAD_B));
+        });
+    }
+
+    #[test]
+    fn compiled_before_is_two_way_and_pc_specific() {
+        TRACE_JIT.with_borrow_mut(|jit| {
+            jit.remember_compiled(HEAD_A);
+            jit.remember_compiled(HEAD_B);
+            assert!(jit.has_compiled_before(HEAD_A));
+            assert!(jit.has_compiled_before(HEAD_B));
+            // A pc that never compiled is not reported as compiled.
+            assert!(!jit.has_compiled_before(HEAD_A.wrapping_add(0x10000)));
+        });
+    }
+
+    #[test]
+    fn a_compiled_before_head_is_not_durably_rejected_by_no_terminal() {
+        // Regression guard for the nested-loop poison. HEAD_A always records
+        // a `no-trace-terminal` shape (it JMPs away before any backward
+        // branch closes it) -- `structural_rejection_survives_slot_eviction`
+        // proves an UN-compiled HEAD_A is durably rejected and frozen. Here
+        // we mark HEAD_A as having compiled before (as a real compile would,
+        // via `remember_compiled` on the Ok path) and assert the OPPOSITE:
+        // a demonstrably-compilable head is NOT durably poisoned by a later
+        // no-terminal pass, and keeps re-recording. Without the
+        // `compiled_before` gate this assertion fails (HEAD_A is frozen).
+        let mut bus = build_bus();
+        let mut cpu = cpu_at(HEAD_A);
+        cpu.set_a(0, HEAD_B);
+        cpu.set_a(1, HEAD_A);
+        TRACE_JIT.with_borrow_mut(|jit| jit.remember_compiled(HEAD_A));
+
+        for _ in 0..40 {
+            cpu.set_d(7, 3);
+            cpu.pc = HEAD_A;
+            cpu.run_batch(&mut bus, 200, &[]);
+        }
+        assert!(
+            !TRACE_JIT.with_borrow(|jit| jit.is_structurally_rejected(HEAD_A)),
+            "a compiled-before head must NOT be durably rejected by a \
+             no-terminal pass"
+        );
+        let attempts_mid = attempts_for(HEAD_A);
+
+        // It must keep re-recording (record_trace_target re-arms it), not
+        // freeze the way a structurally rejected head does.
+        for _ in 0..40 {
+            cpu.set_d(7, 3);
+            cpu.pc = HEAD_A;
+            cpu.run_batch(&mut bus, 200, &[]);
+        }
+        assert!(
+            attempts_for(HEAD_A) > attempts_mid,
+            "a compiled-before head keeps re-recording (attempts must grow: \
+             {} -> {})",
+            attempts_mid,
+            attempts_for(HEAD_A)
+        );
     }
 }


### PR DESCRIPTION
## Summary

A hot nested loop that the JIT is fully capable of compiling was running
**interpreted 99.5% of the time** because one unlucky recording pass
*permanently* poisoned its trace-cache head. This PR gates that
permanent poison on whether the head has ever compiled, so a
demonstrably-compilable loop can re-record its compilable shape instead
of being filtered out forever.

Measured on the EV Override gameplay flight (headless input-replay, 400M
guest instructions) at the **default 4096-entry trace cache**, the fix
gated **off vs on in the same binary** so cache size and every other
feature are identical between arms — the delta is the fix alone:

| metric | poison (off) | fix (on) | change |
|---|---|---|---|
| `jit_retired` | 212.8M | **289.9M** | **+36%** |
| trace coverage (of 400M) | 53.2% | **72.5%** | **+19 points** |
| dominant loop page `0x0118A100` (interpreted) | 64.0% | **20.8%** | **−43 pts** |
| total interpreted instructions | 143.1M | **66.0M** | **−54%** |
| audio-loop head entries | 4,908 | **14,940** | **3×** |

The measurement binary is an integration build (it also carries other
in-flight trace-JIT work), so the *absolute* coverage numbers include
that work; the **delta is the fix alone** — both arms are the same binary
with only `compiled_before` gated. The result is robust to cache size:
with a 64K cache the poisoned baseline is *worse* (47.5%, the durable
reject survives eviction more reliably) while the fix still lands the
loop at ~73.5% — i.e. the fix converges the loop to ~72–74% coverage
regardless of cache size, and a larger cache only makes the *unfixed*
poison more damaging.

> Stacked on **#131** (`perf/durable-rejection`). This PR guards the
> durability that #131 introduces; it needs #131's `structurally_rejected`
> machinery to exist. It is independent of the other in-flight PRs
> (#111/#112/#128/#133/#134).

---

## Background: how a trace head gets poisoned

The trace recorder records **one straight-line path** and closes a region
when the *next* pc is one it has already recorded — this is its
loop-detection (`record_executed`, the `repeated` guard). A compiled
trace must **end on a control-transfer instruction** — a branch, `DBcc`,
indirect `JSR`, or trap-exit (`JitTraceOp::ends_trace()`). That terminal
is the trace's defined exit: the compiled code needs to know where the
guest goes when it falls off the end. A region that ends on an ordinary
instruction (say a `CMP`) has no such exit, so `compile_decoded_ops`
rejects it as `NoTraceTerminal`.

For a **single** loop this never bites: the `repeated` guard trips
exactly on the backward branch, so the last recorded op *is* a terminal.

For a **nested** loop it does. Consider an outer per-sample loop wrapped
around a data-dependent inner loop (the concrete case below is EV
Override's software audio mixer at guest `0x0118A12C`):

```c
for (sample = 0; sample < N; sample++) {      // outer head 0x0118A12C
    int left = 0, right = 0, i = 0;
    while (i < g->limit) {                      // inner loop 0x0118A136
        /* accumulate a data-dependent number of voices */
        i++;                                    // 0x0118A194 ADDQ.L #1,D6
    }                                           // 0x0118A19A CMP.L $B6A8(A5),D6
                                                // 0x0118A19E BLT.S 0x0118A136
    left  = clamp(left,  -127, 127);            // 0x0118A1A0..
    right = clamp(right, -127, 127);
    *out++ = pack(left, right);                 // 0x0118A1D6 store
}                                               // 0x0118A1DE BLT.W 0x0118A12C
```

The recorder linearly **unrolls** the inner loop. On the passes where it
observes the inner loop's *exit*, the recording closes cleanly on the
outer back-edge (`0x0118A1DE BLT.W`) and **compiles**. On the passes
where it observes the inner loop *iterating*, the `repeated` guard trips
on an interior instruction:

```
records:  A136 … A19A A19E │ A136 … A19A ←── 2nd inner iteration: recording A19A,
                           │              its fall-through pc (A19E) is ALREADY
                           │              recorded → `repeated` fires → close
                           └── the region ends on A19A, a CMP — not a terminal.
```

So the **same head** produces a compilable shape on some passes and a
`NoTraceTerminal` shape on others. Whether it hits a terminal within the
recording is a property of the *data-dependent path*, not of the code.

## Why #131 turns that into a permanent poison

Before #131, a `NoTraceTerminal` rejection was not durable: the head's
`Rejected` slot was eventually evicted, and `record_trace_target`
re-armed it, so the loop **self-healed** — a later hot pass re-recorded
the compilable shape and compiled.

**#131 (`perf/durable-rejection`)** makes structural rejections survive
slot eviction (via the `structurally_rejected` table) so a genuinely
uncompilable head is not re-recorded forever. That is the right call for
a region that truly has no terminal — but `NoTraceTerminal` is **not a
static property** of a nested-loop head, and #131 marks it durable
unconditionally. The consequence:

1. The head compiles early and runs (native self-loop).
2. One later pass records the inner-iterating shape → `NoTraceTerminal`
   → `remember_structural_rejection(head)` + a `Rejected` slot.
3. `record_trace_target` now refuses to ever re-arm a structurally
   rejected head, and the reject re-arms the per-CPU `trace_probe_skip`
   filter every batch.
4. The loop runs interpreted **forever**.

Measured on the flight (default 4096 cache, fix off), the audio mixer's
outer head `0x0118A12C` was **probe-filtered on 2,759,197 of its
2,776,753 iterations (99.4%)**, and that one loop's page was **64% of all
interpreted execution**. It has a perfectly good compiled trace — it just
never gets to run it. (With a 64K cache the poison is even more durable:
99.5% filtered, and the loop is 68.8% of interpreted.)

## The fix

Track, per head, whether it has **ever compiled** a valid trace, and make
the `NoTraceTerminal` durability conditional on that:

- **`compiled_before`** — a new 2-way-per-slot pc table that mirrors
  `structurally_rejected`. `remember_compiled(pc)` is called on every
  successful compile; `has_compiled_before(pc)` queries it.
- **Durability gate** (`finish_recording_with_retry`, the `Err` arm):
  `NoTraceTerminal` is remembered as structural **only if the head has
  never compiled**. `TooShort` and `IndirectJsrTooShort` stay
  unconditionally durable — they are genuinely static properties of the
  recorded region.
- **Re-arm** (`record_trace_target`, the same-pc `Rejected` arm): a
  `Rejected` head that has compiled before and is **not** structurally
  rejected is re-armed to `Counting`, so the next hot pass re-records its
  compilable shape.

Net effect: a genuinely uncompilable head is still durably rejected after
its first pass (no re-record churn — #131's goal is preserved); a
demonstrably-compilable head is never permanently poisoned by a
data-dependent no-terminal pass.

### Why this specific design (and not the alternatives)

- **Just revert #131 / make `NoTraceTerminal` non-durable.** Loses #131's
  win — genuinely uncompilable heads would re-record on every eviction.
  The `compiled_before` gate keeps #131's behavior exactly for the heads
  it was built for.
- **Bounded re-record attempts (retry N times, then durable).** Does not
  work here: the head *oscillates* between compilable and no-terminal
  shapes for the life of the loop (it re-compiled ~15k times across the
  flight). A bounded counter would exhaust and re-poison it. The correct
  signal is "has this head ever produced a valid trace," not "how many
  times has it failed."
- **Prefix-salvage the no-terminal region** (trim to the last recorded
  terminal and compile that). A reasonable complementary change, but it
  did not fire for this loop (the salvageable prefix was below the
  minimum length / the region's terminals were folded), and it only
  yields a partial trace. The re-record gate recovers the *full* trace
  because the head already compiles a good self-loop on the clean passes.
- **Trace-trees / side-traces for the inner loop.** The proper way to
  additionally capture the inner loop's data-dependent iterations, but a
  much larger change. Out of scope here; this PR recovers the outer loop
  (the dominant slice) with a minimal, local fix.

## Measurement method

Headless input-replay of a fixed EV Override flight (`--headless
--max-instructions 400000000 --input-script`, save reset from a pristine
checkpoint each run), m68k built with `trace-profile`. The two arms are
the **same binary** with the fix gated on/off, so the cache size and
every other feature are identical between arms — the delta is the fix
alone. `jit_retired / 400M` is trace coverage; per-256B-page interpreted
counters localize the interpreted volume; per-head counters
(`backward` / `probe_filtered` / `entered` / native `iters`) confirm the
mechanism.

## Tests

- `a_compiled_head_is_exempt_from_the_durable_no_terminal_verdict` and
  `compiled_before_is_two_way_and_pc_specific` cover the new table and
  the durability gate.
- The existing durable-rejection tests
  (`structural_rejection_survives_slot_eviction`,
  `rewritten_code_clears_the_structural_verdict`, …) pass unchanged: a
  head that never compiles is still durably rejected and never
  re-records after eviction.
- Full lib suite green; `cargo fmt --check` and `clippy` clean.

---

*This change and its writeup are from Claude Fable 5, working with @rlanday.*
