### PR TITLE
perf(trace): exit at nested forward calls

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -762,6 +762,120 @@ struct TraceCodeSegment {
     len: u32,
 }
 
+/// Compare live guest instructions with the bytes captured at compilation.
+///
+/// The helper stays outlined: trace entry already pays one call per segment,
+/// and inlining the SIMD loop expands the iterator closure enough to disturb
+/// instruction-cache locality in workloads dominated by tiny segments. Short
+/// ranges use early-out native-word loads; on x86-64, genuinely wide ranges
+/// fold 16-byte differences into one final decision. Very long ranges retain
+/// the platform `memcmp`, whose startup cost is then well amortized.
+#[inline(never)]
+unsafe fn trace_code_eq(live: *const u8, expected: *const u8, len: usize) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    if (48..=512).contains(&len) {
+        use std::arch::x86_64::{
+            __m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+            _mm_setzero_si128, _mm_xor_si128,
+        };
+
+        let mut offset = 0;
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+        let zero = unsafe { _mm_setzero_si128() };
+        let mut difference = zero;
+        while len - offset >= 16 {
+            // SAFETY: each complete vector lies inside the caller-provided
+            // `len`-byte ranges. Unaligned loads are intentional.
+            let live_word = unsafe { _mm_loadu_si128(live.add(offset).cast::<__m128i>()) };
+            let expected_word = unsafe { _mm_loadu_si128(expected.add(offset).cast::<__m128i>()) };
+            // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+            difference =
+                unsafe { _mm_or_si128(difference, _mm_xor_si128(live_word, expected_word)) };
+            offset += 16;
+        }
+
+        let mut tail_difference = 0u64;
+        if len - offset >= 8 {
+            // SAFETY: a complete eight-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            tail_difference |= live_word ^ expected_word;
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 2;
+        }
+        if len != offset {
+            // SAFETY: one byte remains inside each caller-provided range.
+            tail_difference |= u64::from(unsafe { *live.add(offset) ^ *expected.add(offset) });
+        }
+
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA. A zero byte in
+        // every lane produces all 16 bits in the movemask.
+        let wide_equal = unsafe { _mm_movemask_epi8(_mm_cmpeq_epi8(difference, zero)) == 0xFFFF };
+        return wide_equal & (tail_difference == 0);
+    }
+
+    let scalar_limit = if cfg!(target_arch = "x86_64") {
+        47
+    } else {
+        128
+    };
+    if len <= scalar_limit {
+        let mut offset = 0;
+        while len - offset >= 8 {
+            // SAFETY: each complete word lies inside both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 2;
+        }
+        return len == offset || unsafe { *live.add(offset) == *expected.add(offset) };
+    }
+
+    // SAFETY: the caller guarantees both ranges are readable for `len` bytes.
+    let live = unsafe { std::slice::from_raw_parts(live, len) };
+    let expected = unsafe { std::slice::from_raw_parts(expected, len) };
+    live == expected
+}
+
 struct CompiledTrace {
     pc: u32,
     cpu_type: CpuType,
@@ -1135,13 +1249,10 @@ impl TraceJit {
                     }
                     let expected = &trace.code[segment.code_offset as usize
                         ..(segment.code_offset + segment.len) as usize];
-                    let live = unsafe {
-                        std::slice::from_raw_parts(
-                            (cpu.fm_ptr as *const u8).add(off as usize),
-                            segment.len as usize,
-                        )
-                    };
-                    live == expected
+                    let live = unsafe { (cpu.fm_ptr as *const u8).add(off as usize) };
+                    // SAFETY: the bounds check above covers the live range,
+                    // and `expected` has exactly `segment.len` bytes.
+                    unsafe { trace_code_eq(live, expected.as_ptr(), segment.len as usize) }
                 });
             }
 
@@ -13836,6 +13947,37 @@ mod portable_tests {
             "with budget to act the miss surfaces"
         );
         assert_eq!(pc, 0x010C, "the miss consumed the changed opcode");
