### PR TITLE
perf(jit): admit TST.B/W/L (An) into traces

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -3234,6 +3234,26 @@ fn decode_an_disp_trace_op<B: AddressBus>(
     let (extension, extension2, op) = match decoded {
         DecodedMemOp::Tst {
             size,
+            ea: FastEa::AnInd(reg),
+        } => {
+            // TST.B/W/L (An): plain register-indirect is (0,An). Reuse the
+            // proven AnDispUnary path with a zero displacement and no
+            // extension word. This unblocks hot pointer-chasing loops that
+            // test the node at (An) each iteration -- without it the whole
+            // loop rejects at its first instruction and runs interpreted.
+            (
+                None,
+                None,
+                JitTraceOp::AnDispUnary {
+                    op: JitUnaryOp::Tst,
+                    size,
+                    reg,
+                    displacement: 0,
+                },
+            )
+        }
+        DecodedMemOp::Tst {
+            size,
             ea: FastEa::AnDisp(reg),
         } => {
             let displacement = read_ext(2, bus)?;
@@ -15253,6 +15273,58 @@ mod portable_tests {
         jit.grant_call_permission(COLLIDER);
         assert!(jit.has_call_permission(HEAD));
         assert!(jit.has_call_permission(COLLIDER));
+    }
+
+    #[test]
+    fn tst_from_register_indirect_decodes_as_zero_displacement() {
+        let dcpu = cpu();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        // 4A52 = TST.W (A2): plain register-indirect, no extension word.
+        // Decodes as the (0,An) special case of the AnDispUnary path.
+        bus.write_word(0x0100, 0x4A52);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("TST.W (A2) should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::AnDispUnary {
+                op: JitUnaryOp::Tst,
+                size: Size::Word,
+                reg: 2,
+                displacement: 0,
+            }
+        ));
+        assert!(
+            trace.extension.is_none() && trace.extension2.is_none(),
+            "(An) carries no extension word"
+        );
+
+        // 4A93 = TST.L (A3).
+        bus.write_word(0x0100, 0x4A93);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("TST.L (A3) should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::AnDispUnary {
+                op: JitUnaryOp::Tst,
+                size: Size::Long,
+                reg: 3,
+                displacement: 0,
+            }
+        ));
+
+        // 4A12 = TST.B (A2).
+        bus.write_word(0x0100, 0x4A12);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("TST.B (A2) should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::AnDispUnary {
+                op: JitUnaryOp::Tst,
+                size: Size::Byte,
+                reg: 2,
+                displacement: 0,
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`TST` with plain register-indirect addressing `(An)` was the **only**
unsupported form of `TST` in the trace decoder — it already handles
`(d16,An)`, `d8(An,Xn)`, `abs.W`, and `abs.L`. So a hot pointer-chasing
loop that tests the node at `(An)` on every iteration rejected at its
**first instruction** and ran entirely interpreted.

## The change

Decode `TST.B/W/L (An)` as the `(0,An)` special case of the existing
`AnDispUnary` op — zero displacement, no extension word:

```rust
DecodedMemOp::Tst { size, ea: FastEa::AnInd(reg) } => (
    None, None,
    JitTraceOp::AnDispUnary { op: JitUnaryOp::Tst, size, reg, displacement: 0 },
),
```

The executor (`execute_portable_an_disp`), emitter (`emit_an_disp_mem`),
cycle counts, and SMC coverage are all the proven `AnDisp` machinery —
`(An)` is just `(d16=0, An)`. Only the decode arm is new.

## Impact

Measured on the EV Override gameplay flight (headless input-replay, 400M
guest instructions), before vs after this one decode arm (integration
build; the delta is this admission alone):

| | before | after |
|---|---|---|
| whole-app `jit_retired` | 290.5M | **301.0M** (**+10.5M**) |
| whole-app trace coverage | 72.6% | **75.3%** (**+2.6 pts**) |
| interpreted execution | 65.4M | **54.7M** |

The mechanism: a **linked-list traversal loop** at `0x010F1800`–
`0x010F1900` (pointer-chasing — `MOVEA.L (d16,An),An` to follow
next-pointers, `TST.W (An)` to test each node, `CMP.W (d16,An),Dn` on
fields, `BNE.W` to loop) that could not compile at all. Its other ops
were already trace-supported; `TST.W (An)` at the loop top was the sole
blocker. Its dominant page collapses:

| interpreted page | before | after |
|---|---|---|
| `0x010F1900` | 15.8% of interp | **2.3%** |
| `0x010F1800` | 8.5% of interp | **1.2%** |

(Those two pages fall ~14M; the net `jit_retired` gain is a bit less,
+10.5M, because an adjacent unrelated region at `0x010F2300` — a
guard-exiting loop plus `JSR (xxx).L`-blocked recordings, which this fix
does **not** address — shifts up slightly, and the flight is
non-deterministic run to run. +10.5M / +2.6 points is the measured
whole-app delta.)

## Tests

`tst_from_register_indirect_decodes_as_zero_displacement` — `TST.B/W/L
(An)` for `A2`/`A3` decode to `AnDispUnary { Tst, displacement: 0 }` with
no extension words. Full lib suite green; `fmt`/`clippy` clean.

---

*From Claude Fable 5, working with @rlanday.*
