### PR TITLE
perf(trace): scope the guarded stack-frame gate to portable execution

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -682,7 +682,9 @@ enum RegionRejectReason {
     LinearMemoryAlu,
     /// A guarded path mutates a function stack frame before a possible
     /// prefix exit. Keep the region decoded so host batch boundaries cannot
-    /// expose partially replayed prologue memory effects.
+    /// expose partially replayed prologue memory effects. Portable-executor
+    /// configurations only; native traces execute prefixes directly.
+    #[cfg_attr(all(feature = "jit", not(target_family = "wasm")), allow(dead_code))]
     GuardedStackFrame,
     AddressWrap,
     /// A recorded call's caller or callee segment exceeds
@@ -2575,16 +2577,25 @@ impl TraceJit {
         // the recording. Keep function prologues that have already mutated
         // the stack frame on the decoded path: their partial memory effects
         // otherwise become dependent on the embedder's run_batch boundary.
-        let guarded = guarded_op_mask(&ops) != 0;
-        if guarded
-            && ops.iter().any(|op| {
-                matches!(
-                    op.op,
-                    JitTraceOp::Link { .. } | JitTraceOp::MovemLongPredec { .. }
-                )
-            })
+        //
+        // Only the portable executor replays a trace's ops at host batch
+        // boundaries; a native trace executes its ops directly and side-
+        // exits with exact architectural and memory state, so the gate is
+        // scoped to the configurations whose compiled traces run portably.
+        // Natively compiled prologues stay admitted.
+        #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
         {
-            return Err(RegionRejectReason::GuardedStackFrame);
+            let guarded = guarded_op_mask(&ops) != 0;
+            if guarded
+                && ops.iter().any(|op| {
+                    matches!(
+                        op.op,
+                        JitTraceOp::Link { .. } | JitTraceOp::MovemLongPredec { .. }
+                    )
+                })
+            {
+                return Err(RegionRejectReason::GuardedStackFrame);
+            }
         }
 
         let max_cycles = ops.iter().map(|op| op.op.max_cycles()).sum();
@@ -21302,6 +21313,7 @@ mod portable_tests {
         };
         *expected_taken = Some(true);
         let mut jit = TraceJit::new();
+        #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
         assert!(matches!(
             jit.compile_decoded_ops_reason(
                 &actual,
@@ -21312,6 +21324,18 @@ mod portable_tests {
             ),
             Err(RegionRejectReason::GuardedStackFrame)
         ));
+        #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+        assert!(
+            jit.compile_decoded_ops_reason(
+                &actual,
+                START,
+                CpuType::M68040,
+                ops.clone(),
+                Some(0x01CE),
+            )
+            .is_ok(),
+            "a native build compiles the guarded prologue"
+        );
         let packed = execute_portable_trace(&mut actual, &ops, CodeSpans::caller(START, 0x01C6));
 
         assert_eq!(packed >> 32, 10);


### PR DESCRIPTION
## Summary

#155 keeps guarded regions containing `LINK` / `MOVEM.L -(SP)` off the trace path entirely, because a guarded multi-block path may side-exit after only a prefix of the recording and the **portable executor's** replay of that prefix at a host batch boundary exposed partial stack-frame effects (#154).

Native traces do not have that failure mode: a Cranelift-compiled trace executes its ops directly and side-exits with exact architectural and memory state (the `#[cfg]` in `try_execute` shows compiled traces run portably only when the `jit` feature is off or on wasm). The gate is therefore scoped to the configurations whose compiled traces actually run portably; natively compiled prologues stay admitted. The #155 regression test keeps asserting the rejection in portable configurations and now also asserts that a native build compiles the same prologue.

### Why it matters

On SimCity 2000 this gate is a large regression: guarded function prologues sit behind the workload's hottest call sites, and refusing the callee segment strands the *caller's* recording with no terminal. Head `$002184CA` — the #6 compiled trace on 0.11.4 (850 k calls, 40.0 M retired instructions) — is recorded 14,041 times on 0.11.5+ and never compiles; `no-trace-terminal` recordings rise from 1,331 to 16,652, native trace calls fall 20.2 M → 13.9 M, and natively retired instructions fall 941.8 M → 792.7 M over a 2 B-instruction run. Bisect across exact-pinned releases on the same host build: 0.11.2/0.11.3/0.11.4 all measure −7.6 % host instructions vs 0.11.5/0.11.6, ticks identical (283,023) in every run.

### Evidence

Same Systemless tree (current master plus its two open perf PRs), 2 billion instructions of the headless SimCity 2000 replay, three interleaved pairs, exact-pinned dependencies verified in the lockfile:

| | m68k 0.11.6 | this branch | Δ |
|---|---|---|---|
| host instructions retired | 335.11 G | 305.54 G | **−8.80 %** (3/3, spreads ≤ 0.05 %) |
| CPU cycles | 135.93 G | 122.67 G | −9.5 % |
| guest ticks | 355,838 | 355,838 | bit-identical |
| milestone sequence (windows/dialogs/menus/resources) | 75 lines | 75 lines | zero diff |

Trace-profile (`--features trace-profile`, `M68K_TRACE_PROFILE=1`) on this branch reproduces **0.11.2's totals bit-for-bit** — `native_calls=20,162,546`, `jit_retired=941,759,734` — with `$002184CA` back as the #6 compiled trace carrying its exact 0.11.2 row (63 ops, 850,564 calls, 39,960,711 retired), and `no-trace-terminal` recordings fall from 16,652 to 1,602 (0.11.2 baseline: 1,331). The gate's scoping does not merely recover the cost; it restores the pre-0.11.5 trace population exactly.

## Validation

`cargo test --lib --no-default-features` (186 passed — the gate and its rejection assert still active), `cargo test --lib --all-features` (296 passed — the differential test now also proves the native build compiles the prologue), `cargo clippy --all-features --lib -- -D warnings`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoS2nQc8CBYWtb9LZgdGVh