+    }
+
+    #[test]
+    fn trace_code_compare_covers_scalar_simd_and_platform_boundaries() {
+        let lengths = [
+            0usize, 1, 2, 3, 7, 8, 9, 15, 16, 47, 48, 49, 511, 512, 513, 768,
+        ];
+        for len in lengths {
+            let mut live = vec![0xA5u8; len + 8];
+            let mut expected = vec![0x5Au8; len + 8];
+            for index in 0..len {
+                let byte = (index as u8).wrapping_mul(37).wrapping_add(11);
+                live[index + 1] = byte;
+                expected[index + 3] = byte;
+            }
+            let live_ptr = unsafe { live.as_ptr().add(1) };
+            let expected_ptr = unsafe { expected.as_ptr().add(3) };
+            assert!(unsafe { trace_code_eq(live_ptr, expected_ptr, len) });
+
+            if len != 0 {
+                let positions = [0, len / 2, len - 1];
+                for position in positions {
+                    live[position + 1] ^= 0x80;
+                    assert!(
+                        !unsafe { trace_code_eq(live.as_ptr().add(1), expected_ptr, len) },
+                        "length {len} mismatch at byte {position}"
+                    );
+                    live[position + 1] ^= 0x80;
+                }
+            }
+        }
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -493,6 +493,15 @@ pub(crate) enum JitTraceOp {
         return_pc: u32,
         cycles: i32,
     },
+    /// A nested call at the recorder's one-level depth cap. Execute the
+    /// architectural push, land at the observed static callee, and end the
+    /// trace there; normal exit seeding can then compile or chain that callee
+    /// without adding work to interpreted call dispatch.
+    CallExit {
+        return_pc: u32,
+        target_pc: u32,
+        cycles: i32,
+    },
     /// The callee's RTS: pops the return address and bails unless it
     /// equals the recorded call's return -- a different return value is
     /// a different flow. Checked before the stack pointer moves.
@@ -894,6 +903,11 @@ struct CompiledTrace {
     /// iterations.
     #[cfg_attr(all(feature = "jit", not(target_family = "wasm")), allow(dead_code))]
     self_loop: bool,
+    /// A clean completion should seed candidacy at its exit (a dynamic
+    /// return continuation or a forward nested-call callee). Computed once
+    /// when the trace is built instead of decoding the last op on every
+    /// native entry.
+    seeded_exit: bool,
     /// The native body was generated as a counted loop. Short read/write
     /// MoveMem loops deliberately retain the original one-pass body: the
     /// extra loop-carried state costs more than the saved call boundary.
@@ -1329,10 +1343,7 @@ impl TraceJit {
             // head, which a fresh continuation never is, so without this
             // the continuations after a returning subroutine would only
             // ever compile by luck of a backward branch.
-            let ends_in_return_exit = trace
-                .ops
-                .last()
-                .is_some_and(|op| matches!(op.op, JitTraceOp::ReturnExit { .. }));
+            let ends_in_seeded_exit = trace.seeded_exit;
             // A generated loop clearly amortizes the ABI boundary for
             // profiled mixed 3+-op and read-only loops. A
             // two-op read/write MoveMem loop is already dominated by its two
@@ -1544,12 +1555,12 @@ impl TraceJit {
             if clean_link_exit {
                 super::trace_profile::note_link_exit(pc, cpu_type);
             }
-            // A clean ReturnExit completion seeds its dynamic target
-            // (each caller's continuation) even when nothing is compiled
-            // there yet; see `ends_in_return_exit` above.
-            let return_exit_completion =
-                ends_in_return_exit && !guarded_branch_exit && !partial_call_this_entry;
-            if (guarded_branch_exit || clean_link_exit || return_exit_completion)
+            // A clean ReturnExit completion seeds its dynamic continuation;
+            // a CallExit similarly seeds the static nested callee that the
+            // recorder could not include at its one-level depth cap.
+            let seeded_exit_completion =
+                ends_in_seeded_exit && !guarded_branch_exit && !partial_call_this_entry;
+            if (guarded_branch_exit || clean_link_exit || seeded_exit_completion)
                 && !single_iter
                 && chain_budget > 0
                 && cpu.pc != pc
@@ -2494,9 +2505,24 @@ impl TraceJit {
                 JitTraceOp::CallThrough { return_pc, .. } => {
                     let recording = self.recording.as_mut().unwrap();
                     if recording.pending_return.is_some() {
-                        // Depth cap: a nested call ends the region at the
-                        // outer callee's boundary.
-                        self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        // A forward nested call has no backward edge to seed
+                        // its callee independently. Make the call itself the
+                        // trace terminal so the normal compiled-exit path can
+                        // seed and eventually chain the callee. Backward
+                        // callees keep the existing edge-admission behavior.
+                        if next_pc > executed_pc {
+                            recording.ops.push(TraceBuildOp {
+                                op: JitTraceOp::CallExit {
+                                    return_pc,
+                                    target_pc: next_pc,
+                                    cycles: call_op.op.max_cycles(),
+                                },
+                                ..call_op
+                            });
+                            self.finish_recording(cpu, next_pc, RecordingEnd::Region);
+                        } else {
+                            self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        }
                         return;
                     }
                     // The caller's recorded bytes and the callee's each get
@@ -2851,7 +2877,9 @@ impl TraceJit {
         let ends_in_dynamic_exit = ops.last().is_some_and(|op| {
             matches!(
                 op.op,
-                JitTraceOp::IndirectJsr { .. } | JitTraceOp::ReturnExit { .. }
+                JitTraceOp::IndirectJsr { .. }
+                    | JitTraceOp::ReturnExit { .. }
+                    | JitTraceOp::CallExit { .. }
             )
         });
         if ends_in_dynamic_exit && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS {
@@ -2929,6 +2957,7 @@ impl TraceJit {
                     | JitTraceOp::AnDispBit { .. }
                     | JitTraceOp::IndirectJsr { .. }
                     | JitTraceOp::CallThrough { .. }
+                    | JitTraceOp::CallExit { .. }
                     | JitTraceOp::RtsReturn { .. }
                     | JitTraceOp::ReturnExit { .. }
             )
@@ -3370,7 +3399,7 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("Unlk implies a window env");
                         emit_unlk(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
-                    JitTraceOp::CallThrough { .. } => {
+                    JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
                         let env = mem_env.as_ref().expect("CallThrough implies a window env");
                         emit_call_through(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
@@ -3494,6 +3523,12 @@ impl TraceJit {
         };
 
         let guarded_ops = guarded_op_mask(ops);
+        let seeded_exit = ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: start_pc,
             cpu_type,
@@ -3502,6 +3537,7 @@ impl TraceJit {
             code_segments,
             max_cycles,
             self_loop,
+            seeded_exit,
             native_loop,
             callee_start,
             callee_end,
@@ -3520,6 +3556,12 @@ impl TraceJit {
     #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
     fn compile_ops(&mut self, params: CompileParams<'_>) -> Option<CompiledTrace> {
         let guarded_ops = guarded_op_mask(params.ops);
+        let seeded_exit = params.ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: params.start_pc,
             cpu_type: params.cpu_type,
@@ -3530,6 +3572,7 @@ impl TraceJit {
             code_segments: params.code_segments,
             max_cycles: params.max_cycles,
             self_loop: params.self_loop,
+            seeded_exit,
             needs_window: params.needs_window,
             code_start: params.code_start,
             code_end: params.code_end,
@@ -3684,6 +3727,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::MoveImmReg { .. }
             | JitTraceOp::MoveImmMem { .. }
             | JitTraceOp::CallThrough { .. }
+            | JitTraceOp::CallExit { .. }
             | JitTraceOp::RtsReturn { .. }
             | JitTraceOp::ReturnExit { .. } => return false,
         }
@@ -4174,7 +4218,7 @@ impl JitTraceOp {
             Self::Unlk { .. } => 12,
             // MC68000 BSR is 18(2/2) for every displacement width; RTS is
             // 16(4/0).
-            Self::CallThrough { cycles, .. } => cycles,
+            Self::CallThrough { cycles, .. } | Self::CallExit { cycles, .. } => cycles,
             Self::RtsReturn { .. } => 16,
             Self::ReturnExit { cycles, .. } => cycles,
         }
@@ -4186,6 +4230,7 @@ impl JitTraceOp {
             Self::Branch { .. }
                 | Self::Dbcc { .. }
                 | Self::IndirectJsr { .. }
+                | Self::CallExit { .. }
                 | Self::PcIndexJmp {
                     expected_target: Some(_),
                     ..
@@ -5865,7 +5910,10 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     if matches!(op.op, JitTraceOp::Unlk { .. }) {
         return execute_portable_unlk(cpu, op);
     }
-    if matches!(op.op, JitTraceOp::CallThrough { .. }) {
+    if matches!(
+        op.op,
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. }
+    ) {
         return execute_portable_call_through(cpu, op, spans);
     }
     if matches!(op.op, JitTraceOp::RtsReturn { .. }) {
@@ -7427,7 +7475,7 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::Link { .. } | JitTraceOp::Unlk { .. } => {
             unreachable!("LINK/UNLK are handled by execute_portable_link/unlk")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is handled by execute_portable_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -8133,7 +8181,7 @@ fn emit_jit_op(
         JitTraceOp::PeaInd { .. } | JitTraceOp::PeaDisp { .. } | JitTraceOp::PeaAbs { .. } => {
             unreachable!("PEA is emitted by emit_pea_disp")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is emitted by emit_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -9098,8 +9146,14 @@ fn emit_call_through(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        unreachable!("expected a call-through trace op")
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => unreachable!("expected a call-through or call-exit trace op"),
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -9114,6 +9168,10 @@ fn emit_call_through(
     let value = iconst_u32(builder, return_pc);
     window_store(builder, env, off, Size::Long, value);
     store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
+    if let Some(target_pc) = exit_target {
+        store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
+        store_u32(builder, cpu, offset_of!(CpuCore, pc), target_pc);
+    }
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -9195,8 +9253,14 @@ fn execute_portable_call_through(
     trace: TraceBuildOp,
     spans: CodeSpans,
 ) -> Option<i32> {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        return None;
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => return None,
     };
     if cpu.fm_len == 0 {
         return None;
@@ -9222,6 +9286,10 @@ fn execute_portable_call_through(
         *p.add(3) = b[3];
     }
     cpu.dar[15] = new_sp;
+    if let Some(target_pc) = exit_target {
+        cpu.change_of_flow = true;
+        cpu.pc = target_pc;
+    }
     Some(trace.op.max_cycles())
 }
 
@@ -17094,6 +17162,128 @@ mod portable_tests {
             },
         });
         ops
+    }
+
+    #[test]
+    fn forward_nested_call_becomes_an_executing_seeded_exit() {
+        const HEAD: u32 = 0x0100;
+        const CALL_PC: u32 = 0x010C;
+        const TARGET: u32 = 0x0180;
+        const RETURN: u32 = 0x010E;
+
+        let mut prefix = rts_region_ops(TRACE_MIN_INDIRECT_JSR_OPS);
+        prefix.pop();
+        let mut recording_cpu = cpu();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        // BSR.S +0x72: base is RETURN, destination is TARGET.
+        bus.write_word(CALL_PC, 0x6172);
+        recording_cpu.ir = 0x6172;
+        recording_cpu.pc = TARGET;
+        recording_cpu.trace_recording = true;
+
+        let mut jit = TraceJit::new();
+        // This test is about the depth-cap terminal, not first-pass linear
+        // admission, so treat the shape as already deferred once.
+        jit.defer_linear_compilation(HEAD);
+        jit.recording = Some(TraceRecording {
+            start_pc: HEAD,
+            cpu_type: CpuType::M68000,
+            ops: prefix,
+            adaptive_rerecords: 0,
+            allow_call_through: true,
+            pending_return: Some(0x0200),
+            skip_record_until: None,
+            from_exit_seed: false,
+        });
+        jit.record_executed(&mut recording_cpu, &mut bus, CALL_PC, TARGET);
+
+        let TraceSlot::Compiled(trace) = &jit.slots[trace_cache_index(HEAD)] else {
+            panic!("the forward nested-call region should compile");
+        };
+        assert!(matches!(
+            trace.ops.last().unwrap().op,
+            JitTraceOp::CallExit {
+                return_pc: RETURN,
+                target_pc: TARGET,
+                cycles: 18,
+            }
+        ));
+        assert!(trace.seeded_exit);
+        assert_eq!(
+            (trace.code_start, trace.code_end),
+            (HEAD, RETURN),
+            "the terminal call bytes belong to the caller snapshot"
+        );
+        assert_eq!(
+            (trace.callee_start, trace.callee_end),
+            (0, 0),
+            "CallExit does not pretend the separately compiled callee is inline"
+        );
+        let ops = trace.ops.clone();
+
+        let mut portable_memory = vec![0u8; 0x1000];
+        let mut portable = cpu();
+        attach_window(&mut portable, &mut portable_memory);
+        portable.set_a(7, 0x0800);
+        portable.change_of_flow = false;
+        let portable_packed =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!(
+            (portable_packed >> 32) as u32,
+            TRACE_MIN_INDIRECT_JSR_OPS as u32
+        );
+        assert_eq!(portable_packed as u32 as i32, 42); // six MOVEQs + BSR
+        assert_eq!(portable.a(7), 0x07FC);
+        assert_eq!(&portable_memory[0x07FC..0x0800], &RETURN.to_be_bytes());
+        assert_eq!(portable.pc, TARGET);
+        assert!(portable.change_of_flow);
+
+        // The push is a checked operation. If its address is outside the
+        // active window, the prefix remains committed but the call itself
+        // must not change SP, PC, flow state, or memory; full dispatch will
+        // retry it at CALL_PC.
+        let prepare_bail = |memory: &mut Vec<u8>| {
+            let mut bail = cpu();
+            attach_window(&mut bail, memory);
+            bail.set_a(7, 2);
+            bail.pc = HEAD;
+            bail.change_of_flow = false;
+            bail
+        };
+        let mut portable_bail_memory = vec![0u8; 0x1000];
+        let mut portable_bail = prepare_bail(&mut portable_bail_memory);
+        let portable_bail_packed =
+            execute_portable_trace(&mut portable_bail, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!((portable_bail_packed >> 32) as u32, ops.len() as u32 - 1);
+        assert_eq!(portable_bail_packed as u32 as i32, 24); // six MOVEQs only
+        assert_eq!(portable_bail.a(7), 2);
+        assert_eq!(portable_bail.pc, CALL_PC);
+        assert!(!portable_bail.change_of_flow);
+        assert!(portable_bail_memory.iter().all(|&byte| byte == 0));
+
+        #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+        {
+            let mut native_memory = vec![0u8; 0x1000];
+            let mut native = cpu();
+            attach_window(&mut native, &mut native_memory);
+            native.set_a(7, 0x0800);
+            native.change_of_flow = false;
+            let native_packed = unsafe { trace.call_native(&mut native, 1) };
+            assert_eq!(native_packed, portable_packed);
+            assert_eq!(native.dar, portable.dar);
+            assert_eq!(native.pc, portable.pc);
+            assert_eq!(native.change_of_flow, portable.change_of_flow);
+            assert_eq!(native_memory, portable_memory);
+
+            let mut native_bail_memory = vec![0u8; 0x1000];
+            let mut native_bail = prepare_bail(&mut native_bail_memory);
+            let native_bail_packed = unsafe { trace.call_native(&mut native_bail, 1) };
+            assert_eq!(native_bail_packed, portable_bail_packed);
+            assert_eq!(native_bail.dar, portable_bail.dar);
+            assert_eq!(native_bail.pc, portable_bail.pc);
+            assert_eq!(native_bail.change_of_flow, portable_bail.change_of_flow);
+            assert_eq!(native_bail_memory, portable_bail_memory);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This teaches the trace recorder to finish a profitable region by **executing a
nested forward call as its terminal operation**. The trace lands at the callee,
then the existing exit-seeding and bounded-chaining machinery admits and joins
the next trace. It does not skip the call or the callee.

On the deterministic SimCity 2000 replay, the final production binary retires
**9.45% fewer host instructions** for the same 400 million guest instructions,
185,810 simulated ticks, and final-frame hash. Hardware cycles and user CPU
time fall by 9.26% and 9.22%, respectively.

This is a JIT-coverage improvement, not an idle-loop or simulated-time
shortcut. The profile build moves about 54 million guest instructions from
decoded execution into compiled traces:

| SC2K profile, 400M guest instructions | Base | This PR | Change |
|---|---:|---:|---:|
| JIT-retired guest instructions | 283,075,013 | 337,027,263 | +19.06% |
| JIT coverage | 70.77% | 84.26% | +13.49 points |
| non-JIT guest instructions | 116,924,987 | 62,972,737 | **-46.14%** |
| rejected trace-head hits | 3,218,451 | 2,419,816 | -24.81% |
| native trace calls | 12,642,972 | 15,508,654 | +22.67% |

The native-call count rises because more of the guest program is represented
as a graph of compiled regions. That extra trace traffic is still much cheaper
than decoding the 54 million instructions it replaces: production host work
falls from 155.73 to 141.01 retired host instructions per guest instruction.

This PR is stacked on #166 (`89892d5`, specialized trace-code validation),
which in turn is based on released `master` (`6ab4da7`). The new work is the
second commit only.

## The recorder topology problem

The current call-through recorder intentionally tracks only one outstanding
return address. On a permitted retry it can inline one direct 68k call:

1. emit the call's checked stack push;
2. record the callee;
3. turn the callee's `RTS` into a checked return;
4. continue recording the caller.

That is enough for a loop with a leaf call, but not for ordinary game code in
which that callee makes another call. `pending_return` is already occupied when
the recorder reaches the nested call. Before this PR, the recorder stopped
*before* that second call:

```c
if (recording->pending_return != NONE) {
    finish_recording(executed_pc);   /* nested call not included */
    return;
}
```

The prefix often had no valid trace terminal. In that case it could not be
compiled at all, even if it contained dozens of otherwise supported, hot
instructions. It was reported as `no-trace-terminal` and discarded.

The problem is worse for a forward callee. A backward target naturally passes
through the existing backward-edge admission path; a forward call target has
no backward edge and may never be considered as an independent trace head.
The call graph is cyclic, but the local branch topology contains no edge that
teaches the recorder where the next region begins.

### The concrete SC2K case

SC2K's hot code at `0x218466` calls the routine at `0x21851C`. A common path in
that routine executes a long supported prefix, then performs another absolute
`JSR` at `0x2186EC` to the forward callee at `0x218ED6`.

The base profile shows `0x218466` receiving 189,877 hot-head hits but never
retiring a compiled instruction. Related recordings beginning at `0x2184CA`
were repeatedly stranded at nested calls such as `0x21857C`, `0x2186EC`, and
`0x218770`; one representative discarded path was 79 instructions long.
Adding another opcode implementation would not help because the blocker was
the recorder's call depth, not unsupported 68k semantics.

With this PR, `0x218466` becomes an 80-op compiled region whose final operation
is the `JSR` at `0x2186EC`. It makes 176,711 native calls and retires 11,438,071
guest instructions. Its forward target `0x218ED6` becomes a separate 26-op
compiled trace (2,974,691 retired instructions), and the existing connector
logic also discovers hot continuations at `0x218602`, `0x218694`, `0x2186BA`,
`0x218F6A`, and elsewhere.

## What changes

### 1. `CallExit` is an executing trace terminal

When the recorder reaches its one-level call-through depth cap and observes a
direct call whose executed target is forward in memory, it appends this
terminal instead of abandoning the prefix:

```c
struct CallExit {
    uint32_t return_pc;
    uint32_t target_pc;
    int32_t cycles;
};

if (recording.pending_return != NONE && is_direct_call(ir)) {
    if (next_pc > executed_pc) {
        recording.ops.push(CallExit {
            .return_pc = decoded_call.return_pc,
            .target_pc = next_pc,
            .cycles = decoded_call.cycles,
        });
        finish_recording(next_pc);
    } else {
        /* Backward callees already have edge-based admission. */
        finish_recording(executed_pc);
    }
    return;
}
```

The target comes from the successor actually observed while recording. Only
the already-supported static call forms participate: `BSR`, `JSR d16(PC)`,
and `JSR (xxx).L`. The mechanism remains behind the existing earned
call-through permission, so first-pass/ungated recording is unchanged.

`CallExit` shares the measured seven-operation dynamic-exit profitability
floor used by indirect-call and return exits. A tiny prefix therefore cannot
claim a JIT slot merely because it ends in a call.

### 2. The terminal performs the real 68k call

Both Cranelift and the portable executor implement the same architectural
operation:

```c
bool execute_call_exit(Cpu *cpu, uint32_t return_pc,
                       uint32_t target_pc, int cycles) {
    uint32_t new_sp = cpu->a[7] - 4;

    if (pre_68020(cpu) && (new_sp & 1))
        return false;
    if (!fastmem_contains(cpu, new_sp, 4))
        return false;
    if (store_overlaps_compiled_code(new_sp, 4))
        return false;

    store_be32(cpu->fastmem, new_sp, return_pc);
    cpu->a[7] = new_sp;
    cpu->change_of_flow = true;
    cpu->pc = target_pc;
    charge_cycles(cycles);
    return true;
}
```

The checked push happens before any call state is committed. If alignment,
window bounds, or self-modifying-code protection rejects the store, the trace's
earlier prefix remains retired, but SP, PC, flow state, and memory remain
unchanged for the call itself. Execution resumes at the call opcode and full
dispatch retries it. This is the same atomicity contract as the existing
call-through and indirect-JSR implementations.

Cycle charges are inherited from the decoded call: 18 cycles for 68000 `BSR`
and PC-relative `JSR`, and 20 for absolute-long `JSR`. Opcode and extension
bytes remain in the caller's validation snapshot. The target routine is *not*
falsely treated as inline code: `CallExit` leaves the second call-through code
interval empty, and the callee validates its own bytes when it is separately
compiled.

### 3. Existing exit seeding builds the next region

A successfully completed `CallExit` leaves `cpu.pc` at its callee. The trace
driver sends that PC through the same admission mechanism already used for
dynamic returns and guarded branches:

```c
if (trace.seeded_exit && completed_without_bail) {
    switch (note_trace_exit(cpu->pc)) {
    case START_RECORDING:
        /* Record the callee through ordinary execution. */
        break;
    case CHAIN:
        execute_compiled_child_with_reduced_budgets();
        break;
    case NONE:
        /* Interpret normally while evidence accumulates. */
        break;
    }
}
```

An exit from compiled code is stronger reuse evidence than an unrelated
one-pass linear sighting, so it uses the existing eager connector threshold
rather than the 208-hit independent-linear threshold. Once the child exists,
the normal three-link chain budget connects it without unbounded recursion.
Instruction and cycle budgets shrink by the amount retired in each parent, and
watched PCs retain the existing rule that permits candidacy accounting but
does not chain or carry a recording across a host-visible boundary.

The generated trace never assumes that the callee remains compiled. It exits
through the regular lookup path; cache replacement or code invalidation simply
causes decoded execution until the target is admitted again.

### 4. Precompute the seeded-exit property

`ReturnExit` already needed the same driver behavior. The old hot entry path
looked at the final element of `trace.ops` and matched its enum discriminant on
every entry. `CompiledTrace` now stores one `seeded_exit` bit, computed when
the trace is built for either `ReturnExit` or `CallExit`.

This is not merely cleanup. The first correct `CallExit` build, before this
precomputation, delivered about -9.27% on SC2K but measured +0.095% retired
host instructions on a longer Lemmings confirmation. The final precomputed
form measures -9.45% on SC2K and **-0.482%** on Lemmings. It also keeps the
ordinary trace-entry path independent of the variable-length opcode vector.

## Why this boundary instead of deeper inlining

Supporting arbitrary call nesting inside one trace would require a stack of
expected returns, additional disjoint code-validation ranges, more complex
store-overlap guards, larger compiled functions, and a policy for exponential
path growth. It would also keep compilation open through increasingly long
subroutine trees even though existing admission already knows how to compile
and connect regions independently.

`CallExit` makes the one-level inlining cap a useful region boundary. The
parent keeps its long profitable prefix, the call executes exactly, and the
callee owns its own admission, validation, invalidation, and recompilation
lifecycle.

Backward nested calls deliberately keep the old behavior because their target
already supplies the backward edge on which normal trace admission is based.
Seeding those targets again would add work without repairing the topology that
caused SC2K's stranded forward paths.

## Production A/B results

Each arm is a release/fat-LTO Systemless binary. Runs use fresh temporary game
copies/save directories and alternate A/B then B/A order. The primary metric
is macOS's hardware `instructions retired` counter: actual work performed by
the host CPU, not modeled 68k cycles. `cycles elapsed` and process user time
are included as corroborating but noisier timing measures.

Deterministic workloads complete with identical simulated ticks and final
frame hashes in every arm. EV Override reaches slightly different flight paths
under its replay, so its totals are normalized by aggregate simulated ticks.

| Workload | Guest budget | Pairs | Host instructions | Host cycles | User CPU | Correctness |
|---|---:|---:|---:|---:|---:|---|
| SimCity 2000 | 400M | 2 | **-9.453%** | **-9.262%** | **-9.215%** | 185,810 ticks; identical hash in hash-confirmation set |
| Lemmings | 400M | 3 | **-0.482%** | **-1.143%** | **-0.924%** | 72,243 ticks; identical hash |
| 3 in Three | 200M | 2 | -0.011% | -0.066% | +0.269% | 822,511 ticks; identical hash |
| System's Twilight | 100M | 2 | +0.004% | +0.521% | +2.717% | 685,705 ticks; identical hash |
| EV Override | 200M | 4 | -0.028%/tick | -0.339%/tick | -0.052%/tick | 2,363,669 vs 2,360,328 aggregate ticks |

The two high-positive timing percentages on the short Twilight sample do not
correspond to additional executed work: retired host instructions differ by
only 0.004%. They are reported rather than hidden because elapsed cycles and
coarsely sampled user time are sensitive to scheduling and frequency at this
size. The primary hardware-work result is neutral.

Raw SC2K retired-host-instruction counts:

```text
base:      62,301,110,323   62,282,315,235   mean 62,291,712,779
CallExit:  56,346,797,291   56,459,780,496   mean 56,403,288,894
delta:                                             -9.45298%
```

A separate final-binary two-pair run, this time capturing every final frame,
measured **-9.479%** (62,351,469,007 -> 56,441,085,970 mean host
instructions). All four arms again completed at 185,810 ticks and produced the
same SHA-256 frame hash, `f9915bc78d4a50fac721e7d92849ab8733d078ef341195ce5f0405915c25e26d`.

This holds factor one (guest instructions executed) constant and measures the
intended lever directly: fewer host instructions per guest instruction. Equal
ticks and hashes establish that the reduction is not a fast-forward or lost
guest work.

## Rejected alternatives

Several earlier prototypes tried to expose the nested callee as an independent
candidate without making the call a compiled terminal. They are preserved
locally, but are intentionally absent here:

| Prototype | SC2K | 3 in Three | Why rejected |
|---|---:|---:|---|
| signal/seed the observed forward callee from ordinary execution | -0.763% instructions | **+0.808%** | modest SC2K coverage; metadata cost paid on decoded dispatch |
| specialized `CachedOp::Call` variant | — | **+1.300%** | widened/complicated the common decoded-op path |
| richer memory-executor outcome/TLS signal | — | **+0.632%** | avoided CPU fields but still taxed the hot dispatch boundary |
| broad general call-target prototype | — | **+0.866%** | same cost/benefit mismatch at wider scope |

The direct-seeding prototype also discarded the useful parent prefix: it told
the JIT about the callee, but did not make the instructions leading to the call
compilable. `CallExit` fixes both halves while changing no ordinary decoded
opcode, `CpuCore` hot field, memory-op result, or cache lookup.

## Correctness and tests

The focused regression test constructs a seven-operation 68000 trace whose
last operation is a nested forward `BSR`. It verifies:

- recorder conversion to `CallExit` with exact return PC, target PC, and cycle
  charge;
- the caller-only code snapshot and empty inline-callee interval;
- big-endian return-address push, A7 decrement, PC transfer, flow flag,
  retirement count, and total cycles;
- byte-for-byte/register-for-register native and portable equivalence;
- atomic native and portable bailout when the stack write is outside fastmem:
  the six-op prefix commits, while the call's SP/PC/flow/memory effects do not.

Validation completed with:

```text
cargo fmt --all -- --check
cargo test --lib --features jit   # 275 passed
cargo test --lib                  # 201 passed (portable/no-JIT)
```

The application matrix additionally covers native M68000 execution in SC2K,
Lemmings, 3 in Three, System's Twilight, and EV Override with the correctness
checks described above.

## Direct links and stable handles (future work)

This PR still returns from a parent native trace to Rust, performs the existing
trace-cache lookup/validation, and then enters the child. A future optimization
could replace some of that boundary with a stable trace handle:

1. allocate a stable handle per logical guest head;
2. let cache replacement update the handle's generation and current compiled
   entry instead of invalidating raw pointers embedded in parent code;
3. have a linked exit verify the generation, code-validity state, remaining
   budgets, and watch state before entering the child;
4. fall back to the current Rust exit path on any mismatch.

Embedding raw native pointers now would be unsafe because compiled bodies are
owned and replaced by cache slots; a parent could retain a dangling target.
An arena alone fixes address lifetime but not guest-code invalidation or
watch/budget semantics. Stable handles provide the indirection needed to
preserve the current branchless head lookup and safe fallback while making
native-to-native linking possible later.

The present result deliberately establishes the structural value first:
ordinary safe bounded chaining already yields a 9.45% SC2K host-work reduction.
Direct links can be evaluated separately against that stronger baseline.
