### PR TITLE
perf(trace): specialize code validation by segment width

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -762,6 +762,120 @@ struct TraceCodeSegment {
     len: u32,
 }
 
+/// Compare live guest instructions with the bytes captured at compilation.
+///
+/// The helper stays outlined: trace entry already pays one call per segment,
+/// and inlining the SIMD loop expands the iterator closure enough to disturb
+/// instruction-cache locality in workloads dominated by tiny segments. Short
+/// ranges use early-out native-word loads; on x86-64, genuinely wide ranges
+/// fold 16-byte differences into one final decision. Very long ranges retain
+/// the platform `memcmp`, whose startup cost is then well amortized.
+#[inline(never)]
+unsafe fn trace_code_eq(live: *const u8, expected: *const u8, len: usize) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    if (48..=512).contains(&len) {
+        use std::arch::x86_64::{
+            __m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+            _mm_setzero_si128, _mm_xor_si128,
+        };
+
+        let mut offset = 0;
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+        let zero = unsafe { _mm_setzero_si128() };
+        let mut difference = zero;
+        while len - offset >= 16 {
+            // SAFETY: each complete vector lies inside the caller-provided
+            // `len`-byte ranges. Unaligned loads are intentional.
+            let live_word = unsafe { _mm_loadu_si128(live.add(offset).cast::<__m128i>()) };
+            let expected_word = unsafe { _mm_loadu_si128(expected.add(offset).cast::<__m128i>()) };
+            // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+            difference =
+                unsafe { _mm_or_si128(difference, _mm_xor_si128(live_word, expected_word)) };
+            offset += 16;
+        }
+
+        let mut tail_difference = 0u64;
+        if len - offset >= 8 {
+            // SAFETY: a complete eight-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            tail_difference |= live_word ^ expected_word;
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 2;
+        }
+        if len != offset {
+            // SAFETY: one byte remains inside each caller-provided range.
+            tail_difference |= u64::from(unsafe { *live.add(offset) ^ *expected.add(offset) });
+        }
+
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA. A zero byte in
+        // every lane produces all 16 bits in the movemask.
+        let wide_equal = unsafe { _mm_movemask_epi8(_mm_cmpeq_epi8(difference, zero)) == 0xFFFF };
+        return wide_equal & (tail_difference == 0);
+    }
+
+    let scalar_limit = if cfg!(target_arch = "x86_64") {
+        47
+    } else {
+        128
+    };
+    if len <= scalar_limit {
+        let mut offset = 0;
+        while len - offset >= 8 {
+            // SAFETY: each complete word lies inside both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 2;
+        }
+        return len == offset || unsafe { *live.add(offset) == *expected.add(offset) };
+    }
+
+    // SAFETY: the caller guarantees both ranges are readable for `len` bytes.
+    let live = unsafe { std::slice::from_raw_parts(live, len) };
+    let expected = unsafe { std::slice::from_raw_parts(expected, len) };
+    live == expected
+}
+
 struct CompiledTrace {
     pc: u32,
     cpu_type: CpuType,
@@ -1135,13 +1249,10 @@ impl TraceJit {
                     }
                     let expected = &trace.code[segment.code_offset as usize
                         ..(segment.code_offset + segment.len) as usize];
-                    let live = unsafe {
-                        std::slice::from_raw_parts(
-                            (cpu.fm_ptr as *const u8).add(off as usize),
-                            segment.len as usize,
-                        )
-                    };
-                    live == expected
+                    let live = unsafe { (cpu.fm_ptr as *const u8).add(off as usize) };
+                    // SAFETY: the bounds check above covers the live range,
+                    // and `expected` has exactly `segment.len` bytes.
+                    unsafe { trace_code_eq(live, expected.as_ptr(), segment.len as usize) }
                 });
             }
 
@@ -13836,6 +13947,37 @@ mod portable_tests {
             "with budget to act the miss surfaces"
         );
         assert_eq!(pc, 0x010C, "the miss consumed the changed opcode");
