### PR TITLE
perf(trace): bypass admission for compiled exits

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -762,6 +762,120 @@ struct TraceCodeSegment {
     len: u32,
 }
 
+/// Compare live guest instructions with the bytes captured at compilation.
+///
+/// The helper stays outlined: trace entry already pays one call per segment,
+/// and inlining the SIMD loop expands the iterator closure enough to disturb
+/// instruction-cache locality in workloads dominated by tiny segments. Short
+/// ranges use early-out native-word loads; on x86-64, genuinely wide ranges
+/// fold 16-byte differences into one final decision. Very long ranges retain
+/// the platform `memcmp`, whose startup cost is then well amortized.
+#[inline(never)]
+unsafe fn trace_code_eq(live: *const u8, expected: *const u8, len: usize) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    if (48..=512).contains(&len) {
+        use std::arch::x86_64::{
+            __m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+            _mm_setzero_si128, _mm_xor_si128,
+        };
+
+        let mut offset = 0;
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+        let zero = unsafe { _mm_setzero_si128() };
+        let mut difference = zero;
+        while len - offset >= 16 {
+            // SAFETY: each complete vector lies inside the caller-provided
+            // `len`-byte ranges. Unaligned loads are intentional.
+            let live_word = unsafe { _mm_loadu_si128(live.add(offset).cast::<__m128i>()) };
+            let expected_word = unsafe { _mm_loadu_si128(expected.add(offset).cast::<__m128i>()) };
+            // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+            difference =
+                unsafe { _mm_or_si128(difference, _mm_xor_si128(live_word, expected_word)) };
+            offset += 16;
+        }
+
+        let mut tail_difference = 0u64;
+        if len - offset >= 8 {
+            // SAFETY: a complete eight-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            tail_difference |= live_word ^ expected_word;
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 2;
+        }
+        if len != offset {
+            // SAFETY: one byte remains inside each caller-provided range.
+            tail_difference |= u64::from(unsafe { *live.add(offset) ^ *expected.add(offset) });
+        }
+
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA. A zero byte in
+        // every lane produces all 16 bits in the movemask.
+        let wide_equal = unsafe { _mm_movemask_epi8(_mm_cmpeq_epi8(difference, zero)) == 0xFFFF };
+        return wide_equal & (tail_difference == 0);
+    }
+
+    let scalar_limit = if cfg!(target_arch = "x86_64") {
+        47
+    } else {
+        128
+    };
+    if len <= scalar_limit {
+        let mut offset = 0;
+        while len - offset >= 8 {
+            // SAFETY: each complete word lies inside both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 2;
+        }
+        return len == offset || unsafe { *live.add(offset) == *expected.add(offset) };
+    }
+
+    // SAFETY: the caller guarantees both ranges are readable for `len` bytes.
+    let live = unsafe { std::slice::from_raw_parts(live, len) };
+    let expected = unsafe { std::slice::from_raw_parts(expected, len) };
+    live == expected
+}
+
 struct CompiledTrace {
     pc: u32,
     cpu_type: CpuType,
@@ -1135,13 +1249,10 @@ impl TraceJit {
                     }
                     let expected = &trace.code[segment.code_offset as usize
                         ..(segment.code_offset + segment.len) as usize];
-                    let live = unsafe {
-                        std::slice::from_raw_parts(
-                            (cpu.fm_ptr as *const u8).add(off as usize),
-                            segment.len as usize,
-                        )
-                    };
-                    live == expected
+                    let live = unsafe { (cpu.fm_ptr as *const u8).add(off as usize) };
+                    // SAFETY: the bounds check above covers the live range,
+                    // and `expected` has exactly `segment.len` bytes.
+                    unsafe { trace_code_eq(live, expected.as_ptr(), segment.len as usize) }
                 });
             }
 
@@ -13836,6 +13947,37 @@ mod portable_tests {
             "with budget to act the miss surfaces"
         );
         assert_eq!(pc, 0x010C, "the miss consumed the changed opcode");
