### PR TITLE
perf(jit): scope the memory-ALU amortization refusal to short regions

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -2555,19 +2555,27 @@ impl TraceJit {
 
         // Short checked memory ALU regions do not amortize trace validation
         // and the native/Rust boundary. Keep those on the decoded-memory path
-        // unless the measured indirect-call length threshold above provides
-        // enough independent work to cover the fixed cost. Trap-boundary
-        // segments get NO exemption here: a TrapExit ending adds trap
-        // dispatch and re-entry on top of the fixed costs, so the
-        // amortisation economics only tighten.
+        // unless the region carries enough independent work to cover the
+        // fixed cost. The length bound reuses the measured indirect-call
+        // threshold (seven-op trials won at least 7.2% across register,
+        // memory-ALU, and memory-heavy mixes, and an indirect call pays
+        // MORE per entry than a plain linear trace, so the bound is
+        // conservative here). The rejection used to be presence-based with
+        // no length test; once call-through recordings began spanning
+        // whole subroutines, a single memory compare deep inside a long
+        // recording rejected regions the gate's economics never measured.
+        // Trap-boundary segments get no exemption: a TrapExit adds trap
+        // dispatch and re-entry on top of the fixed costs.
         if !self_loop
             && !ends_in_indirect_jsr
+            && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS
             && ops.iter().any(|op| {
                 matches!(
                     op.op,
                     JitTraceOp::AluMemToReg { .. }
                         | JitTraceOp::CmpiWordMem { .. }
                         | JitTraceOp::AddrCmpMemToReg { .. }
+                        | JitTraceOp::AddaMemToReg { .. }
                 )
             })
         {
@@ -18707,6 +18715,103 @@ mod portable_tests {
             .expect("a near-branching callee compiles");
         assert_eq!(near.callee_start, 0x0110);
         assert_eq!(near.callee_end, 0x0134 + 4);
+    }
+
+    /// The memory-ALU amortization refusal is a SHORT-segment rule: a
+    /// non-loop region below the measured length bound rejects, and the
+    /// same shape with enough independent work compiles. Both the
+    /// read-only compare family and the mutating ADDA admission are
+    /// gated identically.
+    #[test]
+    fn linear_memory_alu_gate_rejects_only_short_regions() {
+        let mem_op = |op: JitTraceOp, opcode: u16| TraceBuildOp {
+            opcode,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op,
+        };
+        let build = |first: TraceBuildOp, fillers: usize| {
+            let mut ops = vec![first];
+            for i in 0..fillers {
+                ops.push(TraceBuildOp {
+                    opcode: 0x7000,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0102 + 2 * i as u32,
+                    op: JitTraceOp::Moveq {
+                        reg: (i % 4) as u8,
+                        data: i as u32,
+                    },
+                });
+            }
+            let last_pc = 0x0102 + 2 * fillers as u32;
+            ops.push(TraceBuildOp {
+                opcode: 0x6010,
+                extension: None,
+                extension2: None,
+                pc: last_pc,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: 0x10,
+                    length: 2,
+                    expected_taken: None,
+                },
+            });
+            ops
+        };
+        let cmp = || {
+            mem_op(
+                JitTraceOp::AluMemToReg {
+                    op: JitBinaryOp::Cmp,
+                    size: Size::Word,
+                    src: JitEa::Ind(1),
+                    dst: 0,
+                },
+                0xB051,
+            )
+        };
+        let adda = || {
+            mem_op(
+                JitTraceOp::AddaMemToReg {
+                    size: Size::Word,
+                    src: JitEa::Ind(1),
+                    dst: 3,
+                },
+                0xD6D1,
+            )
+        };
+
+        let mut mem = vec![0u8; 0x1000];
+        let mut c = cpu();
+        c.set_cpu_type(CpuType::M68040);
+        c.set_a(1, 0x0200);
+        attach_window(&mut c, &mut mem);
+        let mut jit = TraceJit::new();
+
+        // Below the bound (op + 4 fillers + branch = 6 < 7): both families
+        // reject with the amortization reason.
+        for short_first in [cmp(), adda()] {
+            let short = jit.compile_decoded_ops_reason(
+                &c,
+                0x0100,
+                CpuType::M68040,
+                build(short_first, 4),
+                None,
+            );
+            assert!(
+                matches!(short, Err(RegionRejectReason::LinearMemoryAlu)),
+                "a short non-loop memory-ALU region must reject: {:?}",
+                short.as_ref().err()
+            );
+        }
+
+        // At the bound (op + 5 fillers + branch = 7): the same shapes
+        // carry enough independent work and compile.
+        for long_first in [cmp(), adda()] {
+            jit.compile_decoded_ops_reason(&c, 0x0100, CpuType::M68040, build(long_first, 5), None)
+                .expect("a bound-length memory-ALU region compiles");
+        }
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]


### PR DESCRIPTION
## What this does

One commit, stacked on #142 (and through it #141): the `LinearMemoryAlu`
compile-stage refusal — which rejects non-loop, non-indirect-JSR regions
containing a checked-memory ALU operation — now rejects only regions
**shorter than `TRACE_MIN_INDIRECT_JSR_OPS` (7)**. Long recordings that
happen to contain a memory compare or add now compile. The gated
operation list also gains #142's `AddaMemToReg`, closing the interim
policy noted in that PR's body: the unified rule is that memory-ALU
operations reject only short non-loop segments.

## Why

The refusal's measured rationale was always about *short* segments: a
linear region whose work is dominated by one or two checked memory
operations does not amortize the fixed costs of trace entry (cache
probe, byte validation, ABI round trip), and the decoded-memory
interpreter tier runs those few operations cheaper. When it was
introduced, non-loop linear recordings were inherently short — they
ended at the first branch — so a presence test and a length test were
indistinguishable.

That stopped being true once recordings grew: #141's call-through
records through `JSR`/`RTS`, and the pending if-conversion work (#138)
records through short forward branches. Non-loop recordings now
routinely span whole subroutines, and a single memory compare deep
inside a 30–100-op recording rejected regions whose economics the gate
never measured. On a tree carrying all four pending PRs, one hot
SimCity 2000 region (`008D2682..28F4`) lost its traces entirely to this
gate — its interpreted retirement rose from 7.5M to 17.0M instructions
— and per-region census attribution showed the same presence-test
rejections scattered across both workloads.

## Why the bound is 7

`TRACE_MIN_INDIRECT_JSR_OPS` is an existing measured constant: in paired
100M-instruction runs, six-op indirect-call traces were only 0.6% faster
at the median and regressed in one of five trials, while **every
seven-op trial won by at least 7.2% across register, memory-ALU, and
memory-heavy mixes**. An indirect call pays *more* per entry than a
plain linear trace (validation + boundary + the call dispatch), so
reusing its break-even length here is conservative rather than tuned.

## Safety boundary

- Compile-stage policy only: no change to recording, execution,
  validation, or any admitted operation's semantics.
- Short-segment behavior is unchanged for the existing gated list; the
  only newly rejectable shape is a short non-loop segment containing
  #142's `AddaMemToReg` (previously compiled; the unified rule now
  applies to it like its siblings).

## Tests

A six-op non-loop region containing a memory-ALU operation rejects with
`LinearMemoryAlu` — checked for both the read-only compare family and
`AddaMemToReg` — and the same shapes at seven ops compile. Suites:
269 / 233 / 166 library tests across `jit,trace-profile`, `jit`, and
`--no-default-features`; `clippy --lib -D warnings` and
`cargo fmt --check` clean.

## Measurements

A harness note first, because it moves every absolute number: the
census harness used for the earlier PRs fast-forwards guest time
through proven-idle boot waits, and its identity proof compared a
non-architectural CPU flag whose value depends on whether execution
arrived via the interpreter or a compiled trace (details and the fix
are in the comment on #134). All numbers below are from the repaired
harness, where trees are tick-comparable again; they are therefore not
directly comparable to the absolute figures in #141/#142's bodies,
which predate the repair. Within each comparison below, both arms run
the same harness.

### On this branch's own base (#142's head)

Fixed 400M-instruction SC2K census, this branch vs its base:

| arm | JIT-retired | coverage | native calls | ops/call | final guest tick |
|---|---:|---:|---:|---:|---:|
| #142 head | 244,682,234 | 61.17% | 15,451,360 | 15.84 | 135,079 |
| + this commit | 274,719,478 | **68.68%** | 16,520,258 | 16.63 | 135,079 |

Identical final guest tick means the two arms executed the same guest
work; the +7.51 coverage points move 30.0M instructions per run from
the interpreter into traces, and the surviving traces are LONGER on
average — the opposite of a coverage-for-fragmentation trade. Most of
the presence-test damage comes from #141's call-through recordings
alone; the pending if-conversion work only widens it further.

EV Override, three interleaved census pairs from a fresh save:

| pair | #142 head | + this commit | delta |
|---|---:|---:|---:|
| 1 | 71.48% | 73.56% | +2.08 pts |
| 2 | 71.18% | 74.62% | +3.44 pts |
| 3 | 71.52% | 74.81% | +3.29 pts |

Every pair positive and outside this harness's observed jitter: EV's
call-through recordings carry memory-ALU operations just as SC2K's do,
so this is a second-workload win rather than a mere regression check.

### On the full pending stack, where the gate bites hardest

Measured on a local tree carrying #134 + #138 + #141 + #142 (with the
merge resolution both #138 and #141 describe for whichever lands
second), where if-conversion makes long recordings common:

- SC2K census, identical guest work (both arms end at tick 135,042):
  coverage **62.73% → 70.51% (+7.78 points)**; interpreted retirement
  −21.8% (142.9M → 111.7M instructions); traces get longer
  (18.10 → 19.01 ops per native call); the gate-poisoned
  `008D2682..28F4` region leaves the top interpreted regions entirely.
- EV Override, three interleaved pairs: **+2.98 / +3.39 / +3.19
  points**, every pair positive and outside this harness's observed
  jitter — EV's call-through recordings carry memory-ALU operations
  just as SC2K's do.
- Six interleaved production pairs (release builds, no trace
  profiling, periodic screenshots suppressed), master vs the full
  stack including this commit: **host instructions −7.24% median,
  6/6 wins, range −6.84..−7.47%** — against −6.43% for the stack
  without it on the equivalent earlier measurement. Host instructions
  are the primary metric because this host's frequency drift makes
  wall time unable to resolve effects of this size; the workload is
  deterministic, so the per-pair instruction spread is ±0.3 points.

## Commit structure

One commit. If #142 is retargeted or declined, the only dependency is
the `AddaMemToReg` match arm in the gated list; dropping that arm makes
the commit apply to #141's head or master unchanged.