+    }
+
+    #[test]
+    fn trace_code_compare_covers_scalar_simd_and_platform_boundaries() {
+        let lengths = [
+            0usize, 1, 2, 3, 7, 8, 9, 15, 16, 47, 48, 49, 511, 512, 513, 768,
+        ];
+        for len in lengths {
+            let mut live = vec![0xA5u8; len + 8];
+            let mut expected = vec![0x5Au8; len + 8];
+            for index in 0..len {
+                let byte = (index as u8).wrapping_mul(37).wrapping_add(11);
+                live[index + 1] = byte;
+                expected[index + 3] = byte;
+            }
+            let live_ptr = unsafe { live.as_ptr().add(1) };
+            let expected_ptr = unsafe { expected.as_ptr().add(3) };
+            assert!(unsafe { trace_code_eq(live_ptr, expected_ptr, len) });
+
+            if len != 0 {
+                let positions = [0, len / 2, len - 1];
+                for position in positions {
+                    live[position + 1] ^= 0x80;
+                    assert!(
+                        !unsafe { trace_code_eq(live.as_ptr().add(1), expected_ptr, len) },
+                        "length {len} mismatch at byte {position}"
+                    );
+                    live[position + 1] ^= 0x80;
+                }
+            }
+        }
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]


### PR DESCRIPTION
## Summary

Replace the generic slice comparison on trace entry with an outlined,
width-specialized instruction-byte validator:

- short segments use unaligned native-word loads and return at the first
  unequal word;
- x86-64 segments from 48 through 512 bytes use an SSE2 XOR/OR reduction and
  one final `movemask` decision;
- longer segments retain Rust slice equality and the platform `memcmp`;
- the validation caller remains outlined and the same size as `master`.

This reduces retired host instructions by **3.50% in SimCity 2000** across six
400M-instruction pairs and by **4.35% in Lemmings** across three 200M pairs.
The other three application workloads are instruction-neutral to slightly
favorable, and every deterministic tick/framebuffer check passes.

## Why traces have to be validated

A compiled trace is generated correctly for the guest instruction bytes that
exist at compilation time. That is not enough to make it correct forever.
68k software treats executable memory as ordinary memory: code can be loaded,
relocated, patched, discarded, reloaded at the same address, or deliberately
self-modified. A trace embeds the meaning of the bytes it decoded, so executing
it after any captured byte changes would run stale semantics.

`CompiledTrace` therefore retains each source-code segment. Before entering
native code, `try_execute` verifies that every live segment still equals its
captured bytes. This also covers discontiguous traces: each constituent range
is checked independently. A mismatch rejects the trace and returns to the
normal execution path.

Before this patch, each segment was converted into a slice and compared with
`live == expected`. In the profiled fat-LTO macOS binary, that became a call to
the platform `memcmp` even for very short segments. A 30-second SC2K sample had
`_platform_memcmp` at the top of stack for 802 of 23,018 samples (**3.48% of the
whole process**) and for roughly half as many samples as `try_execute` itself
(1,650 top-of-stack samples). The comparison was correct, but its fixed call
and setup cost was being paid millions of times for small ranges.

## What the trace segments actually look like

Temporary profiling counted every validation segment in deterministic
production workloads. The instrumentation was removed before building the A/B
binaries.

| Workload | Validation entries | Segments | Dominant exact segment lengths |
|---|---:|---:|---|
| SimCity 2000, 400M | 12,689,598 | 30,514,484 | 6 B: 22.1%; 28 B: 18.2%; 36 B: 17.4%; 8 B: 9.5%; 10 B: 9.3% |
| EV Override, 200M | 2,554,078 | 3,863,600 | 10 B: 52.2%; 98 B: 24.8%; 106 B: 6.6% |
| 3 in Three, 200M | 1,606,544 | 1,607,582 | 12 B: 99.8% |