+    }
+
+    #[test]
+    fn trace_code_compare_covers_scalar_simd_and_platform_boundaries() {
+        let lengths = [
+            0usize, 1, 2, 3, 7, 8, 9, 15, 16, 47, 48, 49, 511, 512, 513, 768,
+        ];
+        for len in lengths {
+            let mut live = vec![0xA5u8; len + 8];
+            let mut expected = vec![0x5Au8; len + 8];
+            for index in 0..len {
+                let byte = (index as u8).wrapping_mul(37).wrapping_add(11);
+                live[index + 1] = byte;
+                expected[index + 3] = byte;
+            }
+            let live_ptr = unsafe { live.as_ptr().add(1) };
+            let expected_ptr = unsafe { expected.as_ptr().add(3) };
+            assert!(unsafe { trace_code_eq(live_ptr, expected_ptr, len) });
+
+            if len != 0 {
+                let positions = [0, len / 2, len - 1];
+                for position in positions {
+                    live[position + 1] ^= 0x80;
+                    assert!(
+                        !unsafe { trace_code_eq(live.as_ptr().add(1), expected_ptr, len) },
+                        "length {len} mismatch at byte {position}"
+                    );
+                    live[position + 1] ^= 0x80;
+                }
+            }
+        }
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -1575,7 +1575,20 @@ impl TraceJit {
                 let entry_watched = watch_pcs
                     .iter()
                     .any(|&watched| cpu.address(watched) == cpu.address(cpu.pc));
-                match self.note_trace_exit(cpu.pc, cpu_type, entry_watched) {
+                // A clean link already performed this exact slot lookup;
+                // guarded and seeded exits need it once. Keep the compiled
+                // steady state in this caller so it does not pay an outlined
+                // admission-helper call merely to return `Chain`.
+                let exit_seed = if clean_link_exit || self.compiled_head_at(cpu.pc, cpu_type) {
+                    if entry_watched {
+                        ExitSeed::None
+                    } else {
+                        ExitSeed::Chain
+                    }
+                } else {
+                    self.note_trace_exit(cpu.pc, cpu_type, entry_watched)
+                };
+                match exit_seed {
                     ExitSeed::Chain => {
                         match self.try_execute(
                             cpu,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -493,6 +493,15 @@ pub(crate) enum JitTraceOp {
         return_pc: u32,
         cycles: i32,
     },
+    /// A nested call at the recorder's one-level depth cap. Execute the
+    /// architectural push, land at the observed static callee, and end the
+    /// trace there; normal exit seeding can then compile or chain that callee
+    /// without adding work to interpreted call dispatch.
+    CallExit {
+        return_pc: u32,
+        target_pc: u32,
+        cycles: i32,
+    },
     /// The callee's RTS: pops the return address and bails unless it
     /// equals the recorded call's return -- a different return value is
     /// a different flow. Checked before the stack pointer moves.
@@ -894,6 +903,11 @@ struct CompiledTrace {
     /// iterations.
     #[cfg_attr(all(feature = "jit", not(target_family = "wasm")), allow(dead_code))]
     self_loop: bool,
+    /// A clean completion should seed candidacy at its exit (a dynamic
+    /// return continuation or a forward nested-call callee). Computed once
+    /// when the trace is built instead of decoding the last op on every
+    /// native entry.
+    seeded_exit: bool,
     /// The native body was generated as a counted loop. Short read/write
     /// MoveMem loops deliberately retain the original one-pass body: the
     /// extra loop-carried state costs more than the saved call boundary.
@@ -1329,10 +1343,7 @@ impl TraceJit {
             // head, which a fresh continuation never is, so without this
             // the continuations after a returning subroutine would only
             // ever compile by luck of a backward branch.
-            let ends_in_return_exit = trace
-                .ops
-                .last()
-                .is_some_and(|op| matches!(op.op, JitTraceOp::ReturnExit { .. }));
+            let ends_in_seeded_exit = trace.seeded_exit;
             // A generated loop clearly amortizes the ABI boundary for
             // profiled mixed 3+-op and read-only loops. A
             // two-op read/write MoveMem loop is already dominated by its two
@@ -1544,12 +1555,12 @@ impl TraceJit {
             if clean_link_exit {
                 super::trace_profile::note_link_exit(pc, cpu_type);
             }
-            // A clean ReturnExit completion seeds its dynamic target
-            // (each caller's continuation) even when nothing is compiled
-            // there yet; see `ends_in_return_exit` above.
-            let return_exit_completion =
-                ends_in_return_exit && !guarded_branch_exit && !partial_call_this_entry;
-            if (guarded_branch_exit || clean_link_exit || return_exit_completion)
+            // A clean ReturnExit completion seeds its dynamic continuation;
+            // a CallExit similarly seeds the static nested callee that the
+            // recorder could not include at its one-level depth cap.
+            let seeded_exit_completion =
+                ends_in_seeded_exit && !guarded_branch_exit && !partial_call_this_entry;
+            if (guarded_branch_exit || clean_link_exit || seeded_exit_completion)
                 && !single_iter
                 && chain_budget > 0
                 && cpu.pc != pc
@@ -2494,9 +2505,24 @@ impl TraceJit {
                 JitTraceOp::CallThrough { return_pc, .. } => {
                     let recording = self.recording.as_mut().unwrap();
                     if recording.pending_return.is_some() {
-                        // Depth cap: a nested call ends the region at the
-                        // outer callee's boundary.
-                        self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        // A forward nested call has no backward edge to seed
+                        // its callee independently. Make the call itself the
+                        // trace terminal so the normal compiled-exit path can
+                        // seed and eventually chain the callee. Backward
+                        // callees keep the existing edge-admission behavior.
+                        if next_pc > executed_pc {
+                            recording.ops.push(TraceBuildOp {
+                                op: JitTraceOp::CallExit {
+                                    return_pc,
+                                    target_pc: next_pc,
+                                    cycles: call_op.op.max_cycles(),
+                                },
+                                ..call_op
+                            });
+                            self.finish_recording(cpu, next_pc, RecordingEnd::Region);
+                        } else {
+                            self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        }
                         return;
                     }
                     // The caller's recorded bytes and the callee's each get
@@ -2851,7 +2877,9 @@ impl TraceJit {
         let ends_in_dynamic_exit = ops.last().is_some_and(|op| {
             matches!(
                 op.op,
-                JitTraceOp::IndirectJsr { .. } | JitTraceOp::ReturnExit { .. }
+                JitTraceOp::IndirectJsr { .. }
+                    | JitTraceOp::ReturnExit { .. }
+                    | JitTraceOp::CallExit { .. }
             )
         });
         if ends_in_dynamic_exit && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS {
@@ -2929,6 +2957,7 @@ impl TraceJit {
                     | JitTraceOp::AnDispBit { .. }
                     | JitTraceOp::IndirectJsr { .. }
                     | JitTraceOp::CallThrough { .. }
+                    | JitTraceOp::CallExit { .. }
                     | JitTraceOp::RtsReturn { .. }
                     | JitTraceOp::ReturnExit { .. }
             )
@@ -3370,7 +3399,7 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("Unlk implies a window env");
                         emit_unlk(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
-                    JitTraceOp::CallThrough { .. } => {
+                    JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
                         let env = mem_env.as_ref().expect("CallThrough implies a window env");
                         emit_call_through(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
@@ -3494,6 +3523,12 @@ impl TraceJit {
         };
 
         let guarded_ops = guarded_op_mask(ops);
+        let seeded_exit = ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: start_pc,
             cpu_type,
@@ -3502,6 +3537,7 @@ impl TraceJit {
             code_segments,
             max_cycles,
             self_loop,
+            seeded_exit,
             native_loop,
             callee_start,
             callee_end,
@@ -3520,6 +3556,12 @@ impl TraceJit {
     #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
     fn compile_ops(&mut self, params: CompileParams<'_>) -> Option<CompiledTrace> {
         let guarded_ops = guarded_op_mask(params.ops);
+        let seeded_exit = params.ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: params.start_pc,
             cpu_type: params.cpu_type,
@@ -3530,6 +3572,7 @@ impl TraceJit {
             code_segments: params.code_segments,
             max_cycles: params.max_cycles,
             self_loop: params.self_loop,
+            seeded_exit,
             needs_window: params.needs_window,
             code_start: params.code_start,
             code_end: params.code_end,
@@ -3684,6 +3727,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::MoveImmReg { .. }
             | JitTraceOp::MoveImmMem { .. }
             | JitTraceOp::CallThrough { .. }
+            | JitTraceOp::CallExit { .. }
             | JitTraceOp::RtsReturn { .. }
             | JitTraceOp::ReturnExit { .. } => return false,
         }
@@ -4174,7 +4218,7 @@ impl JitTraceOp {
             Self::Unlk { .. } => 12,
             // MC68000 BSR is 18(2/2) for every displacement width; RTS is
             // 16(4/0).
-            Self::CallThrough { cycles, .. } => cycles,
+            Self::CallThrough { cycles, .. } | Self::CallExit { cycles, .. } => cycles,
             Self::RtsReturn { .. } => 16,
             Self::ReturnExit { cycles, .. } => cycles,
         }
@@ -4186,6 +4230,7 @@ impl JitTraceOp {
             Self::Branch { .. }
                 | Self::Dbcc { .. }
                 | Self::IndirectJsr { .. }
+                | Self::CallExit { .. }
                 | Self::PcIndexJmp {
                     expected_target: Some(_),
                     ..
@@ -5865,7 +5910,10 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     if matches!(op.op, JitTraceOp::Unlk { .. }) {
         return execute_portable_unlk(cpu, op);
     }
-    if matches!(op.op, JitTraceOp::CallThrough { .. }) {
+    if matches!(
+        op.op,
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. }
+    ) {
         return execute_portable_call_through(cpu, op, spans);
     }
     if matches!(op.op, JitTraceOp::RtsReturn { .. }) {
@@ -7427,7 +7475,7 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::Link { .. } | JitTraceOp::Unlk { .. } => {
             unreachable!("LINK/UNLK are handled by execute_portable_link/unlk")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is handled by execute_portable_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -8133,7 +8181,7 @@ fn emit_jit_op(
         JitTraceOp::PeaInd { .. } | JitTraceOp::PeaDisp { .. } | JitTraceOp::PeaAbs { .. } => {
             unreachable!("PEA is emitted by emit_pea_disp")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is emitted by emit_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -9098,8 +9146,14 @@ fn emit_call_through(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        unreachable!("expected a call-through trace op")
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => unreachable!("expected a call-through or call-exit trace op"),
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -9114,6 +9168,10 @@ fn emit_call_through(
     let value = iconst_u32(builder, return_pc);
     window_store(builder, env, off, Size::Long, value);
     store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
+    if let Some(target_pc) = exit_target {
+        store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
+        store_u32(builder, cpu, offset_of!(CpuCore, pc), target_pc);
+    }
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -9195,8 +9253,14 @@ fn execute_portable_call_through(
     trace: TraceBuildOp,
     spans: CodeSpans,
 ) -> Option<i32> {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        return None;
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => return None,
     };
     if cpu.fm_len == 0 {
         return None;
@@ -9222,6 +9286,10 @@ fn execute_portable_call_through(
         *p.add(3) = b[3];
     }
     cpu.dar[15] = new_sp;
+    if let Some(target_pc) = exit_target {
+        cpu.change_of_flow = true;
+        cpu.pc = target_pc;
+    }
     Some(trace.op.max_cycles())
 }
 
@@ -17094,6 +17162,128 @@ mod portable_tests {
             },
         });
         ops
+    }
+
+    #[test]
+    fn forward_nested_call_becomes_an_executing_seeded_exit() {
+        const HEAD: u32 = 0x0100;
+        const CALL_PC: u32 = 0x010C;
+        const TARGET: u32 = 0x0180;
+        const RETURN: u32 = 0x010E;
+
+        let mut prefix = rts_region_ops(TRACE_MIN_INDIRECT_JSR_OPS);
+        prefix.pop();
+        let mut recording_cpu = cpu();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        // BSR.S +0x72: base is RETURN, destination is TARGET.
+        bus.write_word(CALL_PC, 0x6172);
+        recording_cpu.ir = 0x6172;
+        recording_cpu.pc = TARGET;
+        recording_cpu.trace_recording = true;
+
+        let mut jit = TraceJit::new();
+        // This test is about the depth-cap terminal, not first-pass linear
+        // admission, so treat the shape as already deferred once.
+        jit.defer_linear_compilation(HEAD);
+        jit.recording = Some(TraceRecording {
+            start_pc: HEAD,
+            cpu_type: CpuType::M68000,
+            ops: prefix,
+            adaptive_rerecords: 0,
+            allow_call_through: true,
+            pending_return: Some(0x0200),
+            skip_record_until: None,
+            from_exit_seed: false,
+        });
+        jit.record_executed(&mut recording_cpu, &mut bus, CALL_PC, TARGET);
+
+        let TraceSlot::Compiled(trace) = &jit.slots[trace_cache_index(HEAD)] else {
+            panic!("the forward nested-call region should compile");
+        };
+        assert!(matches!(
+            trace.ops.last().unwrap().op,
+            JitTraceOp::CallExit {
+                return_pc: RETURN,
+                target_pc: TARGET,
+                cycles: 18,
+            }
+        ));
+        assert!(trace.seeded_exit);
+        assert_eq!(
+            (trace.code_start, trace.code_end),
+            (HEAD, RETURN),
+            "the terminal call bytes belong to the caller snapshot"
+        );
+        assert_eq!(
+            (trace.callee_start, trace.callee_end),
+            (0, 0),
+            "CallExit does not pretend the separately compiled callee is inline"
+        );
+        let ops = trace.ops.clone();
+
+        let mut portable_memory = vec![0u8; 0x1000];
+        let mut portable = cpu();
+        attach_window(&mut portable, &mut portable_memory);
+        portable.set_a(7, 0x0800);
+        portable.change_of_flow = false;
+        let portable_packed =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!(
+            (portable_packed >> 32) as u32,
+            TRACE_MIN_INDIRECT_JSR_OPS as u32
+        );
+        assert_eq!(portable_packed as u32 as i32, 42); // six MOVEQs + BSR
+        assert_eq!(portable.a(7), 0x07FC);
+        assert_eq!(&portable_memory[0x07FC..0x0800], &RETURN.to_be_bytes());
+        assert_eq!(portable.pc, TARGET);
+        assert!(portable.change_of_flow);
+
+        // The push is a checked operation. If its address is outside the
+        // active window, the prefix remains committed but the call itself
+        // must not change SP, PC, flow state, or memory; full dispatch will
+        // retry it at CALL_PC.
+        let prepare_bail = |memory: &mut Vec<u8>| {
+            let mut bail = cpu();
+            attach_window(&mut bail, memory);
+            bail.set_a(7, 2);
+            bail.pc = HEAD;
+            bail.change_of_flow = false;
+            bail
+        };
+        let mut portable_bail_memory = vec![0u8; 0x1000];
+        let mut portable_bail = prepare_bail(&mut portable_bail_memory);
+        let portable_bail_packed =
+            execute_portable_trace(&mut portable_bail, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!((portable_bail_packed >> 32) as u32, ops.len() as u32 - 1);
+        assert_eq!(portable_bail_packed as u32 as i32, 24); // six MOVEQs only
+        assert_eq!(portable_bail.a(7), 2);
+        assert_eq!(portable_bail.pc, CALL_PC);
+        assert!(!portable_bail.change_of_flow);
+        assert!(portable_bail_memory.iter().all(|&byte| byte == 0));
+
+        #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+        {
+            let mut native_memory = vec![0u8; 0x1000];
+            let mut native = cpu();
+            attach_window(&mut native, &mut native_memory);
+            native.set_a(7, 0x0800);
+            native.change_of_flow = false;
+            let native_packed = unsafe { trace.call_native(&mut native, 1) };
+            assert_eq!(native_packed, portable_packed);
+            assert_eq!(native.dar, portable.dar);
+            assert_eq!(native.pc, portable.pc);
+            assert_eq!(native.change_of_flow, portable.change_of_flow);
+            assert_eq!(native_memory, portable_memory);
+
+            let mut native_bail_memory = vec![0u8; 0x1000];
+            let mut native_bail = prepare_bail(&mut native_bail_memory);
+            let native_bail_packed = unsafe { trace.call_native(&mut native_bail, 1) };
+            assert_eq!(native_bail_packed, portable_bail_packed);
+            assert_eq!(native_bail.dar, portable_bail.dar);
+            assert_eq!(native_bail.pc, portable_bail.pc);
+            assert_eq!(native_bail.change_of_flow, portable_bail.change_of_flow);
+            assert_eq!(native_bail_memory, portable_bail_memory);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Stack note

This is stacked on #167. Until #167 lands, the comparison against `master`
also contains its nested-forward-call work (and #166 below that). The new
change for this PR is only:

```text
d7cb97c perf(trace): bypass admission for compiled exits
```

## Summary

Bypass exit-admission bookkeeping when a trace has already proven that its
exit target is an exact compiled neighbor.

This reduces actual host CPU work in applications with frequent
compiled-to-compiled transitions:

- SimCity 2000: **-0.861% aggregate host instructions** across three 400M
  pairs (**-0.913% by pair medians**)
- Lemmings: **-1.170% host instructions** across two 200M pairs
- 3 in Three, System's Twilight, and EV Override: within +/-0.03% host
  instructions (neutral)

The patch changes no trace-admission thresholds, cache ownership, generated
code, validation, chaining depth, guest instruction counts, or modeled 68k
cycles.

## What was unnecessarily expensive

After a compiled trace exits, `try_execute` determines whether the exit was:

- a guarded branch side exit;
- a clean completion onto a compiled link target; or
- a seeded dynamic exit such as #167's `CallExit`/`ReturnExit` continuation.

The steady-state action for an exact compiled target is simply `Chain`: enter
that trace, subject to the existing watch and chain-budget rules.

Previously every qualifying exit called `note_trace_exit`. That function is
primarily the admission-policy state machine for targets which are not yet
compiled. Before it can return `Chain` for an already-compiled target, it:

1. recomputes the direct-mapped trace-cache index;
2. clears the target's durable linear-deferral entry;
3. probes the two-way earned-call-permission table;
4. probes the two-way structural-rejection table; and
5. rechecks the cache slot, full PC, and CPU model.

Those operations are useful for empty, counting, rejected, aliased, and
wrong-CPU slots. They cannot affect the decision for an exact compiled
neighbor. A successfully compiled head has already cleared its durable
linear-deferral marker, and the other two side-table probes are read-only.

This became visible after #167 made SC2K's caller/callee/continuation graph
compile successfully. In its 400M opportunity profile, the hottest trace
chained 3,097,192 times and its descendants retired 65,686,660 guest
instructions. A 20-second production stack sample attributed 288 of 15,796
top-of-stack samples (1.82%) directly to `note_trace_exit`; some related lookup
and hashing work was attributed separately.

## The fast path

`try_execute` now resolves the exact compiled-neighbor case before calling the
admission helper:

- a clean link reuses the `compiled_head_at` result it already computed;
- guarded and seeded exits perform that exact slot/PC/CPU lookup once;
- an unwatched exact compiled target returns `Chain` directly;
- a watched exact compiled target still refuses to chain, preserving the
  runner-visible boundary; and
- every noncompiled or mismatched target still enters `note_trace_exit`
  unchanged.

Cache replacement and self-modifying-code invalidation naturally remove the
exact compiled slot. The next exit then falls through to the unchanged
admission helper, so the shortcut cannot keep a stale link alive.

An intermediate version moved the compiled check to the beginning of
`note_trace_exit`. That measured -0.55% SC2K host instructions. Keeping the
check in `try_execute` instead avoids the outlined helper call entirely and
reuses the lookup already done for clean links. The final minimal caller-only
form measures better and adds only 14 lines.

## Host-CPU measurements

Each arm is a release/fat-LTO Systemless binary. The harness uses fresh game
copies/save directories and alternates A/B then B/A order. The primary metric
is macOS hardware `instructions retired`: actual work executed by the host,
not modeled guest cycles. Host cycles and process user time are noisier
corroboration.

| Workload | Guest budget | Pairs | Host instructions | Host cycles | User CPU | Correctness |
|---|---:|---:|---:|---:|---:|---|
| SimCity 2000 | 400M | 3 | **-0.861% aggregate; -0.913% median** | -1.249% | -0.849% | 185,810 ticks/run |
| Lemmings | 200M | 2 | **-1.170%** | -1.243% | -0.517% | 36,409 ticks/run; identical hash |
| 3 in Three | 200M | 2 | +0.023% | +1.526% | +1.299% | 822,511 ticks/run; identical hash |
| System's Twilight | 100M | 2 | -0.022% | -2.039% | -2.730% | 685,705 ticks/run; identical hash |
| EV Override | 200M | 4 | +0.027%/tick | -0.595%/tick | -1.027%/tick | 2,362,189 vs 2,362,099 aggregate ticks |

The non-SC2K/Lemmings instruction movements are within +/-0.03% and are
reported as neutral. Their larger timing movements do not correspond to
changed executed work. EV is normalized by aggregate simulated ticks because
its deterministic input replay can follow slightly different flight paths.

SC2K raw host-instruction counts:

```text
#167 base: 56,476,614,059  56,414,528,626  56,514,915,269
candidate: 55,961,053,451  55,930,939,682  56,054,854,493
aggregate delta: -0.861368%
median delta:    -0.912865%
```

The later SC2K timing runs encountered a changing machine/thermal state, but
the host-instruction reduction remained stable in every pair. This is why the
hardware work counter, rather than elapsed time, is the acceptance gate.

## Related depth-limit experiments (rejected)

The same investigation tested whether #167 was leaving useful compiled work
beyond the existing three-link execution limit.

### Admit exits even when the chain budget is exhausted

The current depth guard suppresses both recursive execution and exit-admission
evidence. A prototype continued counting/promoting the fourth-level target
without executing another nested trace. It passed the full tests but made
SC2K about **0.34% worse** in retired host instructions: the extra bookkeeping
found too little useful code to repay itself.

### Raise recursive chain depth from 3 to 32

This bounded proxy for removing the execution limit was neutral on SC2K:
**+0.004% by medians** and +0.020% by aggregate host instructions. Useful
compiled chains overwhelmingly fit inside the existing limit.

Literally removing the limit is unsafe in the current recursive design: a
compiled cycle can grow the host stack until the batch budget expires. A
constant-stack iterative dispatcher could remove that risk, but the 3-versus-32
result shows no substantive performance reason to make that larger refactor.

Both rejected prototypes remain preserved locally.

## Verification

- `cargo test --lib --features jit`: 275 passed
- `cargo test --lib --no-default-features`: 201 passed
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- deterministic workloads above completed with equal ticks and identical
  final-frame hashes; EV used per-tick normalization as described above

