### PR TITLE
fix: preserve indirect TST in portable traces

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -5937,10 +5937,15 @@ fn execute_portable_an_disp(
             op: JitUnaryOp::Tst,
             size,
             reg,
-            ..
+            displacement,
         } => DecodedMemOp::Tst {
             size,
-            ea: FastEa::AnDisp(reg),
+            ea: if trace.extension.is_some() {
+                FastEa::AnDisp(reg)
+            } else {
+                debug_assert_eq!(displacement, 0);
+                FastEa::AnInd(reg)
+            },
         },
         JitTraceOp::AnDispUnary {
             op: JitUnaryOp::Clr,
@@ -19588,6 +19593,43 @@ mod portable_tests {
                 displacement: 0,
             }
         ));
+    }
+
+    #[test]
+    fn portable_tst_from_register_indirect_reads_exact_address() {
+        for (opcode, size) in [
+            (0x4A12u16, Size::Byte),
+            (0x4A52, Size::Word),
+            (0x4A92, Size::Long),
+        ] {
+            let mut mem = vec![0u8; 0x1000];
+            mem[0x0100..0x0102].copy_from_slice(&opcode.to_be_bytes());
+            // If the portable executor mistakes (A2) for d16(A2), this
+            // following word becomes a displacement and the nonzero value at
+            // A2+4 controls the flags instead of the zero value at A2.
+            mem[0x0102..0x0104].copy_from_slice(&0x0004u16.to_be_bytes());
+            mem[0x0204..0x0208].fill(0x80);
+
+            let mut cpu = cpu();
+            cpu.set_a(2, 0x0200);
+            cpu.set_ccr(0x10);
+            attach_window(&mut cpu, &mut mem);
+
+            let mut decode_bus = super::super::memory::LinearMemoryBus::new(0x1000);
+            decode_bus.write_word(0x0100, opcode);
+            let trace = decode_trace_op(&cpu, &mut decode_bus, 0x0100, CpuType::M68040)
+                .expect("TST (A2) should decode for portable execution");
+            let packed =
+                execute_portable_trace(&mut cpu, &[trace], CodeSpans::caller(0x0100, 0x0102));
+
+            assert_eq!(packed >> 32, 1, "{size:?} TST should retire");
+            assert_eq!(
+                cpu.get_ccr(),
+                0x14,
+                "{size:?} TST should observe zero at A2"
+            );
+            assert_eq!(cpu.pc, 0x0102, "{size:?} TST should consume no extension");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve extensionless `(An)` when the portable trace executor reconstructs `TST.B/W/L`
- keep real `d16(An)` forms on the displacement path
- add byte, word, and long regressions that make the following opcode look like a valid displacement and prove CCR/PC parity

## Root cause

The trace decoder represents `TST (An)` as `AnDispUnary` with a stored zero displacement and no extension word so it can share the displacement emitter. The native emitter consumes that stored value correctly, but the portable executor reconstructed every `AnDispUnary` as `FastEa::AnDisp`. The shared memory executor then consumed the following opcode as an extension word and tested `An + sign_extend(next opcode)` instead of `An`.

The portable executor now uses the trace extension metadata to retain the original addressing form: no extension means `FastEa::AnInd`, while a present extension remains `FastEa::AnDisp`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked`
- `cargo package --locked`
- Systemless Marathon 2 deterministic gameplay, automap, and movement screenshots on m68k 0.11.2 match the 0.10.14 known-good hashes byte-for-byte
- Systemless Escape Velocity Override deterministic script completes through live gameplay, targeting, and fire input on m68k 0.11.2

Closes #148