### PR TITLE
fix: emit 68040 format-2 address-error frames

### DIFF
--- a/src/core/exceptions.rs
+++ b/src/core/exceptions.rs
@@ -337,10 +337,23 @@ impl CpuCore {
                 self.push_32_raw(bus, self.ppc);
                 self.push_16_raw(bus, old_sr);
             }
+            _ if self.is_040() => {
+                // An odd instruction prefetch uses the six-word format-$2
+                // address-error frame (MC68040UM 8.2.2, 8.4.3), not the
+                // format-$7 access-error frame used for bus and ATC faults.
+                // The extra longword contains the referenced address with A0
+                // cleared, while the stacked PC identifies the instruction
+                // that caused the address error.
+                self.push_32_raw(bus, address & !1);
+                self.push_16_raw(bus, 0x2000 | ((vector::ADDRESS_ERROR as u16) << 2));
+                self.push_32_raw(bus, self.ppc);
+                self.push_16_raw(bus, old_sr);
+                let _ = status_word;
+            }
             _ => {
-                // TODO: 68020+ address error stack frames (format A/B/7 variants) are not yet
-                // implemented. Use a minimal 68010+ format-0-like frame to avoid totally losing
-                // control flow, but this is not architecturally accurate.
+                // TODO: 68020/68030/68060 address error stack frames are not
+                // yet implemented. Use a minimal format-0-like frame to avoid
+                // totally losing control flow, but this is not architecturally accurate.
                 self.push_16_raw(bus, (vector::ADDRESS_ERROR as u16) << 2);
                 self.push_32_raw(bus, self.ppc);
                 self.push_16_raw(bus, old_sr);

--- a/tests/unaligned_fetch_tests.rs
+++ b/tests/unaligned_fetch_tests.rs
@@ -126,6 +126,61 @@ fn test_odd_pc_fetch_triggers_address_error_on_68020() {
     );
 }
 
+#[test]
+fn odd_pc_fetch_pushes_68040_format_2_address_error_frame() {
+    for cpu_type in [CpuType::M68EC040, CpuType::M68LC040, CpuType::M68040] {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(cpu_type);
+        let mut bus = TestBus::new();
+
+        bus.write_long_at(0x00, 0x1000);
+        bus.write_long_at(0x04, 0x0100);
+        bus.write_long_at(0x0C, 0x0200);
+        bus.write_word_at(0x0200, 0x4E73); // RTE
+
+        cpu.reset(&mut bus);
+        cpu.pc = 0x0101;
+        cpu.set_sr(0x2700);
+
+        assert!(matches!(cpu.step(&mut bus), StepResult::Ok { .. }));
+        assert_eq!(cpu.pc, 0x0200, "{cpu_type:?}");
+        assert_eq!(
+            cpu.a(7),
+            0x1000 - 12,
+            "{cpu_type:?}: six-word format-$2 frame"
+        );
+
+        let frame = cpu.a(7);
+        assert_eq!(bus.read_word(frame), 0x2700, "{cpu_type:?}: stacked SR");
+        assert_eq!(
+            bus.read_long(frame + 2),
+            0x0101,
+            "{cpu_type:?}: faulting instruction PC"
+        );
+        assert_eq!(
+            bus.read_word(frame + 6),
+            0x200C,
+            "{cpu_type:?}: format and vector offset"
+        );
+        assert_eq!(
+            bus.read_long(frame + 8),
+            0x0100,
+            "{cpu_type:?}: referenced address with A0 cleared"
+        );
+
+        assert!(matches!(cpu.step(&mut bus), StepResult::Ok { .. }));
+        assert_eq!(
+            cpu.pc, 0x0101,
+            "{cpu_type:?}: RTE restores the faulting instruction PC"
+        );
+        assert_eq!(
+            cpu.a(7),
+            0x1000,
+            "{cpu_type:?}: RTE consumes the complete format-$2 frame"
+        );
+    }
+}
+
 // Ported from upstream m68k-rs (post-fork regression test): a register-only
 // instruction followed by an odd-PC opcode fetch must not restore a stale
 // data/address rollback snapshot when the fetch faults. Confirms the vendored


### PR DESCRIPTION
## Summary

- emit the MC68040-family six-word format-$2 frame for odd instruction-prefetch address errors
- preserve the faulting instruction PC and stack the referenced address with A0 cleared
- verify the frame layout and a complete `RTE` round trip on EC040, LC040, and full 68040 variants

The behavior follows sections 8.2.2 and 8.4.3 of the [MC68040 User's Manual](https://www.nxp.com/docs/en/reference-manual/MC68040UM.pdf).

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test unaligned_fetch_tests --locked`
- `cargo test --lib --no-default-features --locked`
- `cargo test --lib --all-features --locked`
- `cargo clippy --lib --all-features --locked -- -D warnings`
- `cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo package --locked`

Closes #157
