### PR TITLE
perf(jit): trace through bytecode dispatchers

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -31,7 +31,11 @@ use std::fmt;
 use std::mem::{offset_of, size_of, transmute};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-const TRACE_CACHE_SIZE: usize = 4096;
+// Guest code in large applications commonly places unrelated hot loops one
+// 8 KiB region apart. A 4K-entry direct-mapped cache aliases those heads
+// because its byte-address period is only 0x2000; four times as many entries
+// keeps the lookup branchless while moving the collision period to 0x8000.
+const TRACE_CACHE_SIZE: usize = 16_384;
 pub(crate) const TRACE_MAX_OPS: usize = 128;
 pub(crate) const TRACE_MIN_OPS: usize = 3;
 
@@ -86,6 +90,28 @@ const NO_TERMINAL_STRIKE_LIMIT: u8 = 3;
 
 /// Sentinel for `CpuCore::trace_record_skip` / `trace_probe_skip`: no PC.
 pub(crate) const TRACE_PC_NONE: u32 = u32::MAX;
+
+/// Trace-return completion status in the otherwise-unused sign bit of the
+/// cycle word. Trace execution is bounded by `CpuCore::cycles_remaining`
+/// (`i32`), so cycles never need this bit. The upper 32 retirement bits stay
+/// fully available for data-dependent retirement such as `CondSkip`.
+const TRACE_RETURN_COMPLETE: u64 = 1 << 31;
+const TRACE_RETURN_CYCLES_MASK: u32 = i32::MAX as u32;
+
+#[inline]
+fn trace_return_complete(packed: u64) -> bool {
+    packed & TRACE_RETURN_COMPLETE != 0
+}
+
+#[inline]
+fn trace_return_cycles(packed: u64) -> u32 {
+    packed as u32 & TRACE_RETURN_CYCLES_MASK
+}
+
+#[inline]
+fn trace_return_retired(packed: u64) -> u32 {
+    (packed >> 32) as u32
+}
 
 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
 /// Original one-pass compiled trace entry point.
@@ -147,6 +173,20 @@ pub(crate) enum JitEa {
         scale: u8,
         displacement: i8,
     },
+    /// Brief (d8,PC,Xn): the PC-relative base and displacement collapse
+    /// to a constant when the trace is recorded (the pc is the trace's
+    /// own code), leaving a constant-base indexed read. Read-only by
+    /// construction: PC-relative modes are not legal destinations.
+    PcIndex {
+        base: u32,
+        index: JitDirectReg,
+        index_long: bool,
+        scale: u8,
+    },
+    /// (d16,PC): the extension-word PC and signed displacement collapse
+    /// to a constant address at record time. Kept distinct from absolute
+    /// addressing because the 68000 effective-address cycle charge differs.
+    PcDisp(u32),
     /// Absolute-short memory address, sign-extended when the trace is
     /// recorded so execution does not read the instruction stream.
     AbsWord(u32),
@@ -163,6 +203,8 @@ impl JitEa {
                 | Self::PreDec(_)
                 | Self::Disp(_, _)
                 | Self::Index { .. }
+                | Self::PcIndex { .. }
+                | Self::PcDisp(_)
                 | Self::AbsWord(_)
                 | Self::AbsLong(_)
         )
@@ -402,6 +444,18 @@ pub(crate) enum JitTraceOp {
         /// means this branch ends the trace; `Some` emits a guarded side
         /// exit and continues along the recorded path on a match.
         expected_taken: Option<bool>,
+    },
+    /// `JMP (d8,PC,Xn)` -- an N-way jump-table dispatch. The base (pc +
+    /// 2 + d8) folds to a constant at record time; the recorded taken
+    /// target guards the trace: a mismatch commits the jump (pc = the
+    /// computed target) and side-exits, where exit seeding compiles the
+    /// other dispatch cases as continuations that link back.
+    PcIndexJmp {
+        base: u32,
+        index: JitDirectReg,
+        index_long: bool,
+        scale: u8,
+        expected_target: Option<u32>,
     },
     Dbcc {
         condition: u8,
@@ -650,15 +704,27 @@ impl TraceBuildOp {
     }
 }
 
