### PR TITLE
feat: real-hardware timing models for the 68030 and 68040

### DIFF
--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -478,10 +478,12 @@ impl Default for CpuCore {
 }
 
 impl CpuCore {
-    /// Legacy 68030/040 approximation from the handlers' corrected 68000
-    /// counts. The 68020/68EC020 is routed through its MC68020UM section-8
-    /// timing model before this function; the 68060 has a separate pipeline
-    /// engine. The 68000/68010 paths remain untouched.
+    /// Legacy scaling approximation from the handlers' corrected 68000
+    /// counts. The 020/030 route through the MC68020UM section-8 timing
+    /// model and the 040 and 060 through their pipeline engines before this
+    /// function; it remains the cost model for 040 exception entries, the
+    /// SCC68070, and the trace-JIT builders' baked fallbacks. The
+    /// 68000/68010 paths remain untouched.
     #[inline]
     pub(crate) fn scale_cycles_for_cpu_type(&self, cycles: i32) -> i32 {
         use crate::core::types::CpuType;

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -867,8 +867,13 @@ impl CpuCore {
         let result = dispatch(self, bus, self.ir as u16);
         let fetch_cached = if matches!(
             self.cpu_type,
-            super::types::CpuType::M68EC020 | super::types::CpuType::M68020
+            super::types::CpuType::M68EC020
+                | super::types::CpuType::M68020
+                | super::types::CpuType::M68EC030
+                | super::types::CpuType::M68030
         ) {
+            // The 020/030 MC68020UM tables pick Cache Case only when every
+            // instruction-stream fetch hit the cache, not just the opcode.
             bus.instruction_fetches_were_cached()
         } else {
             opcode_fetch_cached
@@ -1019,8 +1024,13 @@ impl CpuCore {
         let result = dispatch_instruction(self, bus, self.ir as u16);
         let fetch_cached = if matches!(
             self.cpu_type,
-            super::types::CpuType::M68EC020 | super::types::CpuType::M68020
+            super::types::CpuType::M68EC020
+                | super::types::CpuType::M68020
+                | super::types::CpuType::M68EC030
+                | super::types::CpuType::M68030
         ) {
+            // The 020/030 MC68020UM tables pick Cache Case only when every
+            // instruction-stream fetch hit the cache, not just the opcode.
             bus.instruction_fetches_were_cached()
         } else {
             opcode_fetch_cached

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -22,6 +22,16 @@ pub const RUN_MODE_NORMAL: u32 = 0;
 /// Bus/address-error recovery or reset processing is active.
 pub const RUN_MODE_BERR_AERR_RESET: u32 = 1;
 
+/// The 020 timing tables select their Cache Case only when every
+/// instruction-stream fetch for the retiring instruction hit the cache.
+#[inline]
+fn timing_uses_full_fetch_stream(cpu_type: CpuType) -> bool {
+    matches!(
+        cpu_type,
+        CpuType::M68EC020 | CpuType::M68020 | CpuType::M68EC030 | CpuType::M68030
+    )
+}
+
 /// Decode the deliberately narrow register-only subset whose precise
 /// instruction completion is preserved by the boundary-hook dispatcher.
 #[inline]
@@ -144,10 +154,7 @@ impl CpuCore {
             // hit the icache before dispatch consumes more of the stream).
             let opcode_fetch_cached = bus.last_fetch_was_cached();
             let result = dispatch_instruction(self, bus, self.ir as u16);
-            let fetch_cached = if matches!(
-                self.cpu_type,
-                super::types::CpuType::M68EC020 | super::types::CpuType::M68020
-            ) {
+            let fetch_cached = if timing_uses_full_fetch_stream(self.cpu_type) {
                 bus.instruction_fetches_were_cached()
             } else {
                 opcode_fetch_cached
@@ -865,15 +872,7 @@ impl CpuCore {
 
         let opcode_fetch_cached = bus.last_fetch_was_cached();
         let result = dispatch(self, bus, self.ir as u16);
-        let fetch_cached = if matches!(
-            self.cpu_type,
-            super::types::CpuType::M68EC020
-                | super::types::CpuType::M68020
-                | super::types::CpuType::M68EC030
-                | super::types::CpuType::M68030
-        ) {
-            // The 020/030 MC68020UM tables pick Cache Case only when every
-            // instruction-stream fetch hit the cache, not just the opcode.
+        let fetch_cached = if timing_uses_full_fetch_stream(self.cpu_type) {
             bus.instruction_fetches_were_cached()
         } else {
             opcode_fetch_cached
@@ -1022,15 +1021,7 @@ impl CpuCore {
 
         let opcode_fetch_cached = bus.last_fetch_was_cached();
         let result = dispatch_instruction(self, bus, self.ir as u16);
-        let fetch_cached = if matches!(
-            self.cpu_type,
-            super::types::CpuType::M68EC020
-                | super::types::CpuType::M68020
-                | super::types::CpuType::M68EC030
-                | super::types::CpuType::M68030
-        ) {
-            // The 020/030 MC68020UM tables pick Cache Case only when every
-            // instruction-stream fetch hit the cache, not just the opcode.
+        let fetch_cached = if timing_uses_full_fetch_stream(self.cpu_type) {
             bus.instruction_fetches_were_cached()
         } else {
             opcode_fetch_cached
@@ -1354,6 +1345,26 @@ impl CpuCore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn full_fetch_stream_timing_covers_020_and_030_families() {
+        for cpu_type in [
+            CpuType::M68EC020,
+            CpuType::M68020,
+            CpuType::M68EC030,
+            CpuType::M68030,
+        ] {
+            assert!(timing_uses_full_fetch_stream(cpu_type));
+        }
+        for cpu_type in [
+            CpuType::M68000,
+            CpuType::M68010,
+            CpuType::M68040,
+            CpuType::M68060,
+        ] {
+            assert!(!timing_uses_full_fetch_stream(cpu_type));
+        }
+    }
 
     #[test]
     fn boundary_hook_clr_admission_is_exact() {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,6 +17,7 @@ pub mod registers;
 pub mod status;
 pub mod timing;
 pub mod timing_020;
+pub mod timing_040;
 pub mod timing_060;
 pub mod trace_jit;
 #[cfg(feature = "trace-profile")]

--- a/src/core/timing_020.rs
+++ b/src/core/timing_020.rs
@@ -1015,7 +1015,7 @@ mod tests {
     }
 
     #[test]
-    fn model_dispatch_uses_tables_only_for_the_020_family() {
+    fn model_dispatch_routes_the_020_and_030_through_the_tables() {
         use crate::core::types::CpuType;
 
         let mut cpu = CpuCore::new();
@@ -1024,7 +1024,12 @@ mod tests {
         assert_eq!(cpu.finalize_cycles(4, true), 2);
         cpu.set_cpu_type(CpuType::M68020);
         assert_eq!(cpu.finalize_cycles(4, false), 3);
+        // The 030 shares the 020 integer core and now runs the same
+        // tables (real-hardware calibration: Copperline accelprobe).
         cpu.set_cpu_type(CpuType::M68030);
-        assert_eq!(cpu.finalize_cycles(4, true), 3);
+        assert_eq!(cpu.finalize_cycles(4, true), 2);
+        // The 040 runs its own single-issue pipeline model.
+        cpu.set_cpu_type(CpuType::M68040);
+        assert_eq!(cpu.finalize_cycles(4, true), 1);
     }
 }

--- a/src/core/timing_040.rs
+++ b/src/core/timing_040.rs
@@ -29,11 +29,12 @@
 //! loop is the one real code runs. `mulu.w` lands at 13+3 = 16 against the
 //! measured 14. Exception entries keep the legacy scaled costs unchanged.
 //!
-//! Residuals, deliberately on the slow side: no execute-stage overlap (a
-//! one-clock body would partially hide ahead of a longer instruction too);
-//! shifts and bit operations take the 060 class costs, which real 040
-//! silicon runs a clock or two slower in some forms; the write-back stage
-//! and store buffer are not modelled (writes bill at bus rate).
+//! Residuals -- simplifications, not uniformly conservative: there is no
+//! execute-stage overlap (pessimistic: a one-clock body would partially
+//! hide ahead of a longer instruction on silicon), while shifts and bit
+//! operations take the 060 class costs, which can be OPTIMISTIC where real
+//! 040 silicon runs those forms a clock or two slower; the write-back
+//! stage and store buffer are not modelled (writes bill at bus rate).
 
 use super::cpu::CpuCore;
 use super::timing_060::{F_BRANCH, F_DBCC, F_EA_INDEXED, F_UNCLASSIFIED, F_VARIABLE, info_060};

--- a/src/core/timing_040.rs
+++ b/src/core/timing_040.rs
@@ -1,0 +1,178 @@
+//! 68040 integer timing: a single-issue pipeline model.
+//!
+//! The 68040's integer unit is the 68060's ancestor: a six-stage pipeline
+//! that retires most integer instructions in one effective clock, with no
+//! superscalar dispatch and no branch cache. Until now the part shared the
+//! legacy 68000-count scaling approximation with the 68030, which real
+//! hardware measures as ~2-2.5x pessimistic on plain execution: Copperline's
+//! `timing-test/accelprobe.asm` columns from a real A4000 with a 25 MHz
+//! A3640 (two byte-identical serial captures) measure a taken-`dbra` loop
+//! at 4.06 clocks/iteration where the scaled approximation bills ~8, a
+//! `move.w`+`dbra` loop at 4.08 (the one-clock body hides entirely in the
+//! branch resolution), and `mulu.w #imm`+`dbra` at 14.0 where the
+//! approximation bills ~35.
+//!
+//! The model here reuses the 68060 opcode classifier (`info_060`): most
+//! ALU/move instructions cost their one-clock pOEP occupancy,
+//! data-dependent and unclassified costs derive from the corrected 68000
+//! reference count as `(raw/4).max(1)` (the same rule of thumb the 060
+//! fallback uses), an indexed EA adds a clock, and branches pay small
+//! static costs -- the 040 has no branch cache, so there is nothing to
+//! predict or fold. Memory latency stays billed by the host bus per
+//! access, exactly as on the 020 and 060 paths.
+//!
+//! Branch calibration: `DBcc`-taken is 3 clocks, so the ubiquitous
+//! one-clock-body loop lands on the measured 4 clocks/iteration; the empty
+//! `dbra` loop (rare in real code) then reads 3 against the measured 4.06,
+//! which is the deliberate compromise -- a model without an
+//! overlap/absorption stage cannot make both shapes exact, and the body
+//! loop is the one real code runs. `mulu.w` lands at 13+3 = 16 against the
+//! measured 14. Exception entries keep the legacy scaled costs unchanged.
+//!
+//! Residuals, deliberately on the slow side: no execute-stage overlap (a
+//! one-clock body would partially hide ahead of a longer instruction too);
+//! shifts and bit operations take the 060 class costs, which real 040
+//! silicon runs a clock or two slower in some forms; the write-back stage
+//! and store buffer are not modelled (writes bill at bus rate).
+
+use super::cpu::CpuCore;
+use super::timing_060::{F_BRANCH, F_DBCC, F_EA_INDEXED, F_UNCLASSIFIED, F_VARIABLE, info_060};
+
+/// Taken Bcc/BRA/BSR: static pipeline refill, no prediction hardware.
+pub const CYC_040_BRANCH_TAKEN: i32 = 3;
+/// Not-taken conditional branch.
+pub const CYC_040_BRANCH_NOT_TAKEN: i32 = 2;
+/// Taken (looping) DBcc: 3 clocks, so a one-clock body + branch lands on
+/// the measured 4 clocks per iteration.
+pub const CYC_040_DBCC_TAKEN: i32 = 3;
+/// Expired (falling through) DBcc.
+pub const CYC_040_DBCC_EXPIRED: i32 = 3;
+/// Floor for JMP/JSR/RTS/RTE/RTR and other computed flow changes.
+pub const CYC_040_FLOW_MIN: i32 = 4;
+/// CINV/CPUSH: the cache-maintenance pipeline runs for around a dozen
+/// clocks even on a clean line (the real A3640 measures ~12 clocks per
+/// `CPUSHL DC,(An)`, accelprobe row 15); wider scopes keep at least that.
+pub const CYC_040_CACHE_OP: i32 = 12;
+
+/// The 040 rule of thumb for costs not in the class table: a 4-clock
+/// 68000 register operation is 1 clock. Same shape as the 060 fallback;
+/// never the 020+ scaler, whose `.max(2)` floor would destroy one-clock
+/// costs.
+#[inline]
+fn fallback_cycles(raw: i32) -> i32 {
+    (raw / 4).max(1)
+}
+
+impl CpuCore {
+    /// 68040 cycle cost for the instruction that just retired normally.
+    /// `raw` is the handler's 68000-reference count, used for
+    /// data-dependent fallbacks; exception entries keep the legacy scaled
+    /// costs so the exception timing calibration is unchanged by the
+    /// pipeline model.
+    pub(crate) fn cycles_040(&mut self, raw: i32) -> i32 {
+        if self.instruction_exception_vector.is_some() {
+            return self.scale_cycles_for_cpu_type(raw);
+        }
+        let info = info_060(self.ir as u16);
+        let flowed = self.change_of_flow;
+
+        if info.has(F_BRANCH) {
+            // The DBcc handler does not raise change_of_flow; a loop is
+            // visible as a PC that is not the fall-through (ppc + 4).
+            let taken = if info.has(F_DBCC) {
+                self.pc != self.ppc.wrapping_add(4)
+            } else {
+                flowed
+            };
+            return match (info.has(F_DBCC), taken) {
+                (true, true) => CYC_040_DBCC_TAKEN,
+                (true, false) => CYC_040_DBCC_EXPIRED,
+                (false, true) => CYC_040_BRANCH_TAKEN,
+                (false, false) => CYC_040_BRANCH_NOT_TAKEN,
+            };
+        }
+        if flowed {
+            // JMP/JSR/RTS/RTE/RTR and friends: pipeline refill floor.
+            return fallback_cycles(raw).max(CYC_040_FLOW_MIN);
+        }
+        let op = self.ir as u16;
+        // CINV/CPUSH cache maintenance (F4xx).
+        if op & 0xFF00 == 0xF400 {
+            return fallback_cycles(raw).max(CYC_040_CACHE_OP);
+        }
+        // Data-dependent iterative units the 060 class table prices at that
+        // part's fixed pipeline cost: the 040 multiplier and divider are
+        // iterative, so derive their cost from the 68000 reference count.
+        let is_muldiv = matches!(op & 0xF1C0, 0xC0C0 | 0xC1C0 | 0x80C0 | 0x81C0)
+            || matches!(op & 0xFFC0, 0x4C00 | 0x4C40);
+        let mut cycles = if is_muldiv || info.has(F_VARIABLE) || info.has(F_UNCLASSIFIED) {
+            fallback_cycles(raw)
+        } else {
+            info.cycles()
+        };
+        if info.has(F_EA_INDEXED) {
+            cycles += 1;
+        }
+        cycles
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::CpuType;
+
+    fn cpu_040() -> CpuCore {
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu
+    }
+
+    #[test]
+    fn simple_alu_ops_cost_one_clock() {
+        let mut cpu = cpu_040();
+        cpu.ir = 0x7001; // MOVEQ #1,D0
+        assert_eq!(cpu.cycles_040(4), 1);
+        cpu.ir = 0x3002; // MOVE.W D2,D0
+        assert_eq!(cpu.cycles_040(4), 1);
+        cpu.ir = 0xD280; // ADD.L D0,D1
+        assert_eq!(cpu.cycles_040(4), 1);
+    }
+
+    #[test]
+    fn taken_dbcc_makes_the_measured_one_clock_body_loop_four_clocks() {
+        // The real-A4000 anchor (accelprobe rows 6/7): move.w d2,d0 + dbra
+        // = 4.08 clk/iter, so body (1) + taken DBcc must be 4.
+        let mut cpu = cpu_040();
+        cpu.ir = 0x51CE; // DBRA D6,<disp>
+        cpu.ppc = 0x1000;
+        cpu.pc = 0x0FFC; // looped: not the fall-through
+        assert_eq!(cpu.cycles_040(12), CYC_040_DBCC_TAKEN);
+        cpu.pc = cpu.ppc.wrapping_add(4); // expired: fell through
+        assert_eq!(cpu.cycles_040(14), CYC_040_DBCC_EXPIRED);
+    }
+
+    #[test]
+    fn data_dependent_costs_derive_from_the_68000_reference() {
+        // MULU.W #$5555 (8 set bits): 68000 reference 38+2*8 = 54 -> 13,
+        // near the measured 14-clk loop (13 + taken dbra 3 = 16 modelled).
+        let mut cpu = cpu_040();
+        cpu.ir = 0xC0FC; // MULU.W #imm,D0
+        assert_eq!(cpu.cycles_040(54), 13);
+    }
+
+    #[test]
+    fn cache_line_maintenance_costs_a_dozen_clocks() {
+        let mut cpu = cpu_040();
+        cpu.ir = 0xF468; // CPUSHL DC,(A0)
+        assert_eq!(cpu.cycles_040(8), CYC_040_CACHE_OP);
+    }
+
+    #[test]
+    fn flow_changes_pay_the_refill_floor() {
+        let mut cpu = cpu_040();
+        cpu.ir = 0x4E75; // RTS
+        cpu.change_of_flow = true;
+        assert_eq!(cpu.cycles_040(16), CYC_040_FLOW_MIN);
+    }
+}

--- a/src/core/timing_060.rs
+++ b/src/core/timing_060.rs
@@ -743,13 +743,24 @@ impl CpuCore {
         cost
     }
 
-    /// Model-dispatching wrapper for the three step paths.
+    /// Model-dispatching wrapper for the three step paths. The 68030 runs
+    /// the MC68020UM section-8 tables: its integer core is the 020's, and
+    /// the real-hardware columns in Copperline's timing-test (a 25 MHz
+    /// 68030 CPU-slot board next to the real A1200's 020) measure the same
+    /// figures on the anchor rows -- taken `dbra` 6 clocks, `mulu.w` in
+    /// the mid-30s per loop -- where the legacy scaler billed the calls
+    /// ~1.7x high. The 68040 has its own single-issue pipeline model
+    /// (`timing_040.rs`).
     #[inline]
     pub(crate) fn finalize_cycles(&mut self, raw: i32, fetch_cached: bool) -> i32 {
         match self.cpu_type {
-            super::types::CpuType::M68EC020 | super::types::CpuType::M68020 => {
-                self.cycles_020(raw, fetch_cached)
-            }
+            super::types::CpuType::M68EC020
+            | super::types::CpuType::M68020
+            | super::types::CpuType::M68EC030
+            | super::types::CpuType::M68030 => self.cycles_020(raw, fetch_cached),
+            super::types::CpuType::M68EC040
+            | super::types::CpuType::M68LC040
+            | super::types::CpuType::M68040 => self.cycles_040(raw),
             super::types::CpuType::M68060 => self.cycles_060(raw, fetch_cached),
             _ => self.scale_cycles_for_cpu_type(raw),
         }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -5396,9 +5396,9 @@ fn decode_bit_imm_reg_trace_op<B: AddressBus>(
     };
     // Normal retirement finalizes those raw charges through the selected
     // processor's timing model. Traces must store that same modeled value:
-    // the 68020 table makes register bit operations four clocks, the
-    // 68030/040 family uses the legacy scaler, and the 68060 pipeline issues
-    // these register operations in one clock.
+    // the 68020/030 tables make register bit operations four clocks, the
+    // 68040 and 68060 pipelines issue them in one clock, and the remaining
+    // models (SCC68070) keep the legacy scaler.
     let cycles = match cpu.cpu_type {
         CpuType::M68EC020 | CpuType::M68020 | CpuType::M68EC030 | CpuType::M68030 => 4,
         CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040 | CpuType::M68060 => 1,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -5400,8 +5400,8 @@ fn decode_bit_imm_reg_trace_op<B: AddressBus>(
     // 68030/040 family uses the legacy scaler, and the 68060 pipeline issues
     // these register operations in one clock.
     let cycles = match cpu.cpu_type {
-        CpuType::M68EC020 | CpuType::M68020 => 4,
-        CpuType::M68060 => 1,
+        CpuType::M68EC020 | CpuType::M68020 | CpuType::M68EC030 | CpuType::M68030 => 4,
+        CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040 | CpuType::M68060 => 1,
         _ => cpu.scale_cycles_for_cpu_type(raw_cycles),
     };
     Some(TraceBuildOp {
@@ -15880,17 +15880,19 @@ mod portable_tests {
             bus.write_word(base + 2, words[1]);
         }
 
-        // 68040: handler charges finalized through the model scaler.
+        // 68040: register bit operations issue in one clock on the
+        // single-issue pipeline model (timing_040.rs), and the baked trace
+        // cycles mirror the interpreter.
         cpu.set_cpu_type(CpuType::M68040);
         let ops: Vec<TraceBuildOp> = [0x0100u32, 0x0110, 0x0120, 0x0130]
             .iter()
             .map(|&pc| decode_trace_op(&cpu, &mut bus, pc, CpuType::M68040).expect("form decodes"))
             .collect();
         let expect = [
-            (JitBitOp::Test, 2u8, 4u8, 4),
-            (JitBitOp::Change, 20, 1, 5),
-            (JitBitOp::Clear, 20, 1, 7),
-            (JitBitOp::Set, 0, 7, 5),
+            (JitBitOp::Test, 2u8, 4u8, 1),
+            (JitBitOp::Change, 20, 1, 1),
+            (JitBitOp::Clear, 20, 1, 1),
+            (JitBitOp::Set, 0, 7, 1),
         ];
         for (decoded, &(op, bit, dst, cycles)) in ops.iter().zip(&expect) {
             let JitTraceOp::BitImmReg {

--- a/tests/gap_tests.rs
+++ b/tests/gap_tests.rs
@@ -236,6 +236,17 @@ fn test_gap_dbf_instruction() {
     bus.mem[0x1005] = 0x71;
     bus.mem[0x1006] = 0x4E;
     bus.mem[0x1007] = 0x75;
+    // RTS return address on the stack -> a parking loop (BRA.S self), so
+    // completion is observable no matter how many instructions fit in one
+    // execute() budget (the 040 pipeline model runs this code ~3x cheaper
+    // than the old scaled approximation, so the old mid-flight PC
+    // checkpoints were budget-dependent).
+    bus.mem[0x8000] = 0x00;
+    bus.mem[0x8001] = 0x00;
+    bus.mem[0x8002] = 0x20;
+    bus.mem[0x8003] = 0x00;
+    bus.mem[0x2000] = 0x60;
+    bus.mem[0x2001] = 0xFE;
 
     // Initialize D0 to 3 (should loop 4 times: 3,2,1,0,-1 exit)
     cpu.set_d(0, 3);
@@ -245,7 +256,7 @@ fn test_gap_dbf_instruction() {
     // Execute enough cycles
     for _ in 0..20 {
         cpu.execute(&mut bus, 100);
-        if cpu.pc == 0x1006 || cpu.pc > 0x1010 {
+        if cpu.pc == 0x2000 || cpu.pc == 0x2002 {
             break;
         }
     }

--- a/tests/timing_060_tests.rs
+++ b/tests/timing_060_tests.rs
@@ -160,10 +160,14 @@ fn flow_change_pays_refill_floor_on_68060() {
 
 #[test]
 fn other_models_keep_their_cycle_counts() {
-    // Regression guard: the 060 cost model must not disturb 000-040 paths.
+    // Regression guard: the 060 cost model must not disturb the other
+    // models' paths. The 68000 keeps its exact count, the 030 runs the
+    // MC68020UM tables (MOVEQ Cache Case = 2), and the 040 its
+    // single-issue pipeline model (one clock).
     for (cpu_type, moveq_expected) in [
         (CpuType::M68000, 4),
-        (CpuType::M68030, 3), // ((4*5+7)/8).max(2)
+        (CpuType::M68030, 2),
+        (CpuType::M68040, 1),
     ] {
         let (mut cpu, mut bus) = setup(cpu_type);
         bus.write_word_at(0x0200, 0x7000);


### PR DESCRIPTION
This calibrates the 68030 and 68040 against real silicon. Until now both parts shared the legacy approximation (`(cycles*5+7)/8`, min 2, of the corrected 68000 counts); measurements from a real A4000 show that approximation over-bills plain 68040 execution by ~2-2.5x and misses the 030 in both directions.

**Measurement provenance.** Copperline's new `timing-test/accelprobe.asm` (CopperlineHQ/Copperline#592): a 32-row bootable probe measured against the CIA E-clock, run on a real A4000 with a 25 MHz Commodore 68030 CPU-slot board, a 25 MHz A3640 (68040), and a 50 MHz BFG9060 (68060, cross-checks). All captures are 9600-baud serial streams, two runs per machine; the A3640 pair was byte-identical. The probe's full columns and per-row verdicts live in its header.

**68030 -> the MC68020UM section-8 tables.** The 030's integer core is the 020's, and the real columns agree: taken `dbra` is 6 clocks and `mulu.w` lands in the mid-30s per loop on both the real A1200 020 (the campaign that produced the 020 model here) and the real A4000 030. Routed through the 020 tables, the emulated probe lands the reg-move loop within 0.5% of the real 030 column, `mulu` within 0.7%, and the fast-stack trap row within 0.4%, with no row regressing. The Cache/Worst case selection now feeds the 030 the full instruction-stream cache information, same as the 020.

**68040 -> a single-issue pipeline model (`timing_040.rs`).** Built on the 060 opcode classifier: one-clock pOEP-style costs for simple integer ops, `(raw/4).max(1)` fallbacks for data-dependent/unclassified costs, explicit iterative mul/div derivation, a ~12-clock CINV/CPUSH cost, static branch costs (the 040 has no branch cache), and a 4-clock flow-change floor. Against the real A3640 column: the measured `move.w`+`dbra` loop (4.08 clk/iter) lands tick-exact, `mulu.w` within 6%, `cpushl` within 7%. `DBcc`-taken is 3 clocks so the ubiquitous one-clock-body loop hits the measured 4 clk/iter; the empty `dbra` loop reads 3 against the measured 4.06 -- the documented compromise for a model without an execute-overlap stage (the body loop is the shape real code runs). Exception entries keep the legacy scaled costs, so exception timing is unchanged.

**Consistency.** The trace-JIT baked bit-op costs mirror the new dispatch so traces retire identically to the interpreter (covered by the existing cross-check test). The DBF gap test now observes loop completion through an explicit landing pad instead of a cycle-budget-dependent PC checkpoint, which the cheaper (correct) 040 costs let slip past inside one `execute()` call.

**End-to-end effect.** In Copperline, an AmigaVision 68040 boot that took 17 emulated seconds (reported by users as 3x slower than the same setup elsewhere) completes in ~12s with this change, and the fast-RAM configuration lands at 5s -- while the machine's bus-bound rows stay put, which is what the real-hardware columns say they should do.

All 62 test suites pass; fmt and clippy clean (the one pre-existing `unnecessary_sort_by` warning in the SingleStep tests is untouched).