The distributions explain why one comparison strategy did not work for every
application. SC2K benefits heavily from making tiny and medium comparisons
cheap, EV has both tiny and much wider ranges, and 3 in Three is almost a pure
12-byte workload.

## Implementation

`trace_code_eq` is `#[inline(never)]`. Trace entry already pays one call per
segment, while keeping the comparator out of the iterator closure prevents a
large instruction-cache footprint at the much hotter lookup/dispatch site.

For a short range, the helper compares complete unaligned `u64`, `u32`, and
`u16` words, then an optional final byte. It exits as soon as one word differs.
This avoids the platform comparator's fixed setup cost and makes an invalidated
trace cheap to reject.

On x86-64, a 48--512-byte range instead uses the SSE2 baseline ISA. Each
16-byte pair is XORed, and all differences are ORed into one accumulator. The
tail is reduced with 8/4/2/1-byte loads. One `pcmpeqb`/`pmovmskb` decision and
the tail result decide equality. This avoids a branch for every word while
still reading only within the caller-provided ranges.

Ranges longer than 512 bytes continue through slice equality/platform
`memcmp`, where its tuned bulk implementation and setup cost are appropriate.
The non-x86 scalar path uses the same bounded unaligned word comparisons before
falling back to slice equality.

The cutovers were informed by a no-inline, 10-million-iteration comparison
microbenchmark using equal, deliberately unaligned buffers on the benchmark
x86-64 host:

| Bytes | platform `memcmp` | scalar words | branchless SSE2 |
|---:|---:|---:|---:|
| 6 | 5.589 ns | 3.355 ns | 3.738 ns |
| 12 | 8.057 ns | 3.024 ns | 3.494 ns |
| 28 | 13.051 ns | 4.529 ns | 5.320 ns |
| 48 | 15.675 ns | 6.462 ns | 5.531 ns |
| 98 | 17.985 ns | 8.683 ns | 6.739 ns |
| 192 | 21.670 ns | 14.981 ns | 7.723 ns |
| 406 | 28.960 ns | 29.950 ns | 12.662 ns |

These numbers chose a scalar/SIMD boundary rather than substituting for the
end-to-end application measurements below.

## Production A/B

Both arms use Systemless `432fc49` (native-trap batching), fat LTO, one codegen
unit, the same scripted inputs, and a fresh private copy of each fixture. The
baseline is exact m68k 0.12.1 `6ab4da7`; the candidate differs only by this
commit (`89892d5`). Preserved production binary hashes are:

- baseline: `fc78c0e7033cb411e09c1e0beded789369144e953f291fc9247912b7b03c8d2b`
- candidate: `057803bbc43f43e611477c8c58175d21aa91318c9b39636cd02ee328e6fde117`

Runs alternate order. Retired host instructions are the primary work metric;
cycles provide an independent hardware-counter check. This particular session
had severe frequency/thermal drift: equal SC2K runs ranged from about 8 to 15
seconds, and user CPU time sometimes moved opposite to cycles. I therefore do
not present noisy wall/user time as a speedup.

| Workload | Guest bound | Pairs | Retired host instructions | Host cycles | Correctness/state |
|---|---:|---:|---:|---:|---|
| SimCity 2000 | 400M | 6 | **-3.50%** | **-1.45%** | 185,810 ticks/run; identical hash |
| Lemmings | 200M | 3 | **-4.35%** | **-0.57%** | 36,409 ticks/run; identical hash |
| 3 in Three | 200M | 2 | **-0.10%** | +0.46% | 822,511 ticks/run; identical hash |
| EV Override | 200M | 2 | **-0.19%/tick** | +0.54%/tick | 1,180,319 vs 1,181,096 aggregate ticks |
| System's Twilight | 100M | 2 | **-0.04%** | +0.86% | 685,705 ticks/run; identical hash |

