### PR TITLE
fix(cpu): RTD raises change_of_flow so T0 trace sees it

### DIFF
--- a/src/core/decode.rs
+++ b/src/core/decode.rs
@@ -1379,6 +1379,9 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             if cpu.cpu_type == CpuType::M68000 {
                 illegal_instruction(cpu, bus)
             } else {
+                // RTD changes flow exactly as RTS does; T0 trace mode
+                // (trace on change of flow, 68020+) must see it.
+                cpu.change_of_flow = true;
                 let disp = cpu.read_imm_16(bus) as i16 as i32;
                 cpu.pc = cpu.pull_32(bus);
                 cpu.dar[15] = (cpu.dar[15] as i32).wrapping_add(disp) as u32;

--- a/tests/exception_frame_matrix_tests.rs
+++ b/tests/exception_frame_matrix_tests.rs
@@ -323,6 +323,55 @@ fn trace_pushes_format_2_on_020_plus() {
     }
 }
 
+/// T0 trace (trace on change of flow; the 68020/030/040 -- the 68060
+/// dropped the mode): sequential instructions must NOT trace, and every
+/// return must -- including RTD, whose handler was the one flow change
+/// that skipped the flag, hiding RTD returns from T0-stepping debuggers.
+#[test]
+fn t0_traces_rtd_returns_like_rts() {
+    const RETURN: u32 = 0x0500;
+    let t0_models = [CpuType::M68020, CpuType::M68030, CpuType::M68040];
+
+    // Sequential flow under T0: no trace.
+    for cpu_type in t0_models {
+        let mut bus = TestBus::new(0x10000);
+        let mut cpu = user_mode_cpu(&mut bus, cpu_type, 0x4000); // T0 set
+        bus.write_word(CODE, 0x7000); // MOVEQ #0,D0 (sequential)
+
+        step_once(&mut cpu, &mut bus);
+        assert_eq!(
+            cpu.pc,
+            CODE + 2,
+            "{cpu_type:?}: sequential flow does not T0-trace"
+        );
+        assert!(!cpu.is_supervisor(), "{cpu_type:?}: no exception was taken");
+    }
+
+    // RTS and RTD #4 under T0: both are changes of flow, both trace, and
+    // the group-2 frame stacks the return target as the next PC.
+    for words in [[0x4E75u16, 0x4E71], [0x4E74, 0x0004]] {
+        for cpu_type in t0_models {
+            let mut bus = TestBus::new(0x10000);
+            let mut cpu = user_mode_cpu(&mut bus, cpu_type, 0x4000); // T0 set
+            bus.write_word(CODE, words[0]);
+            bus.write_word(CODE + 2, words[1]);
+            bus.write_long(USP, RETURN); // the popped return target
+
+            step_once(&mut cpu, &mut bus);
+            check_frame(
+                &cpu,
+                &mut bus,
+                cpu_type,
+                &ExpectedFrame {
+                    vector: 9,
+                    stacked_pc: RETURN,
+                    format_2_instr: Some(CODE),
+                },
+            );
+        }
+    }
+}
+
 /// Illegal instruction: format $0 with the FAULTING instruction's PC, so
 /// the handler can decode or patch the opcode (AmigaOS SetFunction-style
 /// trap emulation depends on it).


### PR DESCRIPTION
## What this fixes

Every flow-changing instruction's interpreter handler raises the
`change_of_flow` flag — RTS, RTR, RTE, JSR, JMP, taken branches — except
RTD. One commit on master adds the missing line to RTD's handler.

## Why it matters

The flag's one architectural consumer is **T0 trace mode** (trace on
change of flow, SR bit 14, on the 68020/030/040 — the 68060 dropped the
mode): with T0 set, a trace exception must follow every instruction that
changes program flow, and RTD is one — it is RTS plus a stack
adjustment, and the 68020+ manuals place it in the same
change-of-flow class. Before this fix, a guest debugger single-stepping
flow changes with T0 silently missed every RTD return.

## Why nothing else changes

I audited every reader of the flag:

- `check_trace()` (T0 exceptions) — the fix's target, and it clears the
  flag after every instruction, so the effect is confined to the RTD
  instruction itself.
- The 68020 timing model reads it only when pricing Bcc.
- The 68060 branch-fold path consults it only for `F_BRANCH`
  instructions, which are group 6 (Bcc/BRA/BSR) — RTD is group 4 — and
  the 68060 has no T0 mode anyway.

So the only behavioral change is the newly raised (and correct) trace
exception after RTD when a guest runs with T0 set. No timing, flag, or
register behavior changes otherwise.

## Test

`t0_traces_rtd_returns_like_rts` in the exception-frame matrix suite,
over all three T0 models: a sequential instruction under T0 does not
trace; RTS and RTD both trace, vectoring through vector 9 with the
return target as the stacked next PC and the return instruction's
address in the format $2 extra long. The test fails without the fix
(the RTD case never takes the exception) and passes with it. Full run:
62 test suites green with `--features jit`, clippy and rustfmt clean.

## Relation to the trace JIT

The trace JIT keeps bit-for-bit interpreter parity, so today it
reproduces this quirk wherever it executes an RTD. Once this lands I'll
align the JIT's return terminals to raise the flag for RTD too (a
two-line change in the pending return-terminal work), keeping the two
tiers in lockstep in whichever order they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xXVFS9G1t9hEi33kN7MPN