+/// One contiguous guest-code range inside the execution-ordered `code`
+/// snapshot. A trace can jump between several ranges (for example a computed
+/// dispatch or an inlined call); validating each range with a slice compare
+/// avoids re-entering the bus once per recorded instruction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TraceCodeSegment {
+    start: u32,
+    code_offset: u32,
+    len: u32,
+}
+
 struct CompiledTrace {
     pc: u32,
     cpu_type: CpuType,
     ops: Vec<TraceBuildOp>,
-    /// The exact instruction bytes the trace was compiled from (ops are
-    /// in execution order. Contiguous traces can validate this with one
-    /// compare; recorded multi-block paths validate each instruction.
+    /// The exact instruction bytes the trace was compiled from, in execution
+    /// order. `code_segments` maps its contiguous slices back to guest
+    /// addresses so multi-block traces can use the same fast validation as a
+    /// linear trace.
     code: Vec<u8>,
-    contiguous_code: bool,
+    code_segments: Vec<TraceCodeSegment>,
     max_cycles: i32,
     /// The final branch's taken-target is the trace head, so the trace is
     /// a whole loop iteration and can be re-run (budget permitting)
@@ -689,10 +755,10 @@ struct CompiledTrace {
     /// between them is deliberately unguarded.
     callee_start: u32,
     callee_end: u32,
-    /// Bit `n` is set when operation `n` is a recorded branch guard. Trace
-    /// entry can reject guard-free partial returns after one zero check, and
-    /// guarded traces inspect only the guarded operations instead of walking
-    /// up to 128 recorded operations.
+    /// Bit `n` is set when operation `n` has a recorded control-flow guard.
+    /// Trace entry checks this before inspecting `ops`, so the common
+    /// guard-free return is constant-time; guarded traces visit only their
+    /// guarded operations instead of scanning the complete recorded path.
     guarded_ops: u128,
     /// A recorded interior branch is a path prediction eligible for adaptive
     /// rerecording. Cleared after the one allowed rerecord so completed traces
@@ -708,17 +774,22 @@ struct CompiledTrace {
 impl CompiledTrace {
     #[cfg(all(feature = "jit", not(target_family = "wasm"), test))]
     unsafe fn call_native(&self, cpu: *mut CpuCore, max_iters: u32) -> u64 {
-        match self.func {
+        let packed = match self.func {
             NativeTraceFn::Once(func) => unsafe { func(cpu) },
             NativeTraceFn::Loop(func) => unsafe { func(cpu, max_iters) },
-        }
+        };
+        // Direct executor tests assert the architectural cycles/retirement
+        // payload; completion is internal call-driver metadata.
+        packed & !TRACE_RETURN_COMPLETE
     }
 
     fn is_guarded_branch_exit(&self, cpu: &CpuCore) -> bool {
-        // `ops_done` cannot identify an op once a preceding CondSkip makes the
-        // retired count data-dependent. Native and portable guarded branches
-        // both leave the branch address in ppc and one of its two successors
-        // in pc, so identify the exit from that architectural state instead.
+        // A side exit can retire the trace's full numeric op count when the
+        // guarded control-flow op is last, and future data-dependent ops can
+        // make a retired count differ from a static trace index. Both native
+        // and portable guards leave the exiting instruction in PPC and the
+        // architecturally committed successor in PC, so classify from that
+        // state instead.
         let mut guarded_ops = self.guarded_ops;
         while guarded_ops != 0 {
             let index = guarded_ops.trailing_zeros() as usize;
@@ -727,22 +798,28 @@ impl CompiledTrace {
             if cpu.ppc != op.pc {
                 continue;
             }
-            let JitTraceOp::Branch {
-                displacement,
-                length,
-                expected_taken: Some(expected_taken),
-                ..
-            } = op.op
-            else {
-                unreachable!("guarded_ops contains only guarded branches")
+            return match op.op {
+                JitTraceOp::Branch {
+                    displacement,
+                    length,
+                    expected_taken: Some(expected_taken),
+                    ..
+                } => {
+                    let target = (op.pc.wrapping_add(2) as i32).wrapping_add(displacement) as u32;
+                    let fallthrough = op.pc.wrapping_add(length as u32);
+                    if target == fallthrough {
+                        cpu.pc == target
+                    } else {
+                        (cpu.pc == target && !expected_taken)
+                            || (cpu.pc == fallthrough && expected_taken)
+                    }
+                }
+                JitTraceOp::PcIndexJmp {
+                    expected_target: Some(expected),
+                    ..
+                } => cpu.pc != expected,
+                _ => unreachable!("guarded_ops contains only guarded control flow"),
             };
-            let target = (op.pc.wrapping_add(2) as i32).wrapping_add(displacement) as u32;
-            let fallthrough = op.pc.wrapping_add(length as u32);
-            if target == fallthrough {
-                return cpu.pc == target;
-            }
-            return (cpu.pc == target && !expected_taken)
-                || (cpu.pc == fallthrough && expected_taken);
         }
         false
     }
@@ -756,6 +833,9 @@ fn guarded_op_mask(ops: &[TraceBuildOp]) -> u128 {
             op.op,
             JitTraceOp::Branch {
                 expected_taken: Some(_),
+                ..
+            } | JitTraceOp::PcIndexJmp {
+                expected_target: Some(_),
                 ..
             }
         ) {
@@ -782,6 +862,13 @@ struct TraceRecording {
     /// recorded from the fall-through, the recorder skips re-recording the
     /// executed block ops until control reaches this pc (the branch target).
     skip_record_until: Option<u32>,
+    /// Whether this recording was seeded from a guard exit rather than a
+    /// backward branch. Only exit-seeded recordings may finish early by
+    /// LINKING at another compiled head: truncating a backward-branch loop
+    /// recording at an interior compiled head replaces the whole loop with
+    /// a stub (measured: whole-application trace coverage fell 14 points
+    /// on one workload when loop recordings were allowed to link-finish).
+    from_exit_seed: bool,
 }
 
 enum TraceSlot {
@@ -816,6 +903,11 @@ pub(crate) struct TraceJit {
     next_func: u32,
     slots: Vec<TraceSlot>,
     recording: Option<TraceRecording>,
+    /// A guarded exit already counted candidacy at this exact target. The
+    /// decoded loop probes again immediately after any trace returns; carry
+    /// the provenance across that probe so it neither double-counts the hit
+    /// nor starts the resulting recording as an ordinary loop candidate.
+    pending_exit_seed: Option<(u32, CpuType)>,
     /// Heads that have earned call-through permission: a recording here
     /// blocked at a recordable call, so future candidacy at the same pc
     /// starts with permission instead of re-earning it through a doomed
@@ -885,6 +977,7 @@ impl TraceJit {
             next_func: 0,
             slots: (0..TRACE_CACHE_SIZE).map(|_| TraceSlot::Empty).collect(),
             recording: None,
+            pending_exit_seed: None,
             earned_call_permission: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
             structurally_rejected: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
             compiled_before: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
@@ -969,25 +1062,31 @@ impl TraceJit {
                 return None;
             }
 
-            // Fast validation: when a fastmem window covers the whole
-            // trace, one slice compare against the live instruction bytes
-            // replaces per-op bus reads. (SMC through the window is still
-            // caught: we compare the actual RAM.)
+            // Fast validation: when the fastmem window covers every
+            // contiguous code segment, compare the live instruction bytes
+            // directly. This is one compare for a linear trace and a small
+            // handful for a recorded multi-block path, instead of a virtual
+            // bus read for every op. SMC is still caught because these are
+            // comparisons against the actual RAM; a mismatch falls through
+            // to the per-op path below to locate the architecturally first
+            // changed instruction.
             let mut validated = false;
-            if trace.contiguous_code && cpu.fm_len != 0 {
-                let n = trace.code.len() as u32;
-                let off = cpu.address(pc).wrapping_sub(cpu.fm_base);
-                if n <= cpu.fm_len && off <= cpu.fm_len - n {
+            if cpu.fm_len != 0 {
+                validated = trace.code_segments.iter().all(|segment| {
+                    let off = segment.start.wrapping_sub(cpu.fm_base);
+                    if segment.len > cpu.fm_len || off > cpu.fm_len - segment.len {
+                        return false;
+                    }
+                    let expected = &trace.code[segment.code_offset as usize
+                        ..(segment.code_offset + segment.len) as usize];
                     let live = unsafe {
                         std::slice::from_raw_parts(
                             (cpu.fm_ptr as *const u8).add(off as usize),
-                            n as usize,
+                            segment.len as usize,
                         )
                     };
-                    if live == trace.code.as_slice() {
-                        validated = true;
-                    }
-                }
+                    live == expected
+                });
             }
 
             let mut miss = None;
@@ -1081,14 +1180,27 @@ impl TraceJit {
                 let NativeTraceFn::Loop(func) = trace.func else {
                     unreachable!("a batched trace must have a counted entry point")
                 };
+                // When a trace combines data-dependent CondSkip retirement
+                // with an adaptive guard, a packed retirement count cannot
+                // reveal how many whole iterations preceded a side exit.
+                // Run one iteration per call for that uncommon combination;
+                // ordinary CondSkip loops remain batched.
+                let dynamic_guard_retirement = trace.adaptive_branch
+                    && trace
+                        .ops
+                        .iter()
+                        .any(|op| matches!(op.op, JitTraceOp::CondSkip { .. }));
                 loop {
-                    let call_max_iters = max_iters - full_iters;
+                    let call_max_iters = if dynamic_guard_retirement {
+                        1
+                    } else {
+                        max_iters - full_iters
+                    };
                     let packed = unsafe { func(cpu as *mut CpuCore, call_max_iters) };
-                    cycles_total += (packed as u32) as i64;
-                    let ops_done = (packed >> 32) as u32;
-                    let completed = ops_done / ops_len;
-                    let partial_call = completed < call_max_iters;
-                    let guarded_branch_exit = partial_call && trace.is_guarded_branch_exit(cpu);
+                    cycles_total += i64::from(trace_return_cycles(packed));
+                    let ops_done = trace_return_retired(packed);
+                    let complete = trace_return_complete(packed);
+                    let guarded_branch_exit = !complete && trace.is_guarded_branch_exit(cpu);
                     #[cfg(feature = "trace-profile")]
                     super::trace_profile::note_native_call(pc, cpu_type, ops_done);
                     #[cfg(feature = "trace-profile")]
@@ -1096,10 +1208,24 @@ impl TraceJit {
                         super::trace_profile::note_guarded_branch_exit(pc, cpu_type);
                     }
                     retired += ops_done;
-                    full_iters += completed;
-                    if partial_call {
+                    if !complete {
+                        if !dynamic_guard_retirement {
+                            let numeric_completed = ops_done / ops_len;
+                            let remainder = ops_done % ops_len;
+                            // A last-op guard contributes one whole numeric
+                            // trace length but is still a side exit.
+                            let side_exit_at_last =
+                                guarded_branch_exit && remainder == 0 && ops_done != 0;
+                            full_iters +=
+                                numeric_completed.saturating_sub(u32::from(side_exit_at_last));
+                        }
                         break (guarded_branch_exit, true);
                     }
+                    // A counted body returns complete only after exhausting
+                    // the request or after a complete final iteration leaves
+                    // the self-loop. Once PC leaves the head, one completed
+                    // entry is sufficient for adaptive-policy accounting.
+                    full_iters += if cpu.pc == pc { call_max_iters } else { 1 };
                     if full_iters >= max_iters || cpu.pc != pc {
                         break (false, false);
                     }
@@ -1114,10 +1240,10 @@ impl TraceJit {
                 };
                 loop {
                     let packed = unsafe { func(cpu as *mut CpuCore) };
-                    cycles_total += (packed as u32) as i64;
-                    let ops_done = (packed >> 32) as u32;
-                    let partial_call = ops_done < ops_len;
-                    let guarded_branch_exit = partial_call && trace.is_guarded_branch_exit(cpu);
+                    cycles_total += i64::from(trace_return_cycles(packed));
+                    let ops_done = trace_return_retired(packed);
+                    let complete = trace_return_complete(packed);
+                    let guarded_branch_exit = !complete && trace.is_guarded_branch_exit(cpu);
                     #[cfg(feature = "trace-profile")]
                     super::trace_profile::note_native_call(pc, cpu_type, ops_done);
                     #[cfg(feature = "trace-profile")]
@@ -1125,7 +1251,7 @@ impl TraceJit {
                         super::trace_profile::note_guarded_branch_exit(pc, cpu_type);
                     }
                     retired += ops_done;
-                    if partial_call {
+                    if !complete {
                         break (guarded_branch_exit, true);
                     }
                     full_iters += 1;
@@ -1136,7 +1262,7 @@ impl TraceJit {
             };
             #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
             let (guarded_branch_exit, partial_call_this_entry) = loop {
-                let packed = execute_portable_trace(
+                let packed = execute_portable_trace_raw(
                     cpu,
                     &trace.ops,
                     CodeSpans {
@@ -1146,10 +1272,10 @@ impl TraceJit {
                         callee_end: trace.callee_end,
                     },
                 );
-                cycles_total += (packed as u32) as i64;
-                let ops_done = (packed >> 32) as u32;
-                let partial_call = ops_done < ops_len;
-                let guarded_branch_exit = partial_call && trace.is_guarded_branch_exit(cpu);
+                cycles_total += i64::from(trace_return_cycles(packed));
+                let ops_done = trace_return_retired(packed);
+                let complete = trace_return_complete(packed);
+                let guarded_branch_exit = !complete && trace.is_guarded_branch_exit(cpu);
                 #[cfg(feature = "trace-profile")]
                 super::trace_profile::note_native_call(pc, cpu_type, ops_done);
                 #[cfg(feature = "trace-profile")]
@@ -1157,7 +1283,7 @@ impl TraceJit {
                     super::trace_profile::note_guarded_branch_exit(pc, cpu_type);
                 }
                 retired += ops_done;
-                if partial_call {
+                if !complete {
                     break (guarded_branch_exit, true);
                 }
                 full_iters += 1;
@@ -1227,7 +1353,22 @@ impl TraceJit {
             // pc is an access the trace could not execute, so seeding it
             // would probe and compile a continuation that starts on the
             // very op that just bailed.
-            if guarded_branch_exit && !single_iter && chain_budget > 0 && cpu.pc != pc {
+            // A clean completion that exits exactly onto another compiled
+            // head (a LINK-EXIT trace's tail) chains the same way a guarded
+            // branch exit does: entering the neighbour now instead of
+            // interpreting until the next backward-branch probe.
+            let clean_link_exit = !guarded_branch_exit
+                && !partial_call_this_entry
+                && self.compiled_head_at(cpu.pc, cpu_type);
+            #[cfg(feature = "trace-profile")]
+            if clean_link_exit {
+                super::trace_profile::note_link_exit(pc, cpu_type);
+            }
+            if (guarded_branch_exit || clean_link_exit)
+                && !single_iter
+                && chain_budget > 0
+                && cpu.pc != pc
+            {
                 // A watched exit target still counts candidacy hits, but
                 // neither chains nor starts a recording: a chained entry
                 // is not observed by the runner (watches fire before an
@@ -1274,6 +1415,10 @@ impl TraceJit {
             return Some((CachedRunResult::Ran, retired));
         }
 
+        let from_exit_seed = self.pending_exit_seed == Some((pc, cpu_type));
+        if from_exit_seed {
+            self.pending_exit_seed = None;
+        }
         match &mut self.slots[idx] {
             TraceSlot::Counting {
                 pc: counted_pc,
@@ -1283,7 +1428,9 @@ impl TraceJit {
                 allow_call_through,
                 deferred_trap,
             } if *counted_pc == pc && *counted_type == cpu_type => {
-                *hits = hits.saturating_add(1);
+                if !from_exit_seed {
+                    *hits = hits.saturating_add(1);
+                }
                 let threshold = if *deferred_trap {
                     TRACE_TRAP_SEGMENT_HOT_THRESHOLD
                 } else {
@@ -1300,6 +1447,7 @@ impl TraceJit {
                     allow_call_through: *allow_call_through,
                     pending_return: None,
                     skip_record_until: None,
+                    from_exit_seed,
                 });
                 #[cfg(feature = "trace-profile")]
                 super::trace_profile::note_recording(pc, cpu_type);
@@ -1369,6 +1517,15 @@ impl TraceJit {
             ways[1] = ways[0];
             ways[0] = pc;
         }
+    }
+
+    /// Whether a compiled trace for `cpu_type` is installed with its head
+    /// at exactly `pc` -- the target a link-exit region may end on.
+    fn compiled_head_at(&self, pc: u32, cpu_type: CpuType) -> bool {
+        matches!(
+            &self.slots[trace_cache_index(pc)],
+            TraceSlot::Compiled(trace) if trace.pc == pc && trace.cpu_type == cpu_type
+        )
     }
 
     fn has_compiled_before(&self, pc: u32) -> bool {
@@ -1545,6 +1702,9 @@ impl TraceJit {
                     TRACE_HOT_THRESHOLD
                 };
                 if entry_watched || *hits < threshold || self.recording.is_some() {
+                    if !entry_watched && self.recording.is_none() {
+                        self.pending_exit_seed = Some((exit_pc, cpu_type));
+                    }
                     return ExitSeed::None;
                 }
                 let adaptive_rerecords = *adaptive_rerecords;
@@ -1562,6 +1722,7 @@ impl TraceJit {
                     allow_call_through,
                     pending_return: None,
                     skip_record_until: None,
+                    from_exit_seed: true,
                 });
                 #[cfg(feature = "trace-profile")]
                 super::trace_profile::note_recording(exit_pc, cpu_type);
@@ -1583,6 +1744,7 @@ impl TraceJit {
                     allow_call_through: permission,
                     deferred_trap: false,
                 };
+                self.pending_exit_seed = Some((exit_pc, cpu_type));
                 ExitSeed::None
             }
         }
@@ -2221,6 +2383,14 @@ impl TraceJit {
                     *expected_taken = Some(taken);
                 }
             }
+            // A computed jump records its taken target and the recording
+            // follows it (like a taken Branch); execution guards on the
+            // recorded target and side-exits on any other dispatch case.
+            JitTraceOp::PcIndexJmp {
+                expected_target, ..
+            } => {
+                *expected_target = Some(next_pc);
+            }
             // DBcc remains a natural region boundary for now. Its data-
             // dependent counter update is already compiled efficiently.
             JitTraceOp::Dbcc { .. } => {
@@ -2241,14 +2411,32 @@ impl TraceJit {
         }
 
         let recording = self.recording.as_mut().unwrap();
+        let recording_cpu_type = recording.cpu_type;
         recording.ops.push(op);
+        let recorded_len = recording.ops.len();
         if next_pc == start_pc {
             self.finish_recording(cpu, next_pc, RecordingEnd::Region);
             return;
         }
 
+        // Link exit: the recorded path reached another compiled trace's
+        // head. Finish here -- the region compiles with its exit chaining
+        // into that trace -- instead of recording on through code the
+        // neighbour already covers and tripping the repeated-pc guard
+        // into a rejection. Too-short regions keep recording: ending them
+        // here would reject TooShort, and durably.
+        let from_exit_seed = self.recording.as_ref().unwrap().from_exit_seed;
+        if from_exit_seed
+            && recorded_len >= TRACE_MIN_OPS
+            && self.compiled_head_at(next_pc, recording_cpu_type)
+        {
+            self.finish_recording(cpu, next_pc, RecordingEnd::Region);
+            return;
+        }
+
+        let recording = self.recording.as_ref().unwrap();
         let repeated = recording.ops.iter().any(|op| op.pc == next_pc);
-        if recording.ops.len() >= TRACE_MAX_OPS || repeated {
+        if recorded_len >= TRACE_MAX_OPS || repeated {
             self.finish_recording(cpu, next_pc, RecordingEnd::Region);
         }
     }
@@ -2282,7 +2470,19 @@ impl TraceJit {
         recorded_exit_pc: Option<u32>,
     ) -> Result<CompiledTrace, RegionRejectReason> {
         if !ops.last().is_some_and(|op| op.op.ends_trace()) {
-            return Err(RegionRejectReason::NoTraceTerminal);
+            // A region whose recorded exit lands exactly on another
+            // compiled trace's head ends by LINKING into that trace: the
+            // non-branch tail is a valid terminal (the runtime probes and
+            // chains at the exit pc), so only a tail that reaches neither
+            // a terminal nor a link target rejects. This is what lets the
+            // guard-exit side paths of a hot loop compile: their natural
+            // shape rejoins the loop at its head rather than closing a
+            // backward branch of their own.
+            let links_to_compiled_head = recorded_exit_pc
+                .is_some_and(|exit| exit != start_pc && self.compiled_head_at(exit, cpu_type));
+            if !links_to_compiled_head {
+                return Err(RegionRejectReason::NoTraceTerminal);
+            }
         }
 
         let self_loop = recorded_exit_pc == Some(start_pc)
@@ -2299,13 +2499,11 @@ impl TraceJit {
         }
 
         let max_cycles = ops.iter().map(|op| op.op.max_cycles()).sum();
-        let contiguous_code = ops.first().is_some_and(|op| op.pc == start_pc)
-            && ops
-                .windows(2)
-                .all(|pair| pair[0].pc.wrapping_add(pair[0].length() as u32) == pair[1].pc);
-
         let mut code = Vec::with_capacity(ops.len() * 4);
+        let mut code_segments: Vec<TraceCodeSegment> = Vec::new();
         for op in &ops {
+            let start = cpu.address(op.pc);
+            let code_offset = code.len() as u32;
             code.extend_from_slice(&op.opcode.to_be_bytes());
             if let Some(extension) = op.extension {
                 code.extend_from_slice(&extension.to_be_bytes());
@@ -2313,15 +2511,19 @@ impl TraceJit {
             if let Some(extension) = op.extension2 {
                 code.extend_from_slice(&extension.to_be_bytes());
             }
-        }
-        if contiguous_code {
-            debug_assert_eq!(
-                code.len() as u32,
-                ops.last()
-                    .map(|op| op.pc.wrapping_add(op.length() as u32))
-                    .unwrap_or(start_pc)
-                    .wrapping_sub(start_pc)
-            );
+            debug_assert_eq!(code.len() as u32 - code_offset, u32::from(op.length()));
+            if let Some(segment) = code_segments.last_mut()
+                && segment.start.checked_add(segment.len) == Some(start)
+            {
+                debug_assert_eq!(segment.code_offset + segment.len, code_offset);
+                segment.len += u32::from(op.length());
+            } else {
+                code_segments.push(TraceCodeSegment {
+                    start,
+                    code_offset,
+                    len: u32::from(op.length()),
+                });
+            }
         }
 
         let ends_in_indirect_jsr = ops
@@ -2452,7 +2654,7 @@ impl TraceJit {
             cpu_type,
             ops: &ops,
             code,
-            contiguous_code,
+            code_segments,
             max_cycles,
             self_loop,
             needs_window,
@@ -2473,7 +2675,7 @@ impl TraceJit {
             cpu_type,
             ops,
             code,
-            contiguous_code,
+            code_segments,
             max_cycles,
             callee_start,
             callee_end,
@@ -2709,6 +2911,25 @@ impl TraceJit {
                         bail_at.ops_before,
                         1,
                     ),
+                    JitTraceOp::PcIndexJmp {
+                        base,
+                        index: jmp_index,
+                        index_long,
+                        scale,
+                        expected_target: Some(expected_target),
+                    } => emit_guarded_pc_index_jmp(
+                        &mut builder,
+                        cpu_ptr,
+                        op.pc,
+                        base,
+                        jmp_index,
+                        index_long,
+                        scale,
+                        expected_target,
+                        cycles_value,
+                        bail_at.ops_before,
+                        1,
+                    ),
                     JitTraceOp::MoveMem { size, src, dst } => {
                         let env = mem_env.as_ref().expect("MoveMem implies a window env");
                         emit_move_mem(
@@ -2842,6 +3063,17 @@ impl TraceJit {
                     offset_of!(CpuCore, ir),
                     last.opcode as u32,
                 );
+                if !last.op.ends_trace() {
+                    // Link-exit tail: no branch materialized the pc; the
+                    // trace exits at the next sequential instruction (the
+                    // linked head).
+                    store_u32(
+                        &mut builder,
+                        cpu_ptr,
+                        offset_of!(CpuCore, pc),
+                        last.pc.wrapping_add(u32::from(last.length())),
+                    );
+                }
             }
 
             let retired_value = if let Some(rv) = dyn_retired {
@@ -2879,6 +3111,10 @@ impl TraceJit {
                 builder.ins().iconst(types::I64, (ops.len() as i64) << 32)
             };
             let packed = builder.ins().bor(cycles64, retired64);
+            let complete = builder
+                .ins()
+                .iconst(types::I64, TRACE_RETURN_COMPLETE as i64);
+            let packed = builder.ins().bor(packed, complete);
             builder.ins().return_(&[packed]);
 
             // Bail exits: set PC to the un-executed op, return the ops and
@@ -2920,7 +3156,7 @@ impl TraceJit {
             cpu_type,
             ops: ops.to_vec(),
             code,
-            contiguous_code,
+            code_segments,
             max_cycles,
             self_loop,
             native_loop,
@@ -2948,7 +3184,7 @@ impl TraceJit {
             callee_start: params.callee_start,
             callee_end: params.callee_end,
             code: params.code,
-            contiguous_code: params.contiguous_code,
+            code_segments: params.code_segments,
             max_cycles: params.max_cycles,
             self_loop: params.self_loop,
             needs_window: params.needs_window,
@@ -2969,7 +3205,7 @@ struct CompileParams<'a> {
     cpu_type: CpuType,
     ops: &'a [TraceBuildOp],
     code: Vec<u8>,
-    contiguous_code: bool,
+    code_segments: Vec<TraceCodeSegment>,
     max_cycles: i32,
     self_loop: bool,
     needs_window: bool,
@@ -3036,8 +3272,9 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             JitTraceOp::Nop => {}
             // Interior branches make the recorded path non-unique for
             // this head; per-head wait accounting would then erase
-            // opportunity data belonging to other shapes.
-            JitTraceOp::Branch { .. } => return false,
+            // opportunity data belonging to other shapes. A guarded
+            // computed jump is an interior N-way branch: same rule.
+            JitTraceOp::Branch { .. } | JitTraceOp::PcIndexJmp { .. } => return false,
             // Memory-reading compares and tests write NZVC only; the
             // polled value is the only input that can change.
             JitTraceOp::TstMem { .. }
@@ -3345,6 +3582,8 @@ impl JitTraceOp {
                 }
             }
             Self::Nop => 4,
+            // JMP (d8,PC,Xn) (M68000UM table 8-, indexed jump).
+            Self::PcIndexJmp { .. } => 14,
             Self::MoveReg { .. } => 4,
             Self::Moveq { .. } => 4,
             // MC68000: 8(2/0) for the word form, 12(3/0) for the long.
@@ -3417,6 +3656,14 @@ impl JitTraceOp {
                 let long = size == Size::Long;
                 let src_c = match src {
                     JitEa::Data(_) | JitEa::Addr(_) => 0,
+                    // (d8,PC,Xn) costs what (d8,An,Xn) costs (M68000UM).
+                    JitEa::PcIndex { .. } => {
+                        if long {
+                            14
+                        } else {
+                            10
+                        }
+                    }
                     JitEa::Ind(_) | JitEa::PostInc(_) => {
                         if long {
                             8
@@ -3431,7 +3678,7 @@ impl JitTraceOp {
                             6
                         }
                     }
-                    JitEa::Disp(_, _) => {
+                    JitEa::Disp(_, _) | JitEa::PcDisp(_) => {
                         if long {
                             12
                         } else {
@@ -3575,7 +3822,14 @@ impl JitTraceOp {
     fn ends_trace(self) -> bool {
         matches!(
             self,
-            Self::Branch { .. } | Self::Dbcc { .. } | Self::IndirectJsr { .. } | Self::TrapExit
+            Self::Branch { .. }
+                | Self::Dbcc { .. }
+                | Self::IndirectJsr { .. }
+                | Self::PcIndexJmp {
+                    expected_target: Some(_),
+                    ..
+                }
+                | Self::TrapExit
         )
     }
 
@@ -3719,6 +3973,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
+        return Some(op);
+    }
+    if let Some(op) = decode_pc_index_jmp_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
 
@@ -4603,19 +4860,22 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     };
     let src_mode = (opcode >> 3) & 7;
     let dst_mode = (opcode >> 6) & 7;
-    let mut extensions = [0u16; 2];
-    let mut extension_count = 0usize;
+    let extensions = std::cell::Cell::new([0u16; 2]);
+    let extension_count = std::cell::Cell::new(0usize);
     let mut read_ext = || -> Option<u16> {
-        if extension_count == extensions.len() {
+        let count = extension_count.get();
+        if count == 2 {
             return None;
         }
-        let address = pc.wrapping_add(2 + 2 * extension_count as u32);
+        let address = pc.wrapping_add(2 + 2 * count as u32);
         let value = bus.try_read_word(cpu.address(address)).ok()?;
-        extensions[extension_count] = value;
-        extension_count += 1;
+        let mut stored = extensions.get();
+        stored[count] = value;
+        extensions.set(stored);
+        extension_count.set(count + 1);
         Some(value)
     };
-    let mut decode_ea = |mode: u16, reg: u16| -> Option<JitEa> {
+    let mut decode_ea = |mode: u16, reg: u16, is_src: bool| -> Option<JitEa> {
         match (mode, reg) {
             (5 | 6, _) => decode_jit_ea(mode, reg, read_ext()?, cpu.cpu_type),
             (7, 0) => Some(JitEa::AbsWord(read_ext()? as i16 as i32 as u32)),
@@ -4624,11 +4884,45 @@ fn decode_move_mem_trace_op<B: AddressBus>(
                 let low = read_ext()?;
                 Some(JitEa::AbsLong((u32::from(high) << 16) | u32::from(low)))
             }
+            // PC-relative modes are legal sources only. Their base is the
+            // extension word's own address, a record-time constant.
+            (7, 2) if is_src => {
+                let ext_pc = pc.wrapping_add(2 + 2 * extension_count.get() as u32);
+                let displacement = read_ext()? as i16;
+                Some(JitEa::PcDisp(
+                    ext_pc.wrapping_add(displacement as i32 as u32),
+                ))
+            }
+            (7, 3) if is_src => {
+                let ext_pc = pc.wrapping_add(2 + 2 * extension_count.get() as u32);
+                let extension = read_ext()?;
+                // Full-format extension words are not admitted (same rule
+                // as the (d8,An,Xn) decoder).
+                if !is_pre_68020(cpu.cpu_type) && (extension & 0x0100) != 0 {
+                    return None;
+                }
+                let index_num = ((extension >> 12) & 7) as u8;
+                let index = if (extension & 0x8000) != 0 {
+                    JitDirectReg::Addr(index_num)
+                } else {
+                    JitDirectReg::Data(index_num)
+                };
+                Some(JitEa::PcIndex {
+                    base: ext_pc.wrapping_add((extension as u8 as i8) as i32 as u32),
+                    index,
+                    index_long: (extension & 0x0800) != 0,
+                    scale: if is_pre_68020(cpu.cpu_type) {
+                        0
+                    } else {
+                        ((extension >> 9) & 3) as u8
+                    },
+                })
+            }
             _ => decode_jit_ea(mode, reg, 0, cpu.cpu_type),
         }
     };
-    let src = decode_ea(src_mode, opcode & 7)?;
-    let dst = decode_ea(dst_mode, (opcode >> 9) & 7)?;
+    let src = decode_ea(src_mode, opcode & 7, true)?;
+    let dst = decode_ea(dst_mode, (opcode >> 9) & 7, false)?;
     // Indexed destinations were gated until "a profile demonstrates that
     // their extra emitter paths pay". Three profiled heads across two
     // workloads now terminate on indexed-destination stores (MOVE.W 3180
@@ -4643,10 +4937,53 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     }
     Some(TraceBuildOp {
         opcode,
-        extension: (extension_count >= 1).then_some(extensions[0]),
-        extension2: (extension_count >= 2).then_some(extensions[1]),
+        extension: (extension_count.get() >= 1).then_some(extensions.get()[0]),
+        extension2: (extension_count.get() >= 2).then_some(extensions.get()[1]),
         pc,
         op: JitTraceOp::MoveMem { size, src, dst },
+    })
+}
+
+/// Decode `JMP (d8,PC,Xn)` -- the jump-table dispatch of a bytecode
+/// interpreter. The recorded taken target is filled in by the recorder
+/// (like a Branch's expected direction); execution guards on it.
+fn decode_pc_index_jmp_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+) -> Option<TraceBuildOp> {
+    if opcode != 0x4EFB {
+        return None;
+    }
+    let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+    if !is_pre_68020(cpu.cpu_type) && (extension & 0x0100) != 0 {
+        return None;
+    }
+    let index_num = ((extension >> 12) & 7) as u8;
+    let index = if (extension & 0x8000) != 0 {
+        JitDirectReg::Addr(index_num)
+    } else {
+        JitDirectReg::Data(index_num)
+    };
+    Some(TraceBuildOp {
+        opcode,
+        extension: Some(extension),
+        extension2: None,
+        pc,
+        op: JitTraceOp::PcIndexJmp {
+            base: pc
+                .wrapping_add(2)
+                .wrapping_add((extension as u8 as i8) as i32 as u32),
+            index,
+            index_long: (extension & 0x0800) != 0,
+            scale: if is_pre_68020(cpu.cpu_type) {
+                0
+            } else {
+                ((extension >> 9) & 3) as u8
+            },
+            expected_target: None,
+        },
     })
 }
 
@@ -4851,7 +5188,7 @@ impl CodeSpans {
 }
 
 #[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
-fn execute_portable_trace(cpu: &mut CpuCore, ops: &[TraceBuildOp], spans: CodeSpans) -> u64 {
+fn execute_portable_trace_raw(cpu: &mut CpuCore, ops: &[TraceBuildOp], spans: CodeSpans) -> u64 {
     let mut cycles: i32 = 0;
     // Guest instructions retired -- tracked explicitly (not the trace op
     // index) because a `CondSkip` block executes a data-dependent count.
@@ -4899,6 +5236,19 @@ fn execute_portable_trace(cpu: &mut CpuCore, ops: &[TraceBuildOp], spans: CodeSp
                         return ((retired as u64) << 32) | cycles as u32 as u64;
                     }
                 }
+                if let JitTraceOp::PcIndexJmp {
+                    expected_target: Some(expected),
+                    ..
+                } = op.op
+                {
+                    // The jump committed (pc = computed target); any
+                    // other dispatch case than the recorded one exits.
+                    if cpu.pc != expected {
+                        cpu.ppc = op.pc;
+                        cpu.ir = op.opcode as u32;
+                        return ((retired as u64) << 32) | cycles as u32 as u64;
+                    }
+                }
             }
             None => {
                 cpu.pc = op.pc;
@@ -4910,8 +5260,21 @@ fn execute_portable_trace(cpu: &mut CpuCore, ops: &[TraceBuildOp], spans: CodeSp
     if let Some(last) = ops.last() {
         cpu.ppc = last.pc;
         cpu.ir = last.opcode as u32;
+        if !last.op.ends_trace() {
+            // Link-exit tail: a plain op does not materialize the pc the
+            // way branch terminals do; the trace exits at the next
+            // sequential instruction (the linked head).
+            cpu.pc = last.pc.wrapping_add(u32::from(last.length()));
+        }
     }
-    ((retired as u64) << 32) | cycles as u32 as u64
+    ((retired as u64) << 32) | cycles as u32 as u64 | TRACE_RETURN_COMPLETE
+}
+
+/// Architectural payload used by direct parity tests. Completion is call-
+/// driver metadata, not part of their cycles/count contract.
+#[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
+fn execute_portable_trace(cpu: &mut CpuCore, ops: &[TraceBuildOp], spans: CodeSpans) -> u64 {
+    execute_portable_trace_raw(cpu, ops, spans) & !TRACE_RETURN_COMPLETE
 }
 
 /// Execute one trace op; `None` means a mem-op check failed and nothing
@@ -5750,7 +6113,27 @@ fn execute_portable_move_mem(
                 .wrapping_add(displacement as i32 as u32);
             read(cpu, locate(cpu, a)?)
         }
-        JitEa::AbsWord(address) | JitEa::AbsLong(address) => read(cpu, locate(cpu, address)?),
+        JitEa::PcIndex {
+            base,
+            index,
+            index_long,
+            scale,
+        } => {
+            let raw_index = match index {
+                JitDirectReg::Data(r) => cpu.dar[r as usize],
+                JitDirectReg::Addr(r) => cpu.dar[8 + r as usize],
+            };
+            let index = if index_long {
+                raw_index
+            } else {
+                raw_index as u16 as i16 as i32 as u32
+            };
+            let a = base.wrapping_add(index.wrapping_shl(scale as u32));
+            read(cpu, locate(cpu, a)?)
+        }
+        JitEa::PcDisp(address) | JitEa::AbsWord(address) | JitEa::AbsLong(address) => {
+            read(cpu, locate(cpu, address)?)
+        }
     };
 
     let dst_base = |cpu: &CpuCore, r: u8| match staged {
@@ -5759,6 +6142,10 @@ fn execute_portable_move_mem(
     };
 
     match dst {
+        // PC-relative modes are never decoded as destinations.
+        JitEa::PcDisp(_) | JitEa::PcIndex { .. } => {
+            unreachable!("PC-relative EA as a MoveMem destination")
+        }
         JitEa::Data(r) => {
             if let Some((idx, v)) = staged {
                 cpu.dar[idx] = v;
@@ -5870,6 +6257,29 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
             unreachable!("CondSkip is handled in execute_portable_trace, not the register path")
         }
         JitTraceOp::Nop => 4,
+        JitTraceOp::PcIndexJmp {
+            base,
+            index,
+            index_long,
+            scale,
+            ..
+        } => {
+            // The jump commits architecturally regardless of the guard:
+            // pc = base + scaled index. The guard comparison itself is
+            // handled by the trace executor (mirroring Branch).
+            let raw_index = match index {
+                JitDirectReg::Data(r) => cpu.dar[r as usize],
+                JitDirectReg::Addr(r) => cpu.dar[8 + r as usize],
+            };
+            let idx = if index_long {
+                raw_index
+            } else {
+                raw_index as u16 as i16 as i32 as u32
+            };
+            cpu.pc = base.wrapping_add(idx.wrapping_shl(scale as u32));
+            cpu.change_of_flow = true;
+            14
+        }
         JitTraceOp::Moveq { reg, data } => {
             cpu.dar[reg as usize] = data;
             cpu.n_flag = if (data as i32) < 0 { NFLAG_SET } else { 0 };
@@ -6467,6 +6877,11 @@ fn emit_jit_op(
         }
         JitTraceOp::CondSkip { .. } => {
             unreachable!("CondSkip is emitted by the main compile_ops loop, not emit_jit_op")
+        }
+        // Guarded computed jumps are emitted by the main loop (they need
+        // the exit plumbing); an unguarded one never compiles.
+        JitTraceOp::PcIndexJmp { .. } => {
+            unreachable!("PcIndexJmp reaches emit_jit_op")
         }
         JitTraceOp::Nop => cycles_const(builder, 4),
         JitTraceOp::MoveImmReg { reg, size, value } => {
@@ -8490,7 +8905,7 @@ fn emit_move_mem(
             let (off, _) = checked_window_off(builder, env, bail, a, size);
             window_load(builder, env, off, size)
         }
-        JitEa::AbsWord(address) | JitEa::AbsLong(address) => {
+        JitEa::PcDisp(address) | JitEa::AbsWord(address) | JitEa::AbsLong(address) => {
             let address = iconst_u32(builder, address);
             let (off, _) = checked_window_off(builder, env, bail, address, size);
             window_load(builder, env, off, size)
@@ -8540,6 +8955,31 @@ fn emit_move_mem(
             let (off, _) = checked_window_off(builder, env, bail, a, size);
             window_load(builder, env, off, size)
         }
+        JitEa::PcIndex {
+            base,
+            index,
+            index_long,
+            scale,
+        } => {
+            // Constant base (pc-relative, folded at record time) plus a
+            // live scaled index register.
+            let base = iconst_u32(builder, base);
+            let raw_index = load_reg(builder, cpu, index);
+            let index = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index = if scale == 0 {
+                index
+            } else {
+                builder.ins().ishl_imm(index, i64::from(scale))
+            };
+            let a = builder.ins().iadd(base, index);
+            let (off, _) = checked_window_off(builder, env, bail, a, size);
+            window_load(builder, env, off, size)
+        }
     };
 
     // A destination base register must observe a same-register source
@@ -8555,6 +8995,11 @@ fn emit_move_mem(
     };
 
     match op.dst {
+        // PC-relative modes are never decoded as destinations
+        // (decode_move_mem_trace_op gates them to sources).
+        JitEa::PcDisp(_) | JitEa::PcIndex { .. } => {
+            unreachable!("PC-relative EA as a MoveMem destination")
+        }
         JitEa::Data(r) => {
             commit_staged(builder);
             write_data_reg_sized(builder, cpu, r, size, value);
@@ -9134,6 +9579,77 @@ fn emit_guarded_branch(
 
     builder.switch_to_block(side_exit);
     store_u32(builder, cpu, offset_of!(CpuCore, ppc), trace_pc);
+    let total_cycles = builder.ins().iadd(cycles_before, op_cycles);
+    let cycles64 = builder.ins().uextend(types::I64, total_cycles);
+    let retired = match retired_before_iter {
+        RetiredBefore::Constant(retired) => builder
+            .ins()
+            .iconst(types::I64, i64::from(retired + ops_done) << 32),
+        RetiredBefore::Dynamic(retired) => {
+            let retired = builder.ins().iadd_imm(retired, i64::from(ops_done));
+            let retired = builder.ins().uextend(types::I64, retired);
+            builder.ins().ishl_imm(retired, 32)
+        }
+    };
+    let packed = builder.ins().bor(cycles64, retired);
+    builder.ins().return_(&[packed]);
+
+    builder.switch_to_block(continue_block);
+    op_cycles
+}
+
+#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+#[allow(clippy::too_many_arguments)]
+fn emit_guarded_pc_index_jmp(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace_pc: u32,
+    base: u32,
+    index: JitDirectReg,
+    index_long: bool,
+    scale: u8,
+    expected_target: u32,
+    cycles_before: Value,
+    retired_before_iter: RetiredBefore,
+    ops_done: u32,
+) -> Value {
+    // The jump commits architecturally on every dispatch case:
+    // pc = base + scaled index.
+    let base_v = iconst_u32(builder, base);
+    let raw_index = load_reg(builder, cpu, index);
+    let idx = if index_long {
+        raw_index
+    } else {
+        let word = builder.ins().ireduce(types::I16, raw_index);
+        builder.ins().sextend(types::I32, word)
+    };
+    let idx = if scale == 0 {
+        idx
+    } else {
+        builder.ins().ishl_imm(idx, i64::from(scale))
+    };
+    let target = builder.ins().iadd(base_v, idx);
+    store_pc_value(builder, cpu, target);
+    let true_change = builder.ins().iconst(types::I8, 1);
+    store_value(
+        builder,
+        cpu,
+        offset_of!(CpuCore, change_of_flow),
+        true_change,
+    );
+
+    let op_cycles = cycles_const(builder, 14);
+    let expected = iconst_u32(builder, expected_target);
+    let matches = builder.ins().icmp(IntCC::Equal, target, expected);
+    let continue_block = builder.create_block();
+    let side_exit = builder.create_block();
+    builder
+        .ins()
+        .brif(matches, continue_block, &[], side_exit, &[]);
+
+    builder.switch_to_block(side_exit);
+    store_u32(builder, cpu, offset_of!(CpuCore, ppc), trace_pc);
+    store_u32(builder, cpu, offset_of!(CpuCore, ir), 0x4EFB);
     let total_cycles = builder.ins().iadd(cycles_before, op_cycles);
     let cycles64 = builder.ins().uextend(types::I64, total_cycles);
     let retired = match retired_before_iter {
@@ -9825,6 +10341,7 @@ mod portable_tests {
                 allow_call_through: false,
                 pending_return: None,
                 skip_record_until: None,
+                from_exit_seed: false,
             });
         });
         cpu.trace_recording = true;
@@ -10874,6 +11391,7 @@ mod portable_tests {
                 allow_call_through: false,
                 pending_return: None,
                 skip_record_until: None,
+                from_exit_seed: false,
             });
             cpu.set_cpu_type(CpuType::M68040);
             cpu.trace_recording = true;
@@ -12555,6 +13073,107 @@ mod portable_tests {
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
     #[test]
+    fn fast_validation_checks_every_discontiguous_code_segment_before_execution() {
+        const HEAD: u32 = 0x0100;
+        const SIDE: u32 = 0x0200;
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x5280,
+                extension: None,
+                extension2: None,
+                pc: HEAD,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 0,
+                    data: 1,
+                    size: Size::Long,
+                    is_sub: false,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x5281,
+                extension: None,
+                extension2: None,
+                pc: SIDE,
+                op: JitTraceOp::AddqSubqReg {
+                    reg: 1,
+                    data: 1,
+                    size: Size::Long,
+                    is_sub: false,
+                },
+            },
+            TraceBuildOp {
+                opcode: 0x6000,
+                extension: None,
+                extension2: None,
+                pc: SIDE + 2,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: HEAD as i32 - (SIDE + 4) as i32,
+                    length: 2,
+                    expected_taken: None,
+                },
+            },
+        ];
+        let mut mem = vec![0u8; 0x1000];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        for op in &ops {
+            let bytes = op.opcode.to_be_bytes();
+            mem[op.pc as usize..op.pc as usize + 2].copy_from_slice(&bytes);
+            bus.write_word(op.pc, op.opcode);
+        }
+        let mut actual = cpu();
+        actual.pc = HEAD;
+        actual.cycles_remaining = 1_000;
+        attach_window(&mut actual, &mut mem);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&actual, HEAD, CpuType::M68000, ops, Some(HEAD))
+            .expect("two-segment trace compiles");
+        assert_eq!(
+            compiled.code_segments,
+            [
+                TraceCodeSegment {
+                    start: HEAD,
+                    code_offset: 0,
+                    len: 2,
+                },
+                TraceCodeSegment {
+                    start: SIDE,
+                    code_offset: 2,
+                    len: 4,
+                },
+            ]
+        );
+        jit.slots[trace_cache_index(HEAD)] = TraceSlot::Compiled(compiled);
+
+        // Change only the second segment. The aggregate fast check must
+        // notice it, then the exact fallback must invalidate before the
+        // valid first op can commit.
+        mem[SIDE as usize..SIDE as usize + 2].copy_from_slice(&0x4E71u16.to_be_bytes());
+        bus.write_word(SIDE, 0x4E71);
+        let result = jit.try_execute(
+            &mut actual,
+            &mut bus,
+            CpuType::M68000,
+            3,
+            false,
+            &[],
+            TRACE_EXIT_CHAIN_BUDGET,
+        );
+        assert!(
+            result.is_none(),
+            "a mid-trace SMC miss restarts at the head"
+        );
+        assert_eq!(actual.pc, HEAD);
+        assert_eq!((actual.d(0), actual.d(1)), (0, 0));
+        assert!(matches!(
+            jit.slots[trace_cache_index(HEAD)],
+            TraceSlot::Empty
+        ));
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
     fn short_blocked_recordings_still_reject() {
         // A five-op prefix whose last terminal sits at op four: below
         // SALVAGE_MIN_OPS the head must reject exactly as before. (The
@@ -12877,11 +13496,13 @@ mod portable_tests {
         );
         for row in &chaining {
             assert!(
-                row.chained_calls <= row.guarded_branch_exits,
-                "every chain hangs off a guard exit ({:08X}: {} chains, {} exits)",
+                row.chained_calls <= row.guarded_branch_exits + row.link_exits,
+                "every chain hangs off an exit ({:08X}: {} chains, {} guard \
+                 exits, {} link exits)",
                 row.start_pc,
                 row.chained_calls,
-                row.guarded_branch_exits
+                row.guarded_branch_exits,
+                row.link_exits
             );
             assert!(
                 row.chained_retired > 0,
@@ -16098,7 +16719,10 @@ mod portable_tests {
         // reports in the wait section, and wait-attributed volume cannot
         // inflate projected dispatches.
         super::super::trace_profile::reset();
-        let mut bus = super::super::memory::LinearMemoryBus::new(0x4000);
+        const HEAD: u32 = 0x0100;
+        const COLLIDER: u32 = HEAD + (TRACE_CACHE_SIZE as u32) * 2;
+        assert_eq!(trace_cache_index(HEAD), trace_cache_index(COLLIDER));
+        let mut bus = super::super::memory::LinearMemoryBus::new(COLLIDER as usize + 0x1000);
         bus.write_word(0x0100, 0xB26D); // CMP.W (-0x10,A5),D1
         bus.write_word(0x0102, 0xFFF0);
         bus.write_word(0x0104, 0x67FA); // BEQ.S head
@@ -16106,8 +16730,8 @@ mod portable_tests {
         bus.write_word(0x0108, 0x0800);
         bus.write_word(0x010A, 0x60F4); // BRA.S head
         bus.write_word(0x0300, 0x1234); // the polled word
-        bus.write_word(0x2100, 0x5282); // ADDQ.L #1,D2
-        bus.write_word(0x2102, 0x60FC); // BRA.S 0x2100
+        bus.write_word(COLLIDER, 0x5282); // ADDQ.L #1,D2
+        bus.write_word(COLLIDER + 2, 0x60FC); // BRA.S COLLIDER
 
         let mut cpu = cpu();
         cpu.set_cpu_type(CpuType::M68040);
@@ -16132,7 +16756,7 @@ mod portable_tests {
         );
 
         // Phase 2: evict the direct-mapped slot with the colliding head.
-        cpu.pc = 0x2100;
+        cpu.pc = COLLIDER;
         cpu.run_batch(&mut bus, 200, &[]);
 
         // Phase 3: equal compare -- the taken loop classifies as a wait.
@@ -16188,14 +16812,17 @@ mod portable_tests {
     fn wait_then_eviction_then_fall_through_restores_the_blocker() {
         // The wait bit must reflect the most recent completed recording,
         // not the first. Sequence: classify a genuine wait; evict its
-        // direct-mapped slot with a colliding head (0x0100 and 0x2100 both
-        // map to slot 0x80); revisit with the compare unequal so the back
-        // edge falls through into an unsupported operation. The second
+        // direct-mapped slot with a head one cache period away; revisit with
+        // the compare unequal so the back edge falls through into an
+        // unsupported operation. The second
         // recording finds a real blocker, and the head must return to the
         // opportunity ranking rather than staying hidden in the wait
         // section by the stale classification.
         super::super::trace_profile::reset();
-        let mut bus = super::super::memory::LinearMemoryBus::new(0x4000);
+        const HEAD: u32 = 0x0100;
+        const COLLIDER: u32 = HEAD + (TRACE_CACHE_SIZE as u32) * 2;
+        assert_eq!(trace_cache_index(HEAD), trace_cache_index(COLLIDER));
+        let mut bus = super::super::memory::LinearMemoryBus::new(COLLIDER as usize + 0x1000);
         // Wait/fall-through head at 0x0100.
         bus.write_word(0x0100, 0xB26D); // CMP.W (-0x10,A5),D1
         bus.write_word(0x0102, 0xFFF0);
@@ -16204,9 +16831,9 @@ mod portable_tests {
         bus.write_word(0x0108, 0x0800);
         bus.write_word(0x010A, 0x60F4); // BRA.S head
         bus.write_word(0x0300, 0x1234); // the polled word
-        // Colliding loop head at 0x2100.
-        bus.write_word(0x2100, 0x5282); // ADDQ.L #1,D2
-        bus.write_word(0x2102, 0x60FC); // BRA.S 0x2100
+        // Colliding loop head one cache period after HEAD.
+        bus.write_word(COLLIDER, 0x5282); // ADDQ.L #1,D2
+        bus.write_word(COLLIDER + 2, 0x60FC); // BRA.S COLLIDER
 
         let mut cpu = cpu();
         cpu.set_cpu_type(CpuType::M68040);
@@ -16233,7 +16860,7 @@ mod portable_tests {
 
         // Phase 2: a backward branch to the colliding head evicts the
         // rejected slot for 0x0100.
-        cpu.pc = 0x2100;
+        cpu.pc = COLLIDER;
         cpu.run_batch(&mut bus, 200, &[]);
 
         // Phase 3: unequal compare -- the back edge falls through into the
@@ -16649,11 +17276,30 @@ mod portable_tests {
     #[test]
     fn exit_seeding_counts_promotes_and_respects_slot_owners() {
         let mut jit = TraceJit::new();
-        // First exit seeds a vacant slot; second promotes to recording.
+        // The first exit seeds a vacant slot. The decoded loop immediately
+        // probes the committed target again after the parent trace returns;
+        // that probe must neither count the same exit twice nor lose the
+        // exit-seeded provenance of the eventual recording.
         assert!(matches!(
             jit.note_trace_exit(0x0100, CpuType::M68040, false),
             ExitSeed::None
         ));
+        let mut cpu = cpu();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.pc = 0x0100;
+        cpu.cycles_remaining = 1_000;
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        assert!(
+            jit.try_execute(&mut cpu, &mut bus, CpuType::M68040, 100, false, &[], 1)
+                .is_none()
+        );
+        assert!(jit.recording.is_none(), "the duplicate probe stays cold");
+        assert!(matches!(
+            &jit.slots[trace_cache_index(0x0100)],
+            TraceSlot::Counting { hits: 1, .. }
+        ));
+
+        // A genuinely second exit promotes to an exit-seeded recording.
         assert!(matches!(
             jit.note_trace_exit(0x0100, CpuType::M68040, false),
             ExitSeed::StartRecording
@@ -16662,6 +17308,10 @@ mod portable_tests {
             jit.recording.as_ref().map(|r| r.start_pc),
             Some(0x0100),
             "recording starts at the exit target"
+        );
+        assert!(
+            jit.recording.as_ref().is_some_and(|r| r.from_exit_seed),
+            "link-finish remains enabled for the side-path recording"
         );
         // While a recording is active, another hot exit defers rather than
         // stealing the recorder.
@@ -17029,6 +17679,7 @@ mod portable_tests {
                 allow_call_through: false,
                 pending_return: None,
                 skip_record_until: None,
+                from_exit_seed: false,
                 adaptive_rerecords: 0,
             });
         });
@@ -17073,6 +17724,7 @@ mod portable_tests {
             allow_call_through: false,
             pending_return: None,
             skip_record_until: None,
+            from_exit_seed: false,
             adaptive_rerecords: 0,
         };
         with_trace_jit(|jit| {
@@ -17593,6 +18245,396 @@ mod portable_tests {
                 displacement: 0,
             }
         ));
+    }
+
+    #[test]
+    fn move_from_pc_relative_source_decodes_to_constant_base() {
+        let dcpu = cpu();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        // 303B 0006 = MOVE.W (6,PC,D0.W),D0 -- the jump-table fetch shape.
+        // The PC base is the extension word's address (pc+2), so the
+        // record-time constant base is pc + 2 + 6.
+        bus.write_word(0x0100, 0x303B);
+        bus.write_word(0x0102, 0x0006);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("MOVE.W (d8,PC,Xn),Dn should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::MoveMem {
+                size: Size::Word,
+                src: JitEa::PcIndex {
+                    base: 0x0108,
+                    index: JitDirectReg::Data(0),
+                    index_long: false,
+                    scale: 0,
+                },
+                dst: JitEa::Data(0),
+            }
+        ));
+        assert_eq!(trace.extension, Some(0x0006));
+
+        // 2A3A 0010 = MOVE.L (d16,PC),D5 -- collapses to a constant
+        // PC-displacement source at pc + 2 + 0x10. It stays distinct from
+        // absolute-long addressing because its 68000 cycle charge is lower.
+        bus.write_word(0x0100, 0x2A3A);
+        bus.write_word(0x0102, 0x0010);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("MOVE.L (d16,PC),Dn should decode");
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::MoveMem {
+                size: Size::Long,
+                src: JitEa::PcDisp(0x0112),
+                dst: JitEa::Data(5),
+            }
+        ));
+
+        // PC-relative destinations are illegal and must not decode: a
+        // synthetic word with dst mode 7/reg 2 stays rejected.
+        bus.write_word(0x0100, 0x35C0); // hypothetical MOVE.W D0,(d16,PC)
+        bus.write_word(0x0102, 0x0010);
+        assert!(
+            decode_move_mem_trace_op(&dcpu, &mut bus, 0x0100, 0x35C0).is_none(),
+            "PC-relative destination must not decode"
+        );
+    }
+
+    #[test]
+    fn pc_relative_move_sources_match_the_68000_interpreter_and_cycles() {
+        let cases = [
+            (
+                0x303Au16,
+                0x0010u16,
+                None,
+                0x0112u32,
+                vec![0x81, 0x23],
+                "MOVE.W (d16,PC),D0",
+            ),
+            (
+                0x203Au16,
+                0x0010u16,
+                None,
+                0x0112u32,
+                vec![0x12, 0x34, 0x56, 0x78],
+                "MOVE.L (d16,PC),D0",
+            ),
+            (
+                0x303Bu16,
+                0x1006u16,
+                Some((1u8, 4u32)),
+                0x010Cu32,
+                vec![0xA5, 0x5A],
+                "MOVE.W (d8,PC,D1.W),D0",
+            ),
+        ];
+
+        for (opcode, extension, index, address, bytes, label) in cases {
+            let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+            bus.write_word(0x0100, opcode);
+            bus.write_word(0x0102, extension);
+            bus.load(address, &bytes);
+
+            let mut interpreter = cpu();
+            interpreter.set_d(0, 0xCAFE_BABE);
+            interpreter.set_ccr(0x10);
+            if let Some((reg, value)) = index {
+                interpreter.set_d(reg as usize, value);
+            }
+            let interpreter_cycles = match interpreter.step(&mut bus) {
+                super::super::types::StepResult::Ok { cycles } => cycles,
+                other => panic!("{label}: interpreter step failed: {other:?}"),
+            };
+
+            let trace = decode_trace_op(&cpu(), &mut bus, 0x0100, CpuType::M68000)
+                .unwrap_or_else(|| panic!("{label}: trace decode failed"));
+            let mut mem = vec![0u8; 0x1000];
+            mem[0x0100..0x0102].copy_from_slice(&opcode.to_be_bytes());
+            mem[0x0102..0x0104].copy_from_slice(&extension.to_be_bytes());
+            mem[address as usize..address as usize + bytes.len()].copy_from_slice(&bytes);
+            let mut portable = cpu();
+            portable.set_d(0, 0xCAFE_BABE);
+            portable.set_ccr(0x10);
+            if let Some((reg, value)) = index {
+                portable.set_d(reg as usize, value);
+            }
+            attach_window(&mut portable, &mut mem);
+            let portable_cycles =
+                execute_portable_op(&mut portable, trace, CodeSpans::caller(0x0100, 0x0104))
+                    .unwrap_or_else(|| panic!("{label}: portable execution bailed"));
+
+            assert_eq!(portable.dar, interpreter.dar, "{label}: registers");
+            assert_eq!(portable.get_ccr(), interpreter.get_ccr(), "{label}: CCR");
+            assert_eq!(
+                portable_cycles, interpreter_cycles,
+                "{label}: exact 68000 cycle charge"
+            );
+        }
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_pc_relative_move_sources_match_portable_results_and_cycles() {
+        let cases = [
+            (
+                JitEa::PcDisp(0x0120),
+                0x303Au16,
+                0x001Eu16,
+                0u32,
+                26u32,
+                "(d16,PC)",
+            ),
+            (
+                JitEa::PcIndex {
+                    base: 0x0120,
+                    index: JitDirectReg::Data(1),
+                    index_long: false,
+                    scale: 0,
+                },
+                0x303Bu16,
+                0x101Eu16,
+                4u32,
+                28u32,
+                "(d8,PC,D1.W)",
+            ),
+        ];
+
+        for (src, opcode, extension, d1, expected_cycles, label) in cases {
+            let ops = vec![
+                TraceBuildOp {
+                    opcode,
+                    extension: Some(extension),
+                    extension2: None,
+                    pc: 0x0100,
+                    op: JitTraceOp::MoveMem {
+                        size: Size::Word,
+                        src,
+                        dst: JitEa::Data(0),
+                    },
+                },
+                TraceBuildOp {
+                    opcode: 0x4E71,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0104,
+                    op: JitTraceOp::Nop,
+                },
+                TraceBuildOp {
+                    opcode: 0x60F8,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0106,
+                    op: JitTraceOp::Branch {
+                        condition: 0,
+                        displacement: -8,
+                        length: 2,
+                        expected_taken: None,
+                    },
+                },
+            ];
+            let seed_mem = |mem: &mut [u8]| {
+                mem[0x0100..0x0102].copy_from_slice(&opcode.to_be_bytes());
+                mem[0x0102..0x0104].copy_from_slice(&extension.to_be_bytes());
+                mem[0x0104..0x0106].copy_from_slice(&0x4E71u16.to_be_bytes());
+                mem[0x0106..0x0108].copy_from_slice(&0x60F8u16.to_be_bytes());
+                mem[0x0120..0x0122].copy_from_slice(&0x1234u16.to_be_bytes());
+                mem[0x0124..0x0126].copy_from_slice(&0xA55Au16.to_be_bytes());
+            };
+
+            let mut native_mem = vec![0u8; 0x1000];
+            seed_mem(&mut native_mem);
+            let mut native = cpu();
+            native.set_d(0, 0xCAFE_BABE);
+            native.set_d(1, d1);
+            native.set_ccr(0x10);
+            attach_window(&mut native, &mut native_mem);
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(&native, 0x0100, CpuType::M68000, ops.clone(), Some(0x0100))
+                .unwrap_or_else(|| panic!("{label}: trace should compile"));
+            let native_packed = unsafe { compiled.call_native(&mut native, 1) };
+
+            let mut portable_mem = vec![0u8; 0x1000];
+            seed_mem(&mut portable_mem);
+            let mut portable = cpu();
+            portable.set_d(0, 0xCAFE_BABE);
+            portable.set_d(1, d1);
+            portable.set_ccr(0x10);
+            attach_window(&mut portable, &mut portable_mem);
+            let portable_packed =
+                execute_portable_trace(&mut portable, &ops, CodeSpans::caller(0x0100, 0x0108));
+
+            assert_eq!(native_packed, portable_packed, "{label}: packed result");
+            assert_eq!(native_packed as u32, expected_cycles, "{label}: cycles");
+            assert_eq!(native.dar, portable.dar, "{label}: registers");
+            assert_eq!(native.get_ccr(), portable.get_ccr(), "{label}: CCR");
+            assert_eq!(native.pc, 0x0100, "{label}: loop closes");
+        }
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn guarded_pc_index_jmp_matches_portable_and_seeds_a_last_op_exit() {
+        const START: u32 = 0x00FC;
+        const JMP_PC: u32 = 0x0100;
+        const EXPECTED: u32 = 0x010C;
+        const ALTERNATE: u32 = 0x010E;
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x4E71,
+                extension: None,
+                extension2: None,
+                pc: START,
+                op: JitTraceOp::Nop,
+            },
+            TraceBuildOp {
+                opcode: 0x4E71,
+                extension: None,
+                extension2: None,
+                pc: START + 2,
+                op: JitTraceOp::Nop,
+            },
+            TraceBuildOp {
+                opcode: 0x4EFB,
+                extension: Some(0x0006),
+                extension2: None,
+                pc: JMP_PC,
+                op: JitTraceOp::PcIndexJmp {
+                    base: 0x0108,
+                    index: JitDirectReg::Data(0),
+                    index_long: false,
+                    scale: 0,
+                    expected_target: Some(EXPECTED),
+                },
+            },
+        ];
+
+        // Independent interpreter reference for the computed jump itself.
+        let mut interpreter_bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        interpreter_bus.write_word(JMP_PC, 0x4EFB);
+        interpreter_bus.write_word(JMP_PC + 2, 0x0006);
+        let mut interpreter = cpu();
+        interpreter.pc = JMP_PC;
+        interpreter.set_d(0, 6);
+        let interpreter_cycles = match interpreter.step(&mut interpreter_bus) {
+            super::super::types::StepResult::Ok { cycles } => cycles,
+            other => panic!("interpreter JMP failed: {other:?}"),
+        };
+        assert_eq!(interpreter_cycles, 14, "68000 indexed JMP timing");
+        assert_eq!(interpreter.pc, ALTERNATE, "the computed target commits");
+
+        let mut jit = TraceJit::new();
+        let seed = cpu();
+        assert_eq!(guarded_op_mask(&ops[..2]), 0, "plain ops need no scan");
+        assert_eq!(
+            guarded_op_mask(&ops),
+            1 << 2,
+            "only the computed jump is guarded"
+        );
+        let compiled = jit
+            .compile_decoded_ops(&seed, START, CpuType::M68000, ops.clone(), Some(EXPECTED))
+            .expect("the guarded computed-jump trace should compile");
+        assert_eq!(compiled.guarded_ops, 1 << 2);
+
+        for (index, expected_pc, expected_exit) in
+            [(4u32, EXPECTED, false), (6u32, ALTERNATE, true)]
+        {
+            let mut native = cpu();
+            native.pc = START;
+            native.ppc = 0xDEAD_BEEF;
+            native.ir = 0xA5A5;
+            native.set_d(0, index);
+            let native_packed = unsafe { compiled.call_native(&mut native, 1) };
+
+            let mut portable = cpu();
+            portable.pc = START;
+            portable.ppc = 0xDEAD_BEEF;
+            portable.ir = 0xA5A5;
+            portable.set_d(0, index);
+            let portable_packed =
+                execute_portable_trace(&mut portable, &ops, CodeSpans::caller(START, JMP_PC + 4));
+
+            assert_eq!(
+                native_packed, portable_packed,
+                "index={index}: packed result"
+            );
+            assert_eq!((native_packed >> 32) as u32, 3, "all three ops retire");
+            assert_eq!(native_packed as u32, 22, "two NOPs plus 14-cycle JMP");
+            assert_eq!(native.pc, expected_pc, "index={index}: committed PC");
+            assert_eq!(native.ppc, JMP_PC, "index={index}: PPC identifies JMP");
+            assert_eq!(native.ir, 0x4EFB, "index={index}: IR identifies JMP");
+            assert_eq!(native.change_of_flow, portable.change_of_flow);
+            assert_eq!(
+                compiled.is_guarded_branch_exit(&native),
+                expected_exit,
+                "index={index}: exit classification"
+            );
+        }
+
+        // The mismatch is at the last trace op, so its retired count equals
+        // the full trace length. try_execute must still recognize the guard
+        // exit and create an exit-seeded candidate at the committed target.
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        bus.write_word(START, 0x4E71);
+        bus.write_word(START + 2, 0x4E71);
+        bus.write_word(JMP_PC, 0x4EFB);
+        bus.write_word(JMP_PC + 2, 0x0006);
+        jit.slots[trace_cache_index(START)] = TraceSlot::Compiled(compiled);
+        let mut actual = cpu();
+        actual.pc = START;
+        actual.cycles_remaining = 1_000;
+        actual.set_d(0, 6);
+        let result = jit.try_execute(
+            &mut actual,
+            &mut bus,
+            CpuType::M68000,
+            100,
+            false,
+            &[],
+            TRACE_EXIT_CHAIN_BUDGET,
+        );
+        assert!(matches!(result, Some((CachedRunResult::Ran, 3))));
+        assert_eq!(actual.pc, ALTERNATE);
+        assert!(matches!(
+            &jit.slots[trace_cache_index(ALTERNATE)],
+            TraceSlot::Counting { pc, hits: 1, .. } if *pc == ALTERNATE
+        ));
+    }
+
+    #[test]
+    fn portable_move_from_pc_index_reads_the_live_table() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        // Table of words at 0x0200; code at 0x0100 (unused by the
+        // portable executor beyond spans).
+        mem[0x200] = 0x12;
+        mem[0x201] = 0x34;
+        mem[0x202] = 0x56;
+        mem[0x203] = 0x78;
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_d(0, 4); // index selects the second table word
+        let op = TraceBuildOp {
+            opcode: 0x303B,
+            extension: Some(0x0006),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::MoveMem {
+                size: Size::Word,
+                src: JitEa::PcIndex {
+                    base: 0x01FE,
+                    index: JitDirectReg::Data(0),
+                    index_long: false,
+                    scale: 0,
+                },
+                dst: JitEa::Data(0),
+            },
+        };
+        let packed = execute_portable_trace(&mut cpu, &[op], CodeSpans::caller(0x0100, 0x0104));
+        assert_eq!((packed >> 32) as u32, 1, "the op must retire");
+        assert_eq!(
+            cpu.d(0) & 0xFFFF,
+            0x5678,
+            "base 0x1FE + D0.W(4) reads the table word at 0x202"
+        );
     }
 
     #[test]
@@ -18657,14 +19699,14 @@ mod durable_rejection_tests {
         cpu
     }
 
-    /// Two loop heads 8KB apart share a trace-cache slot
-    /// (`trace_cache_index` = (pc>>1)&0xFFF). HEAD_A's loop crosses a
+    /// Two loop heads one cache period apart share a trace-cache slot.
+    /// HEAD_A's loop crosses a
     /// trap-free stretch and then JUMPS AWAY through a computed JMP before
     /// any backward branch closes it, so every recording ends
     /// `no-trace-terminal`; HEAD_B is an ordinary tight loop whose
     /// candidacy overwrites A's `Rejected` slot each time it counts.
     const HEAD_A: u32 = 0x1000;
-    const HEAD_B: u32 = 0x1000 + 0x2000; // same (pc>>1)&0xFFF
+    const HEAD_B: u32 = HEAD_A + (TRACE_CACHE_SIZE as u32) * 2;
 
     fn build_bus() -> LinearMemoryBus {
         let mut bus = LinearMemoryBus::new(0x10000);
@@ -18935,6 +19977,251 @@ mod durable_rejection_tests {
         assert!(
             !with_trace_jit(|jit| jit.has_no_terminal_strikes(HEAD_C)),
             "a successful compile clears the head's no-terminal strikes"
+        );
+    }
+
+    /// Link exit: an exit-seeded recording that flows sequentially into
+    /// another compiled trace's head finishes there and compiles with that
+    /// head as its exit -- the shape of a guard-exit side path rejoining
+    /// its parent loop -- instead of recording on through the parent's
+    /// code. Exercises both halves: the recorder's early link-finish
+    /// (exit-seeded recordings only) and compile acceptance of the
+    /// non-branch link tail.
+    const PARENT: u32 = 0x2000;
+    const SIDE: u32 = 0x1FF8; // CondSkip side path falls into PARENT
+
+    #[test]
+    fn an_exit_seeded_recording_link_finishes_at_a_compiled_head() {
+        let mut bus = LinearMemoryBus::new(0x10000);
+        // SIDE:   NOP; BCS.S parent-tail; MOVEQ #99,D0; NOP
+        //         (the branch skips MOVEQ, then the tail falls into PARENT)
+        // PARENT: SUBQ.W #1,D7; BNE.S PARENT; JMP (A1)
+        for (i, w) in [0x4E71u16, 0x6502, 0x7063, 0x4E71, 0x5347, 0x66FC, 0x4ED1]
+            .iter()
+            .enumerate()
+        {
+            bus.load(SIDE + 2 * i as u32, &w.to_be_bytes());
+        }
+        let mut cpu = cpu_at(PARENT);
+        cpu.set_a(1, PARENT);
+
+        // Phase 1: make PARENT hot and compiled via its own back edge.
+        for _ in 0..20 {
+            cpu.set_d(7, 40);
+            cpu.pc = PARENT;
+            cpu.run_batch(&mut bus, 120, &[]);
+        }
+        assert!(
+            with_trace_jit(|jit| matches!(
+                &jit.slots[trace_cache_index(PARENT)],
+                TraceSlot::Compiled(trace) if trace.pc == PARENT
+            )),
+            "the parent loop must compile first"
+        );
+
+        // Phase 2: inject an exit-seeded recording at SIDE (what
+        // note_trace_exit's StartRecording arm creates) and run through
+        // the side ops. The recording must finish at PARENT after the 3
+        // side ops and compile them as a link-exit trace.
+        with_trace_jit(|jit| {
+            jit.recording = Some(TraceRecording {
+                start_pc: SIDE,
+                cpu_type: CpuType::M68000,
+                ops: Vec::with_capacity(TRACE_MAX_OPS),
+                adaptive_rerecords: 0,
+                allow_call_through: false,
+                pending_return: None,
+                skip_record_until: None,
+                from_exit_seed: true,
+            });
+        });
+        cpu.trace_recording = true;
+        cpu.c_flag = CFLAG_SET;
+        cpu.set_d(7, 4);
+        cpu.pc = SIDE;
+        cpu.run_batch(&mut bus, 8, &[]);
+
+        let (compiled, ops_len) = with_trace_jit(|jit| match &jit.slots[trace_cache_index(SIDE)] {
+            TraceSlot::Compiled(trace) if trace.pc == SIDE => (true, trace.ops.len()),
+            _ => (false, 0),
+        });
+        assert!(
+            compiled,
+            "an exit-seeded region flowing into a compiled head must \
+             compile as a link exit (durable={}, strikes={})",
+            with_trace_jit(|jit| jit.is_structurally_rejected(SIDE)),
+            with_trace_jit(|jit| jit.has_no_terminal_strikes(SIDE)),
+        );
+        assert_eq!(
+            ops_len, 4,
+            "the link-exit trace holds CondSkip, its skipped op, and the \
+             recorder must finish AT the parent's head, not record on \
+             through the parent's code)"
+        );
+
+        // Taken CondSkip retires only three of the four stored ops, but that
+        // is still a clean completion and must link-chain into PARENT.
+        cpu.set_d(0, 7);
+        cpu.set_d(7, 4);
+        cpu.c_flag = CFLAG_SET;
+        cpu.pc = SIDE;
+        cpu.run_batch(&mut bus, 8, &[]);
+        assert_eq!(cpu.d(0), 7, "the skipped MOVEQ did not execute");
+        let row = super::super::trace_profile::snapshot()
+            .rows
+            .into_iter()
+            .find(|row| row.start_pc == SIDE)
+            .expect("compiled side appears in profile");
+        assert!(
+            row.link_exits > 0,
+            "dynamic retirement is a clean link exit"
+        );
+        assert!(
+            row.chained_calls > 0,
+            "the completed side chains into PARENT"
+        );
+    }
+
+    /// The bytecode-dispatch composition: a loop that reads a byte,
+    /// fetches a jump-table offset through (d8,PC,Xn), and dispatches
+    /// through JMP (d8,PC,Xn). The head must compile THROUGH the guarded
+    /// computed jump; the alternate dispatch case guard-exits, gets
+    /// exit-seeded, and compiles its own continuation.
+    const DISPATCH: u32 = 0x2000;
+    const CASE1: u32 = 0x201E;
+
+    #[test]
+    fn a_bytecode_dispatch_loop_compiles_through_the_guarded_computed_jump() {
+        let mut bus = LinearMemoryBus::new(0x10000);
+        // head:  MOVE.B (A2)+,D5; MOVEQ #0,D0; MOVE.B D5,D0; ADD.W D0,D0
+        //        MOVE.W (6,PC,D0.W),D0   (table at 0x2010)
+        //        JMP (2,PC,D0.W)         (base 0x2010)
+        // table: dc.w case0-0x2010 (=0x0008), case1-0x2010 (=0x000E)
+        // case0: ADDQ.L #1,D1; ADDQ.L #1,D3; BRA.S head
+        // case1: ADDQ.L #1,D2; ADDQ.L #1,D4; BRA.S head
+        // Each case is exactly TRACE_MIN_OPS so the alternate case must
+        // link-finish at the already compiled dispatch head.
+        for (i, w) in [
+            0x1A1Au16, 0x7000, 0x1005, 0xD040, 0x303B, 0x0006, 0x4EFB, 0x0002, 0x0008, 0x000E,
+            0x4E71, 0x4E71, // table + padding
+            0x5281, 0x5283, 0x60E2, // case0 @ 0x2018
+            0x5282, 0x5284, 0x60DC, // case1 @ 0x201E
+        ]
+        .iter()
+        .enumerate()
+        {
+            bus.load(DISPATCH + 2 * i as u32, &w.to_be_bytes());
+        }
+        // Bytecode stream: alternating case 0 / case 1.
+        for i in 0..0x400u32 {
+            bus.load(0x3000 + i, &[(i & 1) as u8]);
+        }
+        let mut cpu = cpu_at(DISPATCH);
+        cpu.set_a(2, 0x3000);
+
+        cpu.run_batch(&mut bus, 4_000, &[]);
+
+        let (head_has_guarded_jmp, code_segments) =
+            with_trace_jit(|jit| match &jit.slots[trace_cache_index(DISPATCH)] {
+                TraceSlot::Compiled(trace) if trace.pc == DISPATCH => (
+                    trace.ops.iter().any(|op| {
+                        matches!(
+                            op.op,
+                            JitTraceOp::PcIndexJmp {
+                                expected_target: Some(_),
+                                ..
+                            }
+                        )
+                    }),
+                    trace
+                        .code_segments
+                        .iter()
+                        .map(|segment| (segment.start, segment.len))
+                        .collect::<Vec<_>>(),
+                ),
+                _ => (false, Vec::new()),
+            });
+        assert!(
+            head_has_guarded_jmp,
+            "the dispatch head must compile THROUGH the guarded computed jump"
+        );
+        assert_eq!(
+            code_segments.len(),
+            2,
+            "dispatcher prefix and recorded case are two fast-validation segments: {code_segments:?}"
+        );
+        assert_eq!(code_segments[0], (DISPATCH, 16));
+        assert!(matches!(code_segments[1], (0x2018 | 0x201E, 6)));
+        // Whichever case the recording did NOT capture as the expected
+        // path must be exit-seeded and compile as its own continuation.
+        const CASE0: u32 = 0x2018;
+        let compiled_case = with_trace_jit(|jit| {
+            [CASE0, CASE1]
+                .iter()
+                .find_map(|&case| match &jit.slots[trace_cache_index(case)] {
+                    TraceSlot::Compiled(trace) if trace.pc == case => {
+                        Some((case, trace.ops.len(), trace.ops.last().copied()))
+                    }
+                    _ => None,
+                })
+        });
+        if compiled_case.is_none() {
+            with_trace_jit(|jit| {
+                let slot = match &jit.slots[trace_cache_index(CASE1)] {
+                    TraceSlot::Empty => "Empty".to_string(),
+                    TraceSlot::Counting { pc, hits, .. } => format!("Counting({pc:X},h={hits})"),
+                    TraceSlot::Rejected { pc, .. } => format!("Rejected({pc:X})"),
+                    TraceSlot::Compiled(t) => format!("Compiled({:X})", t.pc),
+                };
+                eprintln!(
+                    "[DBG] case1 slot={slot} durable={} strikes={} attempts={}",
+                    jit.is_structurally_rejected(CASE1),
+                    jit.has_no_terminal_strikes(CASE1),
+                    attempts_for(CASE1)
+                );
+            });
+        }
+        assert!(
+            compiled_case.is_some(),
+            "an alternate dispatch case must be exit-seeded and compile"
+        );
+        let (compiled_case_pc, compiled_case_ops, last) = compiled_case.unwrap();
+        assert_eq!(
+            compiled_case_ops, TRACE_MIN_OPS,
+            "the alternate case must finish at the dispatch head instead of recording through it"
+        );
+        assert_eq!(
+            last.and_then(|op| op.op.taken_target(op.pc)),
+            Some(DISPATCH),
+            "the case continuation links back to the common dispatcher"
+        );
+        // Semantics: alternating bytecode increments D1 and D2 in lockstep.
+        assert!(
+            cpu.d(1) > 100,
+            "case 0 ran natively many times: {}",
+            cpu.d(1)
+        );
+        assert!(
+            cpu.d(1).abs_diff(cpu.d(2)) <= 1,
+            "the two dispatch cases alternate: D1={} D2={}",
+            cpu.d(1),
+            cpu.d(2)
+        );
+        assert_eq!(cpu.d(3), cpu.d(1), "case 0 executes all three case ops");
+        assert_eq!(cpu.d(4), cpu.d(2), "case 1 executes all three case ops");
+
+        let row = super::super::trace_profile::snapshot()
+            .rows
+            .into_iter()
+            .find(|row| row.start_pc == compiled_case_pc)
+            .expect("compiled case appears in the profile");
+        assert!(
+            row.link_exits > 0,
+            "the case completed onto the dispatch head"
+        );
+        assert!(
+            row.chained_calls > 0,
+            "the completed case entered the compiled dispatcher without interpretation"
         );
     }
 }

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -48,8 +48,14 @@ pub struct TraceProfileRow {
     pub jit_retired: u64,
     /// Exits caused by a guarded branch taking an unrecorded direction.
     pub guarded_branch_exits: u64,
-    /// Guard exits at this head that entered a compiled continuation
-    /// trace (bounded chaining). `guarded_branch_exits` alone cannot
+    /// Exits where the trace ran to completion and landed on another
+    /// compiled trace's head (a link exit). Like a guarded branch exit
+    /// this can enter a continuation, so `chained_calls` is bounded by
+    /// the SUM of the two, not by guard exits alone.
+    pub link_exits: u64,
+    /// Exits at this head (guarded-branch or link) that entered a
+    /// compiled continuation trace (bounded chaining). Exit counts alone
+    /// cannot
     /// separate a parent that exits and thrashes from one that exits and
     /// chains productively; this and `chained_retired` make the split.
     pub chained_calls: u64,
@@ -502,13 +508,13 @@ impl TraceProfileSnapshot {
         let _ = writeln!(out, "compiled traces by retired instructions");
         let _ = writeln!(
             out,
-            "rank  start_pc  ops      calls      retired avg_ops guard_exits chained chain_retired rerecords"
+            "rank  start_pc  ops      calls      retired avg_ops guard_exits link_exits chained chain_retired rerecords"
         );
         for (rank, row) in compiled_rows.iter().take(40).enumerate() {
             let average = row.jit_retired as f64 / row.native_calls as f64;
             let _ = writeln!(
                 out,
-                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2} {:>11} {:>7} {:>13} {:>9}",
+                "{:>4}  {:08X}  {:>3} {:>10} {:>12} {:>7.2} {:>11} {:>10} {:>7} {:>13} {:>9}",
                 rank + 1,
                 row.start_pc,
                 row.compiled_ops,
@@ -516,6 +522,7 @@ impl TraceProfileSnapshot {
                 row.jit_retired,
                 average,
                 row.guarded_branch_exits,
+                row.link_exits,
                 row.chained_calls,
                 row.chained_retired,
                 row.adaptive_rerecords
@@ -740,6 +747,7 @@ struct Row {
     native_calls: u64,
     jit_retired: u64,
     guarded_branch_exits: u64,
+    link_exits: u64,
     /// See `TraceProfileRow::chained_calls` / `chained_retired`.
     chained_calls: u64,
     chained_retired: u64,
@@ -878,6 +886,7 @@ impl Profile {
                 native_calls: row.native_calls,
                 jit_retired: row.jit_retired,
                 guarded_branch_exits: row.guarded_branch_exits,
+                link_exits: row.link_exits,
                 chained_calls: row.chained_calls,
                 chained_retired: row.chained_retired,
                 adaptive_rerecords: row.adaptive_rerecords,
@@ -1174,7 +1183,16 @@ pub(crate) fn note_guarded_branch_exit(pc: u32, cpu_type: CpuType) {
     });
 }
 
-/// A guard exit at `pc` entered a compiled continuation trace which
+/// The trace at `pc` ran to completion and landed on another compiled
+/// trace's head, so it can chain there without a guard exit.
+pub(crate) fn note_link_exit(pc: u32, cpu_type: CpuType) {
+    PROFILE.with_borrow_mut(|profile| {
+        let row = profile.0.row(pc, cpu_type);
+        row.link_exits = row.link_exits.saturating_add(1);
+    });
+}
+
+/// An exit at `pc` entered a compiled continuation trace which
 /// retired `retired` guest instructions before returning (or missing).
 pub(crate) fn note_chained(pc: u32, cpu_type: CpuType, retired: u32) {
     PROFILE.with_borrow_mut(|profile| {


### PR DESCRIPTION
## Summary

This PR adds five general trace-JIT mechanisms needed to follow a bytecode
dispatcher efficiently:

1. an exit-seeded continuation may finish by linking to an already compiled
   trace head;
2. `MOVE` may read from the PC-relative addressing modes used by constant and
   jump tables;
3. `JMP (d8,PC,Xn)` may continue through one recorded target, with an exact
   side exit for every other target and constant-time guard classification for
   guard-free traces;
4. discontiguous traces validate one memory slice per contiguous code segment
   instead of one virtual-bus read per instruction;
5. the direct-mapped trace cache grows from 4,096 to 16,384 slots, reducing
   collisions without adding a probe loop.

The first three commits let the JIT compile through SimCity 2000's dispatcher
and case handlers instead of retaining only the short prefix before the jump
table. On the fixed 400M-instruction SC2K census, those commits raise JIT
coverage from **46.94% to 54.98%** (+8.04 percentage points). Coverage alone
did not produce a wall-time win because it also created more, shorter native
calls. The final two commits and the guard-index optimization reduce the entry,
validation, and cache-churn costs exposed by that new trace shape.

In a direct production comparison of current `master` against the exact clean
five-commit tree, the candidate won all six accepted interleaved pairs. Paired
median: **-9.82% wall time and -9.24% user CPU**. The acceptance gate, exact
binaries, full table, rejected attempts, and outlier treatment are below.

The branch is exactly five commits on `master` (`01a4f7b`):

```text
b3e52e2 perf(jit): expand the direct-mapped trace cache
d125c4c perf(jit): validate discontiguous trace code by segment
5fd2899 perf(jit): guarded computed JMP — trace through jump-table dispatch
d1b8725 perf(jit): admit PC-relative MOVE sources ((d16,PC) and (d8,PC,Xn))
5d1157f perf(jit): link exits — a region reaching a compiled head is a valid trace
```

Every commit carries:

```text
Co-Authored-By: GPT-5.6 <noreply@openai.com>
```

The existing Claude co-authorship trailers on the first three commits are
also preserved.

The branch does **not** contain the previously declined Cranelift-verifier
change, guarded `RTS`, or the unrelated immediate-ALU and PC-relative `LEA`
admissions from the earlier experimental stack.

## Explanation of the change

### What SC2K's dispatcher is doing

SC2K contains a small interpreter inside the 68k application. Its bytecode is
game data, not 68k machine code. Each iteration roughly does this:

```text
read the next SC2K bytecode
use it to select an entry in a nearby table
jump to the corresponding 68k handler
run the handler
return to the dispatcher for the next bytecode
```

The important portion of the hot dispatcher is equivalent to:

```asm
MOVE.W  (6,PC,D0.W),D0   ; load a signed handler offset from a table
JMP     (PC,D0.W)        ; jump to the selected handler
```

For readers unfamiliar with 68k notation:

- `PC` is the program counter: the address of the instruction being executed.
- `D0` is a data register. `D0.W` means use its low 16 bits as a signed index.
- `(6,PC,D0.W)` means memory at a small fixed displacement from this
  instruction plus the runtime index in `D0`.
- `.W` means a 16-bit word.
- The table stores relative offsets. The subsequent `JMP` combines the
  selected offset with a PC-relative base to obtain a handler address.

Before this PR, recording stopped before the indexed table read. Even if a
case handler later became traceable, recording it back to the dispatcher was
rejected because that continuation reached an existing trace instead of
closing a backward branch of its own.

The commits solve those boundaries in execution order, then remove the costs
that the newly discontiguous dispatcher traces expose.

## Commit 1: link exits

Commit: `5d1157f perf(jit): link exits — a region reaching a compiled head is
a valid trace`

### Previous behavior

A guard exit may land in a handler that eventually rejoins its parent loop.
Recording starts at that exit target and follows the handler, but when it
reaches the already compiled parent head, the handler has no terminal branch
of its own. The recorder therefore rejected useful work with
`NoTraceTerminal`, or continued into the parent and built a duplicate
supertrace.

### New behavior

Recordings remember whether they were seeded by a guard exit. Only those
exit-seeded recordings may finish when their next instruction is an existing
compiled head. The continuation retains its own operations up to that point;
its non-branch tail materializes the sequential successor PC, and the existing
bounded chaining path immediately enters the compiled neighbor.

`pending_exit_seed` carries that provenance across the decoded loop's
immediate post-exit probe. Without it, the same exit would count twice and the
second probe would begin an ordinary recording that lacks permission to
link-finish.

The profiler records a link exit separately from a guarded-branch exit, so
every chained invocation still has an attributable source.

### Safety boundary and focused verification

- Ordinary loop recordings cannot link-finish. Allowing them to stop at an
  interior compiled head can replace a useful whole loop with a short stub.
- A watched link target is counted but is neither chained nor recorded across
  the watch boundary.
- Chaining remains bounded by the existing chain and instruction budgets.
- Each linked trace validates its own guest instruction bytes before entry.
- A child validation miss preserves the parent's already retired count while
  returning the changed opcode to full dispatch.
- One robustness nit is noted for review rather than silently carried: the
  pending exit-seed marker is consumed by the immediate post-exit probe at
  the seeded address. If that probe does not occur (the batch's instruction
  budget ran out exactly at the boundary, or a recording was already
  active), the marker survives until a later ordinary probe at that same
  address, which then starts its recording with link-finish permission it
  would not otherwise have. The resulting trace is still correct — at worst
  a shorter stub that chains into the compiled neighbor — so the effect is
  bounded. The tightening (clear the marker on any probe at a different
  address) is left as a follow-up so the published tree stays byte-identical
  to the measured one.

`an_exit_seeded_recording_link_finishes_at_a_compiled_head` proves that an
exit-seeded continuation stops at the compiled neighbor, retains only its own
operations, and uses the normal chain. Related tests cover watched targets,
validation misses, productive guard exits, and memory bails that must not
create exit candidacy.

## Commit 2: PC-relative `MOVE` sources

Commit: `d1b8725 perf(jit): admit PC-relative MOVE sources ((d16,PC) and
(d8,PC,Xn))`

### Previous behavior

The recorder rejected `MOVE` when its source used either form:

```asm
MOVE.W  (d16,PC),Dn       ; fixed data near the instruction
MOVE.W  (d8,PC,Xn),Dn     ; table entry selected by a register
```

The second form is the jump-table lookup at the center of SC2K's dispatcher.

### New behavior

The decoder resolves the architectural PC portion once while recording:

- `(d16,PC)` becomes a `PcDisp` source with its resolved constant address;
- `(d8,PC,Xn)` becomes `PcIndex`: a constant PC base plus the live index
  register, word/long selection, legal scale, and signed displacement.

Only the address calculation is folded. The table value is read from guest
memory every time the trace runs, so guest changes to data tables remain
visible. PC-relative modes remain invalid as `MOVE` destinations.

`PcDisp` intentionally remains distinct from `AbsLong`. They may resolve to
the same numerical address, but the 68000 charges different cycles for the
two addressing modes. Treating PC-relative displacement as absolute-long
would over-retire `MOVE.W` and `MOVE.L` by four cycles. The tests pin the
interpreter's exact cycle result instead of assuming those modes are
interchangeable.

For a pre-68020 CPU, brief-index scaling stays at architectural 68000
behavior. Later-CPU scale bits and long-index selection are decoded only when
the selected CPU model permits them.

### Safety boundary and focused verification

- Runtime memory accesses use the existing checked fast-memory window.
- Bounds and pre-68020 alignment checks occur before register or flag state
  commits.
- Table values are runtime data, not constants embedded in native code.
- Opcode and extension words remain covered by ordinary trace-code
  validation.

`portable_move_from_pc_index_reads_the_live_table` changes the table after
recording and proves the trace sees the new value.
`pc_relative_move_sources_match_the_68000_interpreter_and_cycles` compares
registers, flags, memory, and exact cycles. The native comparison keeps both
JIT executors in lockstep.

## Commit 3: guarded computed `JMP`

Commit: `5fd2899 perf(jit): guarded computed JMP — trace through jump-table
dispatch`

### Previous behavior

Unlike an ordinary branch, `JMP (d8,PC,Xn)` has no single static target. The
register-selected offset may name a different handler on every dispatch, so
the recorder ended at this instruction.

### New behavior

The recorder decodes the brief PC-indexed extension and records the target
observed on that execution. Native and portable execution both:

1. read the live index register;
2. sign-extend it as a word when required and apply the legal scale;
3. add it to the recorded PC-relative base;
4. commit the architectural jump (`PC = actual target` and change-of-flow);
5. compare the actual target with the recorded target.

If the target matches, execution continues into the recorded handler. If it
differs, the trace exits after retiring the `JMP`, with `PC` pointing at the
actual selected handler. Exit seeding can then compile that handler as a
continuation; commit 1 lets it finish when it rejoins the dispatcher.

The native exit also writes the previous PC and real instruction word
(`IR = 0x4EFB`), matching the interpreter and portable executor.

### Guard exits and the full-retirement case

A guard is a runtime check that proves the path recorded earlier still matches
the path selected now. A guard exit is the safe fallback when it does not: the
trace stops before executing the wrong recorded handler and returns to normal
dispatch at the real target.

The guarded `JMP` can be the last operation in a trace. A mismatch there
legitimately retires the full numerical operation count, so
`retired == trace length` cannot distinguish it from clean completion.
Classification instead checks the committed previous PC, current PC,
instruction shape, and recorded target. A last-operation mismatch therefore
still seeds the actual handler and counts as a guard exit.

### Constant-time classification for guard-free traces

The first guarded-JMP implementation searched the complete operation vector
after every native trace return to find an operation capable of explaining a
guard exit. SC2K makes about 12.47 million native calls in the core census, so
that O(trace length) search taxed even traces with no guard.

Compilation now records a 128-bit mask over the at-most-128 trace operations.
A bit is set only for `Branch` operations with a recorded direction and
`PcIndexJmp` operations with a recorded target. A guard-free trace performs
one zero check. A guarded trace scans only set bits and reuses the exact
existing state classifier, including the case where a branch target equals
its fallthrough address. This adds no allocation.

In a six-pair isolation against the otherwise identical candidate, the mask's
median effect was **-2.90% wall and -3.19% user**, with 5/6 wall wins.

### Safety boundary and focused verification

- The real jump commits before the target comparison; a miss exits at the
  selected guest address rather than speculatively running the recorded case.
- The expected target predicts control flow; it does not replace the live
  index.
- Both match and mismatch charge the exact 14-cycle jump cost and one retired
  guest instruction.
- Unsupported full-format index extensions remain outside the decoder.
- The mask contains only operation kinds that the unchanged state classifier
  can recognize.

`guarded_pc_index_jmp_matches_portable_and_seeds_a_last_op_exit` checks native
and portable results in both target directions, including cycles, retirement,
PC/previous-PC/IR, mask contents, and last-operation exit seeding.

`a_bytecode_dispatch_loop_compiles_through_the_guarded_computed_jump` runs a
miniature alternating bytecode dispatcher. It proves that the dispatcher
compiles through the computed jump, the alternate case becomes an exact
three-operation continuation rather than a duplicate supertrace, both case
bodies complete, and the continuation links back to the compiled dispatcher.

## Commit 4: validate discontiguous trace code by segment

Commit: `d125c4c perf(jit): validate discontiguous trace code by segment`

### Previous behavior

Before running compiled guest code, the JIT verifies that the 68k instruction
bytes in memory still match the bytes used for compilation. This is necessary
because a 68k program may rewrite its own code; running a stale translation
would execute the wrong guest instructions.

A conventional loop occupies one consecutive range of guest addresses and
can be validated with one slice comparison. A dispatcher trace contains the
dispatcher at one address and a selected handler at another. Previously every
such discontiguous trace fell back to reading and checking each recorded
instruction through the virtual bus on every entry. That was correct but made
the new dispatcher traces expensive to enter.

### New behavior

The recorder groups adjacent instruction bytes into `TraceCodeSegment`
records. Each says where a consecutive code range starts in guest memory,
where its expected bytes begin in the trace snapshot, and how many bytes it
contains.

For example, a trace with a dispatcher at `0x008C7600..0x008C761F` and a
handler at `0x008D2700..0x008D2711` has two segments. Entry performs two slice
comparisons instead of one virtual-bus read per instruction. This changes only
how the existing validity check is batched, not which instructions run or
their order.

### Safety boundary and focused verification

- Every segment is checked before the first trace operation executes. A
  changed later handler cannot allow an unchanged dispatcher prefix to run.
- The fast path requires every complete segment to lie inside the active
  direct-memory window and match its snapshot.
- Any failure falls through to the existing per-instruction validator, which
  identifies the first changed instruction, invalidates the translation, and
  returns without committing guest state.
- Address gaps between blocks are not assumed contiguous and are not treated
  as trace code.

`fast_validation_checks_every_discontiguous_code_segment_before_execution`
constructs two separated segments, changes only the second, and proves that
neither segment executes before invalidation. The dispatcher composition test
also checks that the dispatcher and handler are represented as two segments.

## Commit 5: expand the direct-mapped trace cache

Commit: `b3e52e2 perf(jit): expand the direct-mapped trace cache`

### Previous behavior

The cache used 4,096 direct-mapped slots. “Direct-mapped” means each guest
program counter has one possible slot:

```text
(PC >> 1) & (slot_count - 1)
```

The lookup is intentionally one shift, one mask, and one slot read. With
4,096 slots, however, heads separated by `0x2000` bytes map to the same slot.
Installing one evicts the other even if both are hot. SC2K's dispatcher adds
useful heads and continuations across separated code regions, so collisions
can repeatedly pay the counting, recording, validation, and compilation cost.

### New behavior

The cache grows to 16,384 slots. The lookup formula and direct-mapped policy
are unchanged, but the address distance that necessarily aliases grows from
`0x2000` to `0x8000` bytes.

This changes capacity and collision frequency, not replacement semantics.
Each slot still stores the full guest PC and CPU type, so a real alias is a
safe miss or eviction rather than execution of another address's trace.

### Trade-off and focused verification

- Slot and candidacy tables use four times the storage.
- Lookup still has no probe loop and adds no hot-path branch.
- Invalidation, code validation, CPU-type discrimination, and bounded tracing
  are unchanged.
- Collision tests derive their second address from `TRACE_CACHE_SIZE`, assert
  that it shares a slot, and then prove the old eviction and rejection-policy
  behavior under the new 16K geometry.

In absolute terms: each slot holds its `CompiledTrace` inline (about 180
bytes on this development target; exact size is target/configuration-
dependent because it contains several `Vec` headers), so the slot table
grows from roughly 0.75 MB to 3 MB per `TraceJit`, which is thread-local
and exists in portable/WASM builds too. The four two-way side tables
indexed like the cache (`earned_call_permission`, `structurally_rejected`,
`compiled_before`, `no_terminal_strikes`) grow from about 160 KB to 640 KB
combined.

## How the five commits compose

```text
dispatcher head
  -> PC-relative MOVE reads the live jump-table entry
  -> guarded computed JMP follows the recorded case
  -> another case exits at its real handler address
  -> exit seeding compiles that handler as a continuation
  -> link completion rejoins the existing dispatcher trace
  -> segmented validation checks the separated blocks cheaply
  -> the larger cache keeps the additional heads resident longer
```

Nothing recognizes SC2K bytecodes or hard-codes its addresses. The JIT sees
ordinary 68k addressing and control flow, records one observed path, and uses
generic guard and continuation machinery for other paths.

## Performance evidence

### Deterministic dispatcher coverage

The fixed census executes the same scripted SC2K path for 400M guest
instructions and reaches guest tick 118533:

| arm | JIT-retired | coverage | native calls | ops/native call |
|---|---:|---:|---:|---:|
| current `master` | 187,775,765 | 46.94% | 9,820,231 | 19.12 |
| first three commits | 219,931,324 | 54.98% | 12,467,858 | 17.64 |

The dispatcher mechanisms add **32,155,559 JIT-retired instructions** and
**8.04 coverage points**. The native-call count rises while average work per
call falls, which is why coverage is not presented as a speed claim. The last
two commits and guard mask admit no additional opcode; they target the cost of
entering, validating, classifying, and retaining the traces already exposed.

### Direct production timing: `master` versus the complete candidate

The release binaries use identical Systemless source and differ only in the
m68k tree. Trace profiling is disabled. A measurement-only environment switch
suppresses the 800 periodic PNG encodes but retains screenshot 9999, its guest
tick check, the fixed input script, and the 400M-instruction budget.

- `master` revision: `01a4f7b`; binary SHA-256
  `a1b671d8085281eb92567dbd5565dba25ffb5736b853bf083c1464133a616045`
- measured candidate tree: `40d337dc0caf489b59a8fc3057c7be8520b6a78d`; presentation
  head `b3e52e2`; binary SHA-256
  `fa079d71d2849745bc6f13e0defc35f5ac571453c54dd3472d31d6263d3f390c`

Every accepted arm had to reach tick 118533, emit exactly one final
screenshot, finish within 45 seconds, and have `user / real >= 95%`. If either
arm failed, the complete pair was discarded. Order alternated, with three
accepted pairs in each order.

| pair | master wall | candidate wall | wall delta | master user | candidate user | user delta |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 16.07s | 15.75s | -1.99% | 15.63s | 15.30s | -2.11% |
| 2 | 17.77s | 16.60s | -6.58% | 17.35s | 16.31s | -5.99% |
| 3 | 14.51s | 13.94s | -3.93% | 14.13s | 13.52s | -4.32% |
| 4 | 19.67s | 13.96s | -29.03% | 18.95s | 13.59s | -28.28% |
| 5 | 20.48s | 17.69s | -13.62% | 19.62s | 17.17s | -12.49% |
| 6 | 18.91s | 16.44s | -13.06% | 18.14s | 15.86s | -12.57% |

The candidate wins 6/6 wall pairs and 6/6 user pairs. Paired median:
**-9.82% wall, -9.24% user**. Paired mean: -11.37% wall, -10.96% user.

Pair 4 is an obvious host-frequency outlier even though both arms passed the
outcome-independent gate. It is retained rather than silently discarded, but
neither it nor the mean is the headline. The median is robust to that one
outlier. Several other attempts were rejected in full for falling below the
95% utilization gate; no favorable arm from a rejected pair was reused.

As narrower mechanism checks:

- the complete candidate versus the three-commit core has median **-2.31%
  wall and -2.37% user**, with 4/6 wall wins and 5/6 user wins;
- the precomputed guard mask versus the otherwise identical candidate has
  median **-2.90% wall and -3.19% user**, with 5/6 wall wins.

The direct five-commit comparison against `master`, rather than either
narrower and noisier ablation, is the PR-level result.

### EV Override regression check

Three of this PR's commits (the guard mask, segmented validation, and the
larger cache) sit on every workload's hot path, so the PR was also checked
on a second application rather than only the dispatcher workload above.

Instrument: the headless census harness, fixed input script, 400 million
guest instructions, m68k trace profiling enabled. Metric: `jit_retired /
400M` — the fraction of retired guest instructions that retired inside
compiled traces. Coverage is a mechanism check, not a speed claim. EV
Override's guest timers advance on wall time while the budget advances on
retired instructions, so arm runs are interleaved pairwise and each pair
starts from a fresh save game; running whole arms as blocks had overstated
deltas by more than half a point in earlier work on this harness.

Arms (release binaries, identical Systemless source, only the m68k revision
differs):

- base: master `01a4f7b`; binary SHA-256
  `eaae440e858784d1cb7fddc0f3a8318f8949134ea9ac5388f99e7f268d8274ed`
- this PR: `b3e52e2` (tree `40d337dc…`, identical to the measured tree);
  binary SHA-256
  `8cb37c4c6d042a9b300b60b7e9a936867a5c1c1cb653a71719fbadf74ae301e4`

| Pair | base | this PR | delta |
|---|---:|---:|---:|
| 1 | 71.86% | 71.66% | −0.20 pts |
| 2 | 71.21% | 71.35% | +0.14 pts |
| 3 | 71.88% | 71.35% | −0.53 pts |

The deltas sit inside this harness's observed run-to-run jitter for EV
Override (about ±0.5 points): this PR neither taxes nor helps that
workload's coverage. For contrast, the same pair of trees moves the
deterministic SC2K census by +8 points, which is why the dispatcher
mechanisms are presented as SC2K-targeted with an explicit EV-neutrality
check rather than as general gains.

On SC2K itself, the complete five-commit tree — which the coverage table
above shows only as its three-commit core — measures JIT-retired
`220,363,450` (55.09%) with `12,510,013` native calls, versus master's
`187,775,765` (46.94%) and `9,820,231`. The final two commits add about
+0.11 coverage points over the three-commit core while keeping the entry
count essentially unchanged.

Six interleaved production wall-time pairs (periodic screenshot encoding
suppressed, fixed 400M guest budget) were inconclusive under this host's
frequency drift: paired wall deltas ranged from −9.4% to +21.8% with no
consistent sign. The harness's own host-work counters, which cancel that
drift far better than wall time, are neutral: host instructions per guest
instruction ranged −1.5%..+1.5% around a median of −0.2%. On this
workload the five commits neither tax nor help host work — consistent
with the unchanged coverage above.

## Repository verification

The measured prototype and the presentation branch have the identical final
Git tree `40d337dc0caf489b59a8fc3057c7be8520b6a78d`.

```sh
cargo test --lib --no-default-features
cargo test --lib --features jit
cargo test --lib --features jit,trace-profile
cargo clippy --lib --features jit,trace-profile -- -D warnings
cargo fmt --check
git diff --check master...HEAD
```

Results: **162**, **227**, and **263** tests respectively; clippy, formatting,
and diff checks are clean.

## Why the remaining experiments are not in this PR

The previously declined release-mode Cranelift-verifier bypass is removed and
will not be republished here. Guarded `RTS`, immediate-memory ALU admission,
and PC-relative `LEA` admission are also absent. They are independent semantic
changes, are not required for the clean wall-time win, and would expand this
review beyond the dispatcher foundation and the two costs directly exposed by
it.

Segmented validation, the larger cache, and the guard index are included
because isolated measurements showed that entry/validation overhead was the
reason the additional coverage failed to become a wall-time win. The final
five-commit tree then cleared the predeclared direct-win threshold. The other
opcode admissions did not clear that same scope-and-evidence test.

## Biggest remaining JIT levers

This section was revised on 2026-08-23 after profiling where the census
process actually spends CPU, because the profile reverses the ranking an
earlier draft gave. Instrument: macOS `sample` (1 ms interval, two
8-second attachments at different phases) on this PR's exact census
binary during the deterministic 400M-instruction SC2K run; leaf
(self-time) attribution, cross-checked against an equivalent tree on a
quiet host. Consistently across the samples:

- interpreter + batch runner (inlined execution): 53–55% of process CPU
- memory bus, mostly serving the interpreter: ~6%
- the entire Rust trace-entry/exit boundary — cache probe, byte
  validation, exit classification, chaining bookkeeping: 3.2–3.7%
- JIT-generated code itself: 1–2%
- the remainder is census-harness overhead (periodic screenshot PNG
  encoding and trace-profile accounting, both absent in production
  builds) plus trap/OS services in the host.

Two consequences, in priority order:

1. **Further admissions/coverage are the top SC2K lever after this PR.**
   The ~45% of guest instructions that still retire in the interpreter
   cost roughly forty times as much per instruction as the 55% that
   retire natively. The census failure tables concentrate the blockers
   into a compact admission cluster — indexed-EA forms
   (`MOVEA.L (0,An,Dn.L)` pointer-table loads,
   `BTST`/`ANDI`/`CMPI` `#imm,(An,Xn)`, indexed `MOVE.B` stores) plus
   `JSR`/`RTS` boundaries around small helpers — rather than a long tail
   of unrelated shapes.
2. **Cross-trace mechanisms compete for the small boundary pool.** A
   multi-target dispatcher inline cache and validated native
   trace-to-trace links both remain coherent designs, but everything
   they can remove lives inside that ≈4% bucket, so neither is ranked
   next on this workload.

For whoever attempts the inline cache later: target selection cannot
simply choose the most frequent handler. A removed experiment did that
and eliminated roughly 898,000 dispatcher guard exits, but the selected
handler immediately encountered another data-dependent branch. Native
calls became shorter and total JIT retirement moved by only -0.013
percentage points. The policy must optimize useful native work retained
per entry, not raw target frequency.

EV Override's short forward-branch problem is addressed separately by
the if-conversion work; combining it with this dispatcher PR would mix
independent workloads, control-flow mechanisms, and performance claims.


