### PR TITLE
perf(trace): defer cold independent linear regions

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -1782,12 +1782,16 @@ impl TraceJit {
         entry_watched: bool,
     ) -> ExitSeed {
         let idx = trace_cache_index(exit_pc);
+        // Reaching this head from an already-compiled trace is stronger
+        // reuse evidence than an earlier independent linear observation.
+        // Let the connector use the eager threshold even if it was first
+        // discovered and deferred through a backward-edge probe.
+        self.clear_linear_deferral(exit_pc);
         // Read the durable grant before borrowing the slot mutably: a
         // candidate created here must carry the permission its head
         // already earned.
         let permission = self.has_call_permission(exit_pc);
         let structurally_rejected = self.is_structurally_rejected(exit_pc);
-        let linear_history = &self.deferred_linear;
         match &mut self.slots[idx] {
             TraceSlot::Compiled(CompiledTrace {
                 pc: compiled_pc,
@@ -1810,6 +1814,7 @@ impl TraceJit {
                 deferred_trap,
                 deferred_linear,
             } if *counted_pc == exit_pc && *counted_type == cpu_type => {
+                *deferred_linear = false;
                 *hits = hits.saturating_add(1);
                 let threshold = if *deferred_trap {
                     TRACE_TRAP_SEGMENT_HOT_THRESHOLD
@@ -1853,8 +1858,6 @@ impl TraceJit {
                 if structurally_rejected {
                     return ExitSeed::None;
                 }
-                let ways = &linear_history[idx];
-                let linear_deferred = ways[0] == exit_pc || ways[1] == exit_pc;
                 *slot = TraceSlot::Counting {
                     pc: exit_pc,
                     cpu_type,
@@ -1862,7 +1865,7 @@ impl TraceJit {
                     adaptive_rerecords: 0,
                     allow_call_through: permission,
                     deferred_trap: false,
-                    deferred_linear: linear_deferred,
+                    deferred_linear: false,
                 };
                 self.pending_exit_seed = Some((exit_pc, cpu_type));
                 ExitSeed::None
@@ -17052,6 +17055,45 @@ mod portable_tests {
             &jit.slots[trace_cache_index(HEAD)],
             TraceSlot::Compiled(trace) if trace.pc == HEAD
         ));
+    }
+
+    #[test]
+    fn exit_seed_overrides_prior_independent_linear_deferral() {
+        const HEAD: u32 = 0x0100;
+        let mut jit = TraceJit::new();
+        jit.defer_linear_compilation(HEAD);
+        jit.slots[trace_cache_index(HEAD)] = TraceSlot::Counting {
+            pc: HEAD,
+            cpu_type: CpuType::M68000,
+            hits: 0,
+            adaptive_rerecords: 0,
+            allow_call_through: false,
+            deferred_trap: false,
+            deferred_linear: true,
+        };
+
+        assert!(matches!(
+            jit.note_trace_exit(HEAD, CpuType::M68000, false),
+            ExitSeed::None
+        ));
+        assert!(!jit.linear_compilation_deferred(HEAD));
+        assert!(matches!(
+            &jit.slots[trace_cache_index(HEAD)],
+            TraceSlot::Counting {
+                hits: 1,
+                deferred_linear: false,
+                ..
+            }
+        ));
+        assert!(matches!(
+            jit.note_trace_exit(HEAD, CpuType::M68000, false),
+            ExitSeed::StartRecording
+        ));
+        assert!(
+            jit.recording
+                .as_ref()
+                .is_some_and(|recording| recording.from_exit_seed)
+        );
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -17000,8 +17000,8 @@ mod portable_tests {
         };
         assert!(jit.linear_compilation_deferred(HEAD));
 
-        // Reinstall the head and prove that both exit-seeded admission and
-        // the second completed recording honor the raised threshold.
+        // Reinstall the head and prove that ordinary independent entries
+        // and the second completed recording honor the raised threshold.
         jit.slots[trace_cache_index(HEAD)] = TraceSlot::Counting {
             pc: HEAD,
             cpu_type: CpuType::M68000,
@@ -17011,17 +17011,37 @@ mod portable_tests {
             deferred_trap: false,
             deferred_linear: true,
         };
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        cpu.pc = HEAD;
+        cpu.cycles_remaining = 1_000_000;
         for _ in 1..TRACE_LINEAR_HOT_THRESHOLD {
-            assert!(matches!(
-                jit.note_trace_exit(HEAD, CpuType::M68000, false),
-                ExitSeed::None
-            ));
+            assert!(
+                jit.try_execute(
+                    &mut cpu,
+                    &mut bus,
+                    CpuType::M68000,
+                    100,
+                    false,
+                    &[],
+                    TRACE_EXIT_CHAIN_BUDGET,
+                )
+                .is_none()
+            );
             assert!(jit.recording.is_none());
         }
-        assert!(matches!(
-            jit.note_trace_exit(HEAD, CpuType::M68000, false),
-            ExitSeed::StartRecording
-        ));
+        assert!(
+            jit.try_execute(
+                &mut cpu,
+                &mut bus,
+                CpuType::M68000,
+                100,
+                false,
+                &[],
+                TRACE_EXIT_CHAIN_BUDGET,
+            )
+            .is_none()
+        );
+        assert!(jit.recording.is_some());
 
         jit.recording = Some(make_recording());
         jit.finish_recording(&mut cpu, 0x0456, RecordingEnd::Region);

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -52,6 +52,12 @@ const TRACE_MIN_SELF_LOOP_OPS: usize = 2;
 /// memory-ALU, and memory-heavy mixes.
 const TRACE_MIN_INDIRECT_JSR_OPS: usize = 7;
 const TRACE_HOT_THRESHOLD: u8 = 2;
+/// A non-self-loop region must demonstrate this many entries before native
+/// compilation. Its first recording is still taken at `TRACE_HOT_THRESHOLD`
+/// so true loops can compile with minimum latency; only the observed one-pass
+/// shape is deferred. This avoids paying the compiler and cache-displacement
+/// costs for startup and traversal paths that execute only a handful of times.
+const TRACE_LINEAR_HOT_THRESHOLD: u8 = 64 * TRACE_HOT_THRESHOLD;
 
 /// Hits a head must re-accumulate after its first trap-boundary closure was
 /// deferred (see `finish_recording_at_trap`): the value only needs to sit
@@ -927,6 +933,10 @@ enum TraceSlot {
         /// deferred instead of compiled; the head must re-reach
         /// `TRACE_TRAP_SEGMENT_HOT_THRESHOLD` hits before recording again.
         deferred_trap: bool,
+        /// The first completed recording was non-self-looping, so this head
+        /// uses the second-stage linear admission threshold. Mirrored into
+        /// the slot so ordinary JIT misses never consult the durable table.
+        deferred_linear: bool,
     },
     Rejected {
         pc: u32,
@@ -985,6 +995,10 @@ pub(crate) struct TraceJit {
     /// observations with no compile in between. A successful compile
     /// clears the count; SMC under the head clears it with the verdict.
     no_terminal_strikes: Vec<[(u32, u8); 2]>,
+    /// Heads whose first hot recording proved to be a non-self-loop region.
+    /// Keep the shape verdict across direct-mapped slot eviction so alias
+    /// churn cannot repeatedly reset the head to the eager threshold.
+    deferred_linear: Vec<[u32; 2]>,
 }
 
 impl fmt::Debug for TraceJit {
@@ -1023,6 +1037,7 @@ impl TraceJit {
             structurally_rejected: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
             compiled_before: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
             no_terminal_strikes: vec![[(u32::MAX, 0); 2]; TRACE_CACHE_SIZE],
+            deferred_linear: vec![[u32::MAX; 2]; TRACE_CACHE_SIZE],
         }
     }
 
@@ -1175,6 +1190,7 @@ impl TraceJit {
                 // Code changed under this head, so any structural verdict
                 // about the old bytes is void too.
                 self.forget_structural_rejection(pc);
+                self.clear_linear_deferral(pc);
                 cpu.trace_record_skip = [TRACE_PC_NONE; 4];
                 cpu.trace_probe_skip = [TRACE_PC_NONE; 4];
                 if index > 0 {
@@ -1389,6 +1405,7 @@ impl TraceJit {
                     adaptive_rerecords,
                     allow_call_through,
                     deferred_trap: false,
+                    deferred_linear: false,
                 };
                 cpu.trace_record_skip = [TRACE_PC_NONE; 4];
                 cpu.trace_probe_skip = [TRACE_PC_NONE; 4];
@@ -1484,12 +1501,15 @@ impl TraceJit {
                 adaptive_rerecords,
                 allow_call_through,
                 deferred_trap,
+                deferred_linear,
             } if *counted_pc == pc && *counted_type == cpu_type => {
                 if !from_exit_seed {
                     *hits = hits.saturating_add(1);
                 }
                 let threshold = if *deferred_trap {
                     TRACE_TRAP_SEGMENT_HOT_THRESHOLD
+                } else if *deferred_linear {
+                    TRACE_LINEAR_HOT_THRESHOLD
                 } else {
                     TRACE_HOT_THRESHOLD
                 };
@@ -1544,6 +1564,35 @@ impl TraceJit {
     fn has_call_permission(&self, pc: u32) -> bool {
         let ways = &self.earned_call_permission[trace_cache_index(pc)];
         ways[0] == pc || ways[1] == pc
+    }
+
+    fn defer_linear_compilation(&mut self, pc: u32) {
+        let ways = &mut self.deferred_linear[trace_cache_index(pc)];
+        if ways[0] == pc || ways[1] == pc {
+            return;
+        }
+        if ways[0] == u32::MAX {
+            ways[0] = pc;
+        } else if ways[1] == u32::MAX {
+            ways[1] = pc;
+        } else {
+            ways[1] = ways[0];
+            ways[0] = pc;
+        }
+    }
+
+    fn linear_compilation_deferred(&self, pc: u32) -> bool {
+        let ways = &self.deferred_linear[trace_cache_index(pc)];
+        ways[0] == pc || ways[1] == pc
+    }
+
+    fn clear_linear_deferral(&mut self, pc: u32) {
+        let ways = &mut self.deferred_linear[trace_cache_index(pc)];
+        for way in ways {
+            if *way == pc {
+                *way = u32::MAX;
+            }
+        }
     }
 
     fn remember_structural_rejection(&mut self, pc: u32) {
@@ -1652,6 +1701,7 @@ impl TraceJit {
         }
 
         let idx = trace_cache_index(pc);
+        let linear_history = &self.deferred_linear;
         match &self.slots[idx] {
             TraceSlot::Compiled(CompiledTrace {
                 pc: compiled_pc,
@@ -1684,6 +1734,8 @@ impl TraceJit {
                 if !self.is_structurally_rejected(pc)
                     && (self.has_compiled_before(pc) || self.has_no_terminal_strikes(pc))
                 {
+                    let ways = &linear_history[idx];
+                    let deferred_linear = ways[0] == pc || ways[1] == pc;
                     self.slots[idx] = TraceSlot::Counting {
                         pc,
                         cpu_type,
@@ -1691,6 +1743,7 @@ impl TraceJit {
                         adaptive_rerecords: 0,
                         allow_call_through: self.has_call_permission(pc),
                         deferred_trap: false,
+                        deferred_linear,
                     };
                     TRACE_JIT_HAS_CANDIDATES.store(true, Ordering::Relaxed);
                 }
@@ -1702,6 +1755,8 @@ impl TraceJit {
                     // the same uncompilable region.
                     return;
                 }
+                let ways = &linear_history[idx];
+                let deferred_linear = ways[0] == pc || ways[1] == pc;
                 self.slots[idx] = TraceSlot::Counting {
                     pc,
                     cpu_type,
@@ -1709,6 +1764,7 @@ impl TraceJit {
                     adaptive_rerecords: 0,
                     allow_call_through: self.has_call_permission(pc),
                     deferred_trap: false,
+                    deferred_linear,
                 };
                 TRACE_JIT_HAS_CANDIDATES.store(true, Ordering::Relaxed);
             }
@@ -1731,6 +1787,7 @@ impl TraceJit {
         // already earned.
         let permission = self.has_call_permission(exit_pc);
         let structurally_rejected = self.is_structurally_rejected(exit_pc);
+        let linear_history = &self.deferred_linear;
         match &mut self.slots[idx] {
             TraceSlot::Compiled(CompiledTrace {
                 pc: compiled_pc,
@@ -1751,10 +1808,13 @@ impl TraceJit {
                 adaptive_rerecords,
                 allow_call_through,
                 deferred_trap,
+                deferred_linear,
             } if *counted_pc == exit_pc && *counted_type == cpu_type => {
                 *hits = hits.saturating_add(1);
                 let threshold = if *deferred_trap {
                     TRACE_TRAP_SEGMENT_HOT_THRESHOLD
+                } else if *deferred_linear {
+                    TRACE_LINEAR_HOT_THRESHOLD
                 } else {
                     TRACE_HOT_THRESHOLD
                 };
@@ -1793,6 +1853,8 @@ impl TraceJit {
                 if structurally_rejected {
                     return ExitSeed::None;
                 }
+                let ways = &linear_history[idx];
+                let linear_deferred = ways[0] == exit_pc || ways[1] == exit_pc;
                 *slot = TraceSlot::Counting {
                     pc: exit_pc,
                     cpu_type,
@@ -1800,6 +1862,7 @@ impl TraceJit {
                     adaptive_rerecords: 0,
                     allow_call_through: permission,
                     deferred_trap: false,
+                    deferred_linear: linear_deferred,
                 };
                 self.pending_exit_seed = Some((exit_pc, cpu_type));
                 ExitSeed::None
@@ -1924,6 +1987,7 @@ impl TraceJit {
                 adaptive_rerecords,
                 allow_call_through,
                 deferred_trap: true,
+                deferred_linear: false,
             };
             return TrapFinish::Closed;
         }
@@ -2036,6 +2100,43 @@ impl TraceJit {
             };
             return;
         }
+
+        let self_loop = exit_pc == start_pc
+            || recording
+                .ops
+                .last()
+                .is_some_and(|op| op.op.taken_target(op.pc) == Some(start_pc));
+        let has_terminal = recording.ops.last().is_some_and(|op| op.op.ends_trace());
+        // Only a path that closed on its own terms (or a deliberately
+        // salvaged prefix ending at a blocker) proves a reusable linear
+        // shape. A host boundary or non-sequential trap merely interrupted
+        // recording; treating its earlier guarded branch as the terminal
+        // would defer an incomplete observation and hide the real stop.
+        if matches!(end, RecordingEnd::Region | RecordingEnd::Blocker)
+            && has_terminal
+            && !self_loop
+            // A guard-exit continuation is already backed by a hot compiled
+            // parent that can chain to it. Deferring that connector breaks
+            // the native trace graph into shorter calls, so reserve the
+            // raised threshold for independently discovered linear heads.
+            && !recording.from_exit_seed
+            && TRACE_LINEAR_HOT_THRESHOLD > TRACE_HOT_THRESHOLD
+            && !self.linear_compilation_deferred(start_pc)
+        {
+            self.defer_linear_compilation(start_pc);
+            self.slots[idx] = TraceSlot::Counting {
+                pc: start_pc,
+                cpu_type,
+                hits: 0,
+                adaptive_rerecords,
+                allow_call_through: recording.allow_call_through,
+                deferred_trap: false,
+                deferred_linear: true,
+            };
+            return;
+        }
+        self.clear_linear_deferral(start_pc);
+
         let outcome =
             self.compile_decoded_ops_reason(cpu, start_pc, cpu_type, recording.ops, Some(exit_pc));
         #[cfg(feature = "trace-profile")]
@@ -2405,6 +2506,7 @@ impl TraceJit {
                         adaptive_rerecords: 0,
                         allow_call_through: true,
                         deferred_trap: false,
+                        deferred_linear: false,
                     };
                     // The reject pushed the head into the probe-skip
                     // filter; clear it so the retry can be probed.
@@ -14391,6 +14493,24 @@ mod portable_tests {
         // Phase 1: 30 instructions of taken-spine iterations.
         step_n(&mut cpu_a, &mut bus_a, 30);
         batch_n(&mut cpu_b, &mut bus_b, 30);
+        let cont_pc = CODE_BASE + 4;
+        // This test concerns validation of an already-admitted continuation,
+        // not its profitability policy; place the candidate one hit before
+        // its second-stage threshold so phase 2 still exercises recording,
+        // compilation, chaining, and validation without spending the test's
+        // deliberately short adaptive-rerecording window on admission.
+        with_trace_jit(|jit| {
+            jit.defer_linear_compilation(cont_pc);
+            jit.slots[trace_cache_index(cont_pc)] = TraceSlot::Counting {
+                pc: cont_pc,
+                cpu_type: CpuType::M68040,
+                hits: TRACE_LINEAR_HOT_THRESHOLD - 1,
+                adaptive_rerecords: 0,
+                allow_call_through: false,
+                deferred_trap: false,
+                deferred_linear: true,
+            };
+        });
         // Phase 2: flip the predicate in both twins; 30 instructions of
         // guard exits, seeding, and chaining.
         cpu_a.set_d(1, 9);
@@ -14399,7 +14519,6 @@ mod portable_tests {
         batch_n(&mut cpu_b, &mut bus_b, 30);
         // The continuation must exist as its own compiled trace for phase 3
         // to test anything.
-        let cont_pc = CODE_BASE + 4;
         let cont_compiled = with_trace_jit(|jit| {
             matches!(
                 &jit.slots[trace_cache_index(cont_pc)],
@@ -16833,6 +16952,161 @@ mod portable_tests {
     }
 
     #[test]
+    fn linear_trace_first_closure_defers_and_second_closure_compiles() {
+        const HEAD: u32 = 0x0100;
+        let make_recording = || TraceRecording {
+            start_pc: HEAD,
+            cpu_type: CpuType::M68000,
+            ops: rts_region_ops(TRACE_MIN_INDIRECT_JSR_OPS),
+            adaptive_rerecords: 0,
+            allow_call_through: false,
+            pending_return: None,
+            skip_record_until: None,
+            from_exit_seed: false,
+        };
+        let mut cpu = cpu();
+        let mut jit = TraceJit::new();
+
+        jit.recording = Some(make_recording());
+        jit.finish_recording(&mut cpu, 0x0456, RecordingEnd::Region);
+        assert!(jit.linear_compilation_deferred(HEAD));
+        assert!(matches!(
+            &jit.slots[trace_cache_index(HEAD)],
+            TraceSlot::Counting {
+                pc: HEAD,
+                hits: 0,
+                deferred_trap: false,
+                deferred_linear: true,
+                ..
+            }
+        ));
+
+        // The shape verdict is independent of the direct-mapped trace slot:
+        // an alias can displace the candidate without making the original
+        // head look newly discovered and cheap to compile again.
+        let collider = HEAD + ((TRACE_CACHE_SIZE as u32) << 1);
+        assert_eq!(trace_cache_index(HEAD), trace_cache_index(collider));
+        jit.slots[trace_cache_index(HEAD)] = TraceSlot::Counting {
+            pc: collider,
+            cpu_type: CpuType::M68000,
+            hits: 1,
+            adaptive_rerecords: 0,
+            allow_call_through: false,
+            deferred_trap: false,
+            deferred_linear: false,
+        };
+        assert!(jit.linear_compilation_deferred(HEAD));
+
+        // Reinstall the head and prove that both exit-seeded admission and
+        // the second completed recording honor the raised threshold.
+        jit.slots[trace_cache_index(HEAD)] = TraceSlot::Counting {
+            pc: HEAD,
+            cpu_type: CpuType::M68000,
+            hits: 0,
+            adaptive_rerecords: 0,
+            allow_call_through: false,
+            deferred_trap: false,
+            deferred_linear: true,
+        };
+        for _ in 1..TRACE_LINEAR_HOT_THRESHOLD {
+            assert!(matches!(
+                jit.note_trace_exit(HEAD, CpuType::M68000, false),
+                ExitSeed::None
+            ));
+            assert!(jit.recording.is_none());
+        }
+        assert!(matches!(
+            jit.note_trace_exit(HEAD, CpuType::M68000, false),
+            ExitSeed::StartRecording
+        ));
+
+        jit.recording = Some(make_recording());
+        jit.finish_recording(&mut cpu, 0x0456, RecordingEnd::Region);
+        assert!(!jit.linear_compilation_deferred(HEAD));
+        assert!(matches!(
+            &jit.slots[trace_cache_index(HEAD)],
+            TraceSlot::Compiled(trace) if trace.pc == HEAD
+        ));
+    }
+
+    #[test]
+    fn exit_seeded_linear_trace_compiles_without_shape_deferral() {
+        const HEAD: u32 = 0x0100;
+        let mut cpu = cpu();
+        let mut jit = TraceJit::new();
+        jit.recording = Some(TraceRecording {
+            start_pc: HEAD,
+            cpu_type: CpuType::M68000,
+            ops: rts_region_ops(TRACE_MIN_INDIRECT_JSR_OPS),
+            adaptive_rerecords: 0,
+            allow_call_through: false,
+            pending_return: None,
+            skip_record_until: None,
+            from_exit_seed: true,
+        });
+
+        jit.finish_recording(&mut cpu, 0x0456, RecordingEnd::Region);
+
+        assert!(!jit.linear_compilation_deferred(HEAD));
+        assert!(matches!(
+            &jit.slots[trace_cache_index(HEAD)],
+            TraceSlot::Compiled(trace) if trace.pc == HEAD
+        ));
+    }
+
+    #[test]
+    fn self_loop_compiles_at_the_base_admission_threshold() {
+        const HEAD: u32 = 0x0100;
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x7001,
+                extension: None,
+                extension2: None,
+                pc: HEAD,
+                op: JitTraceOp::Moveq { reg: 0, data: 1 },
+            },
+            TraceBuildOp {
+                opcode: 0x7201,
+                extension: None,
+                extension2: None,
+                pc: HEAD + 2,
+                op: JitTraceOp::Moveq { reg: 1, data: 1 },
+            },
+            TraceBuildOp {
+                opcode: 0x60FA,
+                extension: None,
+                extension2: None,
+                pc: HEAD + 4,
+                op: JitTraceOp::Branch {
+                    condition: 0,
+                    displacement: -6,
+                    length: 2,
+                    expected_taken: None,
+                },
+            },
+        ];
+        let mut cpu = cpu();
+        let mut jit = TraceJit::new();
+        jit.recording = Some(TraceRecording {
+            start_pc: HEAD,
+            cpu_type: CpuType::M68000,
+            ops,
+            adaptive_rerecords: 0,
+            allow_call_through: false,
+            pending_return: None,
+            skip_record_until: None,
+            from_exit_seed: false,
+        });
+
+        jit.finish_recording(&mut cpu, HEAD, RecordingEnd::Region);
+        assert!(!jit.linear_compilation_deferred(HEAD));
+        assert!(matches!(
+            &jit.slots[trace_cache_index(HEAD)],
+            TraceSlot::Compiled(trace) if trace.pc == HEAD
+        ));
+    }
+
+    #[test]
     fn return_exit_reuses_the_indirect_call_break_even_length() {
         let compile_cpu = cpu();
         let mut jit = TraceJit::new();
@@ -16954,6 +17228,9 @@ mod portable_tests {
         prefix.pop();
         let mut cpu = cpu();
         let mut jit = TraceJit::new();
+        // This test exercises ReturnExit recording semantics, not first-pass
+        // admission. Treat shape discovery as already completed.
+        jit.defer_linear_compilation(0x0100);
         jit.recording = Some(TraceRecording {
             start_pc: 0x0100,
             cpu_type: CpuType::M68000,
@@ -16992,6 +17269,9 @@ mod portable_tests {
         prefix.pop();
         let mut cpu = cpu();
         let mut jit = TraceJit::new();
+        // This test exercises ReturnExit recording semantics, not first-pass
+        // admission. Treat shape discovery as already completed.
+        jit.defer_linear_compilation(0x0100);
         jit.recording = Some(TraceRecording {
             start_pc: 0x0100,
             cpu_type: CpuType::M68000,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -57,7 +57,7 @@ const TRACE_HOT_THRESHOLD: u8 = 2;
 /// so true loops can compile with minimum latency; only the observed one-pass
 /// shape is deferred. This avoids paying the compiler and cache-displacement
 /// costs for startup and traversal paths that execute only a handful of times.
-const TRACE_LINEAR_HOT_THRESHOLD: u8 = 64 * TRACE_HOT_THRESHOLD;
+const TRACE_LINEAR_HOT_THRESHOLD: u8 = 208;
 
 /// Hits a head must re-accumulate after its first trap-boundary closure was
 /// deferred (see `finish_recording_at_trap`): the value only needs to sit

--- a/src/core/trace_profile.rs
+++ b/src/core/trace_profile.rs
@@ -1700,7 +1700,11 @@ mod tests {
             .iter()
             .find(|row| row.start_pc == HEAD)
             .expect("rare-exit loop head was profiled");
-        assert_eq!(row.recording_attempts, 1);
+        // The first complete non-self-loop observation establishes the
+        // raised admission threshold; the second recording compiles it.
+        // Neither is an adaptive branch-bias re-recording, which is the
+        // behavior this test pins below.
+        assert_eq!(row.recording_attempts, 2);
         assert_eq!(row.adaptive_rerecords, 0);
         assert_eq!(row.compiled_ops, 4);
         assert!(row.guarded_branch_exits > 64);


### PR DESCRIPTION
# perf(trace): defer cold independent linear regions

> [!NOTE]
> This PR is stacked on #162 (`63a041b`). The admission implementation is
> `2c5b154`, followed by the independently measured threshold tuning in
> `dde66d2`; once #162 merges, the remaining diff will collapse to those two
> commits.

## Summary

The trace JIT currently uses the same two-entry hot threshold for two very
different shapes:

- a loop that returns to its own head and can amortize compilation indefinitely;
- a linear region that happened to be reached twice during startup, traversal,
  or a phase change and may never run again.

This change records both shapes at the existing threshold of two so admission
can use observed control flow rather than guessing from an opcode or game. It
then applies a shape-aware second stage:

- self-loops still compile immediately at 2 entries;
- guard-exit continuations seeded by an already-compiled parent still compile
  immediately at 2 entries, preserving the native trace graph;
- trap-terminal segments retain their existing 16-entry admission rule;
- only independently discovered, non-self-looping regions are deferred until
  208 subsequent entries prove enough reuse to justify compilation.

On the standard deterministic SC2K replay, the threshold-128 production build
reduces retired host instructions by **12.41%**, host cycles by **15.53%**, and
user CPU time by **15.17%**, at identical guest work, ticks, and framebuffer
output. The follow-up 208 tuning reduces another **0.83%** host instructions,
**1.33%** cycles, and **1.09%** user CPU time relative to 128.

## Why this reduces real CPU work

The JIT does not make compilation free. For every accepted region Cranelift
must construct IR, lower it, allocate registers, emit machine code, finalize
the function, and keep the result in the trace cache. Longer recorded paths
generally cost more to compile than short ones. A compiled path can also evict
another trace from the direct-mapped front cache, causing more lookup,
re-recording, and recompilation work later.

That work pays back only if future native executions save more host work than
the compile and displacement cost. A self-loop is strong evidence of such
future reuse. Reaching a linear path twice is not.

The measurement below is whole-process hardware-counter data, not a count of
compiler calls or an estimate. It includes startup, every short and long trace
compilation, cache effects, and execution. Therefore the SC2K reduction is net
of the cost of compiling the longer paths that remain admitted.

## Why not simply raise the global hot threshold?

An early threshold experiment appeared to help SC2K but regressed Lemmings by
about **5.3% retired host instructions**. Lifecycle counters explained why:
the global threshold also delayed continuations reached from guard exits of
already-hot compiled traces. Those continuations are not isolated cold paths;
they are the edges of a native trace graph. Delaying them split execution into
more, shorter native calls and sent useful work back through Rust dispatch.

The important predictor is therefore provenance plus observed shape:

1. Record at the normal threshold to see whether the path closes on itself.
2. Compile a self-loop immediately.
3. Compile a continuation immediately when a compiled parent seeded it.
4. Demand stronger reuse evidence only for a linear head discovered
   independently.

With the connector exemption in place, the raised-threshold policy that helps
SC2K no longer regresses Lemmings. The threshold-128 production result is a
1.40% Lemmings host-instruction reduction, and moving from 128 to 208 is
instruction-neutral there (+0.12%).

## Admission-state implementation

The first independent linear recording is used for classification but is not
compiled. Its head is returned to `TraceSlot::Counting` with a
`deferred_linear` bit. Normal hits read that bit from the slot itself, so the
per-entry miss path does not pay a side-table lookup.

A small two-way PC history per direct-mapped cache index preserves the verdict
if another head displaces the counting slot. When the original PC is installed
again, the durable history restores `deferred_linear` and continues using the
raised threshold instead of repeatedly treating the head as new. The history
is deliberately lossy beyond two colliding heads: losing an entry costs only
another classification recording, while making the structure larger or
hashed would add work to a hot path.

The verdict is cleared when code under the head is invalidated, because
self-modifying code may have changed the path shape.

### This is not a two-way executable trace cache

The word *two-way* above describes only the tiny, lossy shape-history table.
Each of its entries is a guest PC (`u32`) saying “this head was previously
observed to be independently linear.” It contains no generated code, compiled
trace object, validation bytes, counters, or replacement state. The actual
trace cache remains direct-mapped: every cache index still has exactly one
`TraceSlot`, and therefore at most one compiled trace that can execute from
that index.

The ordinary counting fast path reads `deferred_linear` directly from that
one existing slot. It consults the two-PC history only when a colliding head
has displaced the slot and the old head later has to be installed again. Thus
the history preserves an admission decision without adding a second compiled-
trace lookup or replacement decision to every execution.

The rejected always-two-way cache was much heavier. It retained two complete
`TraceSlot`s (including compiled traces) at each index, searched both ways on
compiled-trace misses, and maintained promotion/replacement behavior. That can
avoid some recompilation when two hot heads alias, but its extra lookup and
ownership work is paid during execution. It modestly helped SC2K, while
regressing EV Override and 3 in Three. #163 uses two metadata fingerprints only
to avoid forgetting “compile this later”; it does not use them to cache or
execute a second trace.

Only recordings that close as an ordinary region, or a deliberately salvaged
prefix ending before an unsupported blocker, can establish the linear verdict.
An externally stopped recording is incomplete. During testing, the existing
non-sequential-trap attribution test caught an initial version that could see
an earlier guarded branch in an interrupted prefix and misclassify it as the
terminal. The final code excludes host boundaries and non-sequential traps;
the original diagnostic test now passes unchanged.

## Why 208 entries?

A same-binary runtime sweep isolated the independent-linear threshold while
holding compiler code layout constant. Each SC2K arm executed 400 million
guest instructions and ended at the same 185,810 ticks and framebuffer hash:

| Independent-linear threshold | Retired host instructions | Host cycles |
|---:|---:|---:|
| 16 | 71.819B | 29.906B |
| 32 | 71.268B | 30.070B |
| 64 | 68.620B | 27.804B |
| 128 | **66.644B** | **27.084B** |

The curve remained strongly favorable through 128. Exact admission counters
also showed the mechanism rather than a code-layout accident:

| SC2K admission counter | threshold 16 | threshold 128 |
|---|---:|---:|
| first-shape deferrals | 1,347 | 1,132 |
| deferred entries | 14,029 | 48,547 |
| promoted/compiled heads | 675 | 203 |
| candidate reinstalls | 284 | 463 |
| candidate evictions | 322 | 503 |

At threshold 16, many 40--104-op independent regions reached the compiler.
Compiling long regions sooner is not intrinsically favorable: their compile
cost grows with their size, and the SC2K whole-process result became worse as
more of them were admitted. This is why the final rule does not lower the
threshold merely because a recording is long.

Because the original curve had not reached a minimum, a follow-up sweep tested
larger values with the same runtime-selectable fat-LTO binary. One 400M SC2K
scout per adjacent comparison found:

| Comparison | Host instructions | Host cycles | Interpretation |
|---|---:|---:|---|
| 128 -> 192 | **-0.438%** | **-0.599%** | still improving |
| 192 -> 208 | **-0.585%** | **-1.573%** | still improving |
| 208 -> 224 | **-0.277%** | +2.442% | instruction gain, cycle reversal |
| 224 -> 255 | +0.503% | +2.249% | past the minimum |

The practical knee is therefore 208, not the largest representable `u8`
value. Three alternating 128-versus-208 confirmation pairs then reproduced the
SC2K improvement at identical 185,810 ticks and final-frame hash: **-0.832%**
host instructions, **-1.332%** cycles, and **-1.088%** user CPU.

The same comparison was checked across the broader workload matrix before the
constant was changed:

| Workload | Guest bound | Pairs | Host instructions | Host cycles | User CPU | State check |
|---|---:|---:|---:|---:|---:|---|
| SimCity 2000 | 400M | 3 | **-0.832%** | **-1.332%** | **-1.088%** | 185,810 ticks; identical hash |
| Lemmings | 200M | 2 | +0.117% | **-3.869%** | **-6.433%** | 36,409 ticks; identical hash |
| EV Override | 200M | 2 | **-0.092%/tick** | **-1.408%/tick** | -1.303% raw | 1,181,481 vs 1,180,564 aggregate ticks |
| 3 in Three | 200M | 2 | +0.071% | +1.059% | +2.887% | 822,511 ticks; identical hash |
| System's Twilight | 100M | 2 | **-0.014%** | **-0.052%** | **-7.118%** | 685,705 ticks; identical hash |

The repeatable primary metric is favorable on SC2K and neutral (within 0.12%)
on every other application. The larger cycle/time movements in
instruction-neutral rows are frequency and scheduling noise; importantly,
raising the cutoff does not reproduce the Lemmings regression caused by a
global threshold.

## Production A/B results at threshold 128

Both arms use Systemless v0.28.5 at native-trap batching PR #1220 commit
`432fc49` and fat LTO with one codegen unit. The baseline uses m68k PR #162
commit `63a041b`; the candidate differs only by this patch. The preserved
binary hashes are:

- baseline: `baa0d1efb0e19002f16c57a46bcf845bd1f41f473b61ee5a6e09d6a2b37f8962`
- candidate: `e31949b544e05aaea8cd637847eab27b5d21fec54be0eca1eafcf4be7e17563d`

Runs alternate A/B order, copy each fixture into a fresh private directory,
disable periodic screenshots, and stop at a fixed guest-instruction count.
Retired host instructions are the primary CPU-work metric; cycles and user CPU
corroborate it but are more sensitive to scheduling and frequency. EV Override
is also reported per simulated tick because its scripted flight reached a
slightly different amount of simulated time at the fixed 200M executed-guest-
instruction bound. Systemless can fast-forward proven idle waits and advance
the guest clock without executing every skipped instruction, so fixed executed
instructions do not necessarily mean fixed simulated time. The raw EV result
was already favorable (-0.395% host instructions and -1.340% cycles); aggregate
ticks differed by only 58 out of about 1.18 million (0.0049%), and normalization
changes those results only to -0.400% and -1.345%. The conclusion therefore does
not depend on the normalization.

| Workload | Guest bound | Pairs | Host instructions | Host cycles | User CPU | State check |
|---|---:|---:|---:|---:|---:|---|
| SimCity 2000 | 400M | 2 | **-12.410%** | **-15.528%** | **-15.167%** | 185,810 ticks; identical hash |
| Lemmings | 200M | 4 | **-1.396%** | **-3.724%** | **-3.093%** | 36,409 ticks; identical hash |
| EV Override | 200M | 2 | **-0.395% raw; -0.400%/tick** | **-1.340% raw; -1.345%/tick** | +0.656% aggregate | 1,180,745 vs 1,180,803 aggregate ticks |
| 3 in Three | 200M | 4 | **-0.264%** | +0.492% | +1.067% | 822,511 ticks; identical hash |
| System's Twilight | 100M | 2 | **-0.046%** | +1.545% | +1.648% | 685,705 ticks; identical hash |

The candidate reduces retired host instructions in every workload. The small
cycle/user movements in the two instruction-neutral workloads are within the
variance observed in order-balanced controls and are far too large to be
caused by their tiny admission differences; no workload executes extra guest
work or changes deterministic output.

Raw results are in the local `game-cpu-final-admission128-*` benchmark logs.
The 128-versus-208 follow-up is in `game-cpu-shape-linear128-vs208-*`.

## 3 in Three's different behavior

3 in Three initially appeared to prefer a lower threshold in elapsed/cycle
measurements. Exact counters show that admission is not its limiting factor:

- both threshold arms classified exactly 72 independent linear heads;
- threshold 16 promoted 17, while threshold 128 promoted 3;
- threshold 128 incurred only 840 additional deferred head entries;
- neither arm had admission-state churn (`reinstalls=0`), and each had one
  candidate eviction;
- the two arms differed by only 5,486 JIT-retired guest instructions out of
  200 million.

That amount of changed JIT work cannot account for billions of host-cycle
variation. The final four-pair production measurement confirms the stable
metric is slightly favorable (-0.264% retired host instructions), while cycles
move by only +0.492%.

The opportunity profile instead shows that 3 in Three spends almost all of
its hot loop work behind unsupported forms. Two heads dominate:

- `$00406008`: 2,403,588 hits, with a two-op prefix stopped by opcode `$0C2D`
  (`CMPI.B #imm,d16(A5)`);
- `$00412550`: 2,403,428 hits, with a one-op prefix stopped by opcode `$4EAD`
  (`JSR d16(A5)`).

Only about 5 million of its 200 million guest instructions retire through the
JIT. Its next substantive optimization is coverage/call topology for those
forms, not weakening admission for cold linear traces.

## Alternatives measured and rejected

### Length-scaled thresholds

A tempting rule is to compile a longer recording sooner because one native
entry could retire more guest instructions. That omits the other half of the
economics: compile cost and generated-code footprint also grow with length.
SC2K's threshold-16 profile compiled many long independent regions and was
substantially worse than threshold 128. Without direct evidence that a long
head will return, length alone is not a profitability signal, so no
length-scaled rule is included.

### Durable lookup on every miss

The first implementation consulted durable linear-admission history on every
ordinary miss. Lemmings regressed by about 5.8%. Mirroring the verdict into
`TraceSlot::Counting` removes that repeated lookup; the side table is consulted
only when a displaced head is installed again.

### Global threshold 128

Applying 128 to all recorded shapes produced the roughly 5.3% Lemmings
regression described above. The connector-aware rule retains the SC2K win and
turns Lemmings into a 1.4% instruction win.

### Fixed 2-/4-/8-way trace caches

One to two ways helped SC2K by about 0.90% instructions and 1.10% cycles, but
additional ways saturated. Always-two-way regressed EV Override and 3 in
Three. Two-to-four and four-to-eight were neutral or mixed, so fixed capacity
was not a general answer.

### One-/two-way front cache plus Swiss-table overflow

A Swiss overflow behind one front way helped SC2K by 1.05% instructions and
0.89% cycles, but regressed 3 in Three by 0.52--0.57% instructions and EV by
0.446% instructions/tick. Swiss behind two ways regressed SC2K as well. The
overflow lookup/ownership work cost more than the avoided recompilation on the
broader matrix.

### Adaptive associativity

A ghost-history policy enabled a secondary way only after a displaced compiled
head returned. On a clean #162 baseline it improved SC2K cycles by 3.48% but
regressed retired instructions in 3 in Three (+0.666%), EV (+0.781%/tick),
Lemmings (+3.976%), and System's Twilight (+0.987%). It is preserved locally
for possible future interaction work but is not part of this PR.

### Stable arena handles without native linking

A monotonic arena gave traces non-reused identities and allowed cache/front
slots to hold stable handles. Both all-trace and evicted-only variants added an
arena dereference or backing lookup without removing a native/Rust/native
boundary. They lost to the simpler caches outside an encouraging isolated
SC2K comparison and regressed EV, so the arena-only patch was rejected.

## Future: stable handles plus real direct links

The arena experiment does not reject direct trace linking; it shows that stable
handles must eliminate a boundary to earn their cost. A separate design can:

1. allocate immutable or generation-tagged trace identities;
2. keep the current primary cache hit path inline;
3. store a small monomorphic successor cell in each compiled parent;
4. on key/generation match, transfer directly to the child's native entry;
5. validate the child's live guest bytes before executing it;
6. detour to Rust and repatch on invalidation or mismatch; and
7. preserve exact guest retirement and cycle accounting across the joined
   chain.

That would remove native/Rust/native dispatch between stable successors,
rather than merely replacing a cache lookup with an arena or hash lookup. It
belongs in a separate PR because its safety/invalidation model and performance
mechanism are independent of admission.

## Validation

- `cargo fmt --check`
- `cargo test --lib --features jit` — 266 passed
- `cargo test --lib --features 'jit trace-profile'` — 302 passed
- `cargo test --lib --all-features` — 302 passed
- fat-LTO Systemless production build
- five-application hardware-counter A/B matrix above