The SC2K instruction reduction reproduced in all six pairs: one three-pair set
measured -3.486%, and a subsequent warmed set measured -3.515%. An earlier
three-pair build on the immediately preceding upstream base independently
measured -3.180% instructions, -4.232% cycles, and -3.747% user CPU. Lemmings
likewise reproduced the same approximately 4.35% instruction reduction on both
bases. The current-base neutral-workload cycle movements are all below 0.9%
and change sign independently of the stable instruction counts.

EV is normalized per tick because Systemless can advance simulated time while
parking proven idle waits; a fixed executed-guest-instruction bound can
therefore end at a slightly different simulated tick. Its raw instruction
result is -0.120%; normalization for the 0.066% tick difference gives -0.185%.

## Rejected approaches

### Use one comparison strategy everywhere

A scalar-only early-out prototype improved retired instructions but did not
produce a convincing cycle/user-time win for wider segments. It is preserved
locally rather than included here.

A universal inline branchless-SIMD prototype improved SC2K but regressed 3 in
Three. The reason was structural, not a mysterious game-specific effect: 3 in
Three validates 12-byte segments almost exclusively, so it received no SIMD
benefit, while inlining the generic SIMD loop expanded the specialized
`Iterator::all` closure from 208 to 688 bytes. That disturbed the surrounding
hot path. Outlining the width-specialized helper restores the closure to the
same 208 bytes as `master`; `try_execute` is also unchanged at 2,928 bytes.

### Validate once per global no-write epoch

I also implemented and measured a conservative validation-elision prototype.
It gave each execution batch a fresh epoch, advanced the epoch after every
decoded operation known to write memory, treated full-dispatch operations as
possible writes, classified JIT traces by whether they may store, and cached a
successful validation epoch per trace. Native/host activity between batches
was conservatively assumed able to change code.

Against the accepted comparator in three SC2K 400M pairs, this was worse:

- **+0.36%** retired host instructions;
- **+0.77%** cycles;
- **+1.56%** user CPU.

The global epoch changes too often. Ordinary data and stack writes invalidate
the proof for every trace even when they cannot overlap that trace's code, and
the classification/bookkeeping cost is paid on hot store paths. The rejected
patch is retained locally for possible combination with a finer design.

## Can validation safely happen less often?

Yes, but the useful unit is a code page or range, not a process-wide epoch.
A future design could:

1. maintain a version for each guest page that has compiled code;
2. record the relevant page/version pairs in each trace;
3. skip byte comparison while all recorded versions still match;
4. increment only versions overlapped by a write; and
5. fall back to byte validation/recompilation after a version mismatch.

That requires one coherent write-observation mechanism. Bus writes alone are
insufficient: decoded and compiled fast-memory stores write the RAM window
directly, bypassing `AddressBus`, while native HLE trap handlers can write via
the host bus between CPU batches. Both paths must update the same page-version
table or a stale trace could be accepted. The existing optional
`InstructionCacheBus` demonstrates versioning for bus-visible writes, but the
trace executor cannot safely rely on it until fast-memory and host writes obey
the same contract.

There are two narrower opportunities:

- memory that the embedder can prove immutable (for example, true ROM) could
  carry an immutable generation and need no repeated byte validation;
- an embedder with authoritative code-resource lifetimes could issue stable
  generations for loaded segments.

Neither proof currently exists for generic writable 68k RAM, and SC2K's code
is loaded and patched in RAM, so assuming that generated code remains correct
would be a correctness bug. This PR takes the lower-risk win: preserve the
existing freshness proof and reduce its measured CPU cost.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked`
- `cargo test --release --features jit,trace-profile --lib` — 310 passed
- `RUSTDOCFLAGS='-D warnings -D rustdoc::private_intra_doc_links' cargo doc
  --all-features --locked --no-deps --document-private-items`
- `cargo package --locked --offline`
- focused equal/mismatch coverage at lengths 0, 1, 2, 3, 7, 8, 9, 15, 16,
  47, 48, 49, 511, 512, 513, and 768, with unaligned buffers and mismatches at
  the first, middle, and last byte
- deterministic multi-application A/B matrix above
