### PR TITLE
perf(trace): extend indirect-call and immediate-memory coverage

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -762,6 +762,120 @@ struct TraceCodeSegment {
     len: u32,
 }
 
+/// Compare live guest instructions with the bytes captured at compilation.
+///
+/// The helper stays outlined: trace entry already pays one call per segment,
+/// and inlining the SIMD loop expands the iterator closure enough to disturb
+/// instruction-cache locality in workloads dominated by tiny segments. Short
+/// ranges use early-out native-word loads; on x86-64, genuinely wide ranges
+/// fold 16-byte differences into one final decision. Very long ranges retain
+/// the platform `memcmp`, whose startup cost is then well amortized.
+#[inline(never)]
+unsafe fn trace_code_eq(live: *const u8, expected: *const u8, len: usize) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    if (48..=512).contains(&len) {
+        use std::arch::x86_64::{
+            __m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+            _mm_setzero_si128, _mm_xor_si128,
+        };
+
+        let mut offset = 0;
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+        let zero = unsafe { _mm_setzero_si128() };
+        let mut difference = zero;
+        while len - offset >= 16 {
+            // SAFETY: each complete vector lies inside the caller-provided
+            // `len`-byte ranges. Unaligned loads are intentional.
+            let live_word = unsafe { _mm_loadu_si128(live.add(offset).cast::<__m128i>()) };
+            let expected_word = unsafe { _mm_loadu_si128(expected.add(offset).cast::<__m128i>()) };
+            // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+            difference =
+                unsafe { _mm_or_si128(difference, _mm_xor_si128(live_word, expected_word)) };
+            offset += 16;
+        }
+
+        let mut tail_difference = 0u64;
+        if len - offset >= 8 {
+            // SAFETY: a complete eight-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            tail_difference |= live_word ^ expected_word;
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 2;
+        }
+        if len != offset {
+            // SAFETY: one byte remains inside each caller-provided range.
+            tail_difference |= u64::from(unsafe { *live.add(offset) ^ *expected.add(offset) });
+        }
+
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA. A zero byte in
+        // every lane produces all 16 bits in the movemask.
+        let wide_equal = unsafe { _mm_movemask_epi8(_mm_cmpeq_epi8(difference, zero)) == 0xFFFF };
+        return wide_equal & (tail_difference == 0);
+    }
+
+    let scalar_limit = if cfg!(target_arch = "x86_64") {
+        47
+    } else {
+        128
+    };
+    if len <= scalar_limit {
+        let mut offset = 0;
+        while len - offset >= 8 {
+            // SAFETY: each complete word lies inside both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 2;
+        }
+        return len == offset || unsafe { *live.add(offset) == *expected.add(offset) };
+    }
+
+    // SAFETY: the caller guarantees both ranges are readable for `len` bytes.
+    let live = unsafe { std::slice::from_raw_parts(live, len) };
+    let expected = unsafe { std::slice::from_raw_parts(expected, len) };
+    live == expected
+}
+
 struct CompiledTrace {
     pc: u32,
     cpu_type: CpuType,
@@ -1135,13 +1249,10 @@ impl TraceJit {
                     }
                     let expected = &trace.code[segment.code_offset as usize
                         ..(segment.code_offset + segment.len) as usize];
-                    let live = unsafe {
-                        std::slice::from_raw_parts(
-                            (cpu.fm_ptr as *const u8).add(off as usize),
-                            segment.len as usize,
-                        )
-                    };
-                    live == expected
+                    let live = unsafe { (cpu.fm_ptr as *const u8).add(off as usize) };
+                    // SAFETY: the bounds check above covers the live range,
+                    // and `expected` has exactly `segment.len` bytes.
+                    unsafe { trace_code_eq(live, expected.as_ptr(), segment.len as usize) }
                 });
             }
 
@@ -13836,6 +13947,37 @@ mod portable_tests {
             "with budget to act the miss surfaces"
         );
         assert_eq!(pc, 0x010C, "the miss consumed the changed opcode");
+    }
+
+    #[test]
+    fn trace_code_compare_covers_scalar_simd_and_platform_boundaries() {
+        let lengths = [
+            0usize, 1, 2, 3, 7, 8, 9, 15, 16, 47, 48, 49, 511, 512, 513, 768,
+        ];
+        for len in lengths {
+            let mut live = vec![0xA5u8; len + 8];
+            let mut expected = vec![0x5Au8; len + 8];
+            for index in 0..len {
+                let byte = (index as u8).wrapping_mul(37).wrapping_add(11);
+                live[index + 1] = byte;
+                expected[index + 3] = byte;
+            }
+            let live_ptr = unsafe { live.as_ptr().add(1) };
+            let expected_ptr = unsafe { expected.as_ptr().add(3) };
+            assert!(unsafe { trace_code_eq(live_ptr, expected_ptr, len) });
+
+            if len != 0 {
+                let positions = [0, len / 2, len - 1];
+                for position in positions {
+                    live[position + 1] ^= 0x80;
+                    assert!(
+                        !unsafe { trace_code_eq(live.as_ptr().add(1), expected_ptr, len) },
+                        "length {len} mismatch at byte {position}"
+                    );
+                    live[position + 1] ^= 0x80;
+                }
+            }
+        }
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -1575,7 +1575,20 @@ impl TraceJit {
                 let entry_watched = watch_pcs
                     .iter()
                     .any(|&watched| cpu.address(watched) == cpu.address(cpu.pc));
-                match self.note_trace_exit(cpu.pc, cpu_type, entry_watched) {
+                // A clean link already performed this exact slot lookup;
+                // guarded and seeded exits need it once. Keep the compiled
+                // steady state in this caller so it does not pay an outlined
+                // admission-helper call merely to return `Chain`.
+                let exit_seed = if clean_link_exit || self.compiled_head_at(cpu.pc, cpu_type) {
+                    if entry_watched {
+                        ExitSeed::None
+                    } else {
+                        ExitSeed::Chain
+                    }
+                } else {
+                    self.note_trace_exit(cpu.pc, cpu_type, entry_watched)
+                };
+                match exit_seed {
                     ExitSeed::Chain => {
                         match self.try_execute(
                             cpu,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -604,6 +604,15 @@ pub(crate) enum JitTraceOp {
         value: u32,
         dst: JitEa,
     },
+    /// `ANDI.B #imm,d8(An,Xn)` through checked fast memory. This is the
+    /// dominant unsupported trace terminal in the profiled SimCity 2000
+    /// workload. Both extension words are captured while recording; every
+    /// address and self-modification guard passes before the read-modify-
+    /// write or condition-code update commits.
+    AndImmByteMem {
+        immediate: u8,
+        dst: JitEa,
+    },
     /// CMPA.W/L through `(An)` or `d16(An)`. Unlike ordinary CMP, the
     /// destination is always the full address register and a word source is
     /// sign-extended before the 32-bit comparison.
@@ -2928,6 +2937,7 @@ impl TraceJit {
                     JitTraceOp::AluMemToReg { .. }
                         | JitTraceOp::CmpiWordMem { .. }
                         | JitTraceOp::CmpiByteAbs { .. }
+                        | JitTraceOp::AndImmByteMem { .. }
                         | JitTraceOp::AddrCmpMemToReg { .. }
                         | JitTraceOp::AddaMemToReg { .. }
                 )
@@ -2964,6 +2974,7 @@ impl TraceJit {
                     | JitTraceOp::TstMem { .. }
                     | JitTraceOp::ClrMem { .. }
                     | JitTraceOp::MoveImmMem { .. }
+                    | JitTraceOp::AndImmByteMem { .. }
                     | JitTraceOp::AddrCmpMemToReg { .. }
                     | JitTraceOp::AddaMemToReg { .. }
                     | JitTraceOp::AddRegToMem { .. }
@@ -3369,6 +3380,12 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("MoveImmMem implies a window env");
                         emit_move_imm_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
+                    JitTraceOp::AndImmByteMem { .. } => {
+                        let env = mem_env
+                            .as_ref()
+                            .expect("AndImmByteMem implies a window env");
+                        emit_and_imm_byte_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
                     JitTraceOp::AddrCmpMemToReg { .. } => {
                         let env = mem_env
                             .as_ref()
@@ -3761,6 +3778,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::ClrMem { .. }
             | JitTraceOp::MoveImmReg { .. }
             | JitTraceOp::MoveImmMem { .. }
+            | JitTraceOp::AndImmByteMem { .. }
             | JitTraceOp::CallThrough { .. }
             | JitTraceOp::CallExit { .. }
             | JitTraceOp::RtsReturn { .. }
@@ -4221,6 +4239,9 @@ impl JitTraceOp {
                 (_, JitEa::Disp(_, _)) => 16,
                 _ => 12,
             },
+            // M68000 immediate ALU to memory: twelve-cycle byte/word base
+            // plus the ten-cycle brief-indexed destination read/EA cost.
+            Self::AndImmByteMem { .. } => 22,
             Self::AddrCmpMemToReg { .. } => 24,
             // MC68000 ADDA: word base 8, long-memory base 6, plus the
             // source EA fetch (4/8 for (An), 8/12 for d16(An)). Memory
@@ -4336,6 +4357,7 @@ fn is_if_convertible_block_op(op: &JitTraceOp) -> bool {
             | JitTraceOp::TstMem { .. }
             | JitTraceOp::ClrMem { .. }
             | JitTraceOp::MoveImmMem { .. }
+            | JitTraceOp::AndImmByteMem { .. }
             | JitTraceOp::AddrCmpMemToReg { .. }
             | JitTraceOp::AddRegToMem { .. }
             | JitTraceOp::MemAddqSubq { .. }
@@ -4391,6 +4413,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_binary_immediate_data_reg_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_andi_byte_index_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_bit_imm_reg_trace_op(cpu, bus, pc, opcode) {
@@ -5397,6 +5422,39 @@ fn decode_move_imm_mem_trace_op<B: AddressBus>(
     })
 }
 
+/// Decode the measured `ANDI.B #imm,d8(An,Xn)` trace blocker. Keeping the
+/// admission deliberately byte/index-only matches the profiled form and
+/// avoids growing the native emitter for unmeasured sizes or destinations.
+fn decode_andi_byte_index_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let DecodedMemOp::AluImm {
+        op: BinaryOp::And,
+        size: Size::Byte,
+        dst: FastEa::AnIndex(base),
+    } = DecodedMemOp::decode(cpu_type, opcode)?
+    else {
+        return None;
+    };
+    let immediate_word = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+    let brief = bus.try_read_word(cpu.address(pc.wrapping_add(4))).ok()?;
+    let dst = decode_jit_ea(6, u16::from(base), brief, cpu_type)?;
+    Some(TraceBuildOp {
+        opcode,
+        extension: Some(immediate_word),
+        extension2: Some(brief),
+        pc,
+        op: JitTraceOp::AndImmByteMem {
+            immediate: immediate_word as u8,
+            dst,
+        },
+    })
+}
+
 fn decode_move_mem_trace_op<B: AddressBus>(
     cpu: &CpuCore,
     bus: &mut B,
@@ -5983,6 +6041,9 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     }
     if matches!(op.op, JitTraceOp::MoveImmMem { .. }) {
         return execute_portable_move_imm_mem(cpu, op, spans);
+    }
+    if matches!(op.op, JitTraceOp::AndImmByteMem { .. }) {
+        return execute_portable_and_imm_byte_mem(cpu, op, spans);
     }
     if matches!(op.op, JitTraceOp::AddrCmpMemToReg { .. }) {
         return execute_portable_addr_cmp_mem_to_reg(cpu, op);
@@ -6647,6 +6708,53 @@ fn execute_portable_move_imm_mem(
     }
     write(cpu, off, value);
     cpu.set_logic_flags(value, size);
+    Some(trace.op.max_cycles())
+}
+
+#[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
+fn execute_portable_and_imm_byte_mem(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    spans: CodeSpans,
+) -> Option<i32> {
+    let JitTraceOp::AndImmByteMem { immediate, dst } = trace.op else {
+        return None;
+    };
+    let JitEa::Index {
+        base,
+        index,
+        index_long,
+        scale,
+        displacement,
+    } = dst
+    else {
+        return None;
+    };
+    let base_value = cpu.dar[8 + base as usize];
+    let raw_index = match index {
+        JitDirectReg::Addr(reg) => cpu.dar[8 + reg as usize],
+        JitDirectReg::Data(reg) => cpu.dar[reg as usize],
+    };
+    let index_value = if index_long {
+        raw_index
+    } else {
+        raw_index as u16 as i16 as i32 as u32
+    };
+    let raw = base_value
+        .wrapping_add(index_value << scale)
+        .wrapping_add(displacement as i32 as u32);
+    if cpu.fm_len == 0 {
+        return None;
+    }
+    let masked = raw & cpu.address_mask;
+    let off = masked.wrapping_sub(cpu.fm_base);
+    if off >= cpu.fm_len || spans.store_hits_code(masked, 1) {
+        return None;
+    }
+    let ptr = unsafe { (cpu.fm_ptr as *mut u8).add(off as usize) };
+    let result = unsafe { *ptr } & immediate;
+    unsafe { *ptr = result };
+    cpu.set_logic_flags(u32::from(result), Size::Byte);
     Some(trace.op.max_cycles())
 }
 
@@ -7581,6 +7689,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::MoveImmMem { .. } => {
             unreachable!("MoveImmMem is handled by execute_portable_move_imm_mem")
         }
+        JitTraceOp::AndImmByteMem { .. } => {
+            unreachable!("AndImmByteMem is handled by execute_portable_and_imm_byte_mem")
+        }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is handled by execute_portable_addr_cmp_mem_to_reg")
         }
@@ -8287,6 +8398,9 @@ fn emit_jit_op(
         JitTraceOp::MoveImmMem { .. } => {
             unreachable!("MoveImmMem is emitted by emit_move_imm_mem")
         }
+        JitTraceOp::AndImmByteMem { .. } => {
+            unreachable!("AndImmByteMem is emitted by emit_and_imm_byte_mem")
+        }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is emitted by emit_addr_cmp_mem_to_reg")
         }
@@ -8925,6 +9039,63 @@ fn emit_move_imm_mem(
     let value = iconst_u32(builder, value);
     window_store(builder, env, off, size, value);
     set_logic_flags(builder, cpu, value, size);
+    cycles_const(builder, trace.op.max_cycles())
+}
+
+/// Emit `ANDI.B #imm,d8(An,Xn)`. The address passes the window and
+/// code-overlap guards before the read-modify-write and flag updates, so a
+/// bail leaves both memory and architectural state untouched.
+#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+fn emit_and_imm_byte_mem(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::AndImmByteMem { immediate, dst } = trace.op else {
+        unreachable!("expected an indexed immediate AND trace")
+    };
+    let JitEa::Index {
+        base,
+        index,
+        index_long,
+        scale,
+        displacement,
+    } = dst
+    else {
+        unreachable!("ANDI.B decoder admitted an unsupported EA")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
+    let raw_index = load_reg(builder, cpu, index);
+    let index = if index_long {
+        raw_index
+    } else {
+        let word = builder.ins().ireduce(types::I16, raw_index);
+        builder.ins().sextend(types::I32, word)
+    };
+    let index = if scale == 0 {
+        index
+    } else {
+        builder.ins().ishl_imm(index, i64::from(scale))
+    };
+    let address = builder.ins().iadd(base, index);
+    let address = builder.ins().iadd_imm(address, displacement as i64);
+    let (off, masked) = checked_window_off(builder, env, bail, address, Size::Byte);
+    guard_store_not_code(builder, env, bail, masked, Size::Byte);
+    let old = window_load(builder, env, off, Size::Byte);
+    let immediate = iconst_u32(builder, u32::from(immediate));
+    let result = builder.ins().band(old, immediate);
+    window_store(builder, env, off, Size::Byte, result);
+    set_logic_flags(builder, cpu, result, Size::Byte);
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -9836,6 +10007,9 @@ fn emit_block_op(
         }
         JitTraceOp::MoveImmMem { .. } => {
             emit_move_imm_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
+        }
+        JitTraceOp::AndImmByteMem { .. } => {
+            emit_and_imm_byte_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
         }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             emit_addr_cmp_mem_to_reg(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
@@ -15609,6 +15783,166 @@ mod portable_tests {
             !matches!(t.map(|t| t.op), Some(JitTraceOp::MoveImmMem { .. })),
             "long immediate to an indexed destination must stay decoded"
         );
+    }
+
+    #[test]
+    fn andi_byte_index_decodes_the_profiled_trace_blocker() {
+        let mut dcpu = cpu();
+        dcpu.set_cpu_type(CpuType::M68040);
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        bus.write_word(0x0100, 0x0231); // ANDI.B #imm,(d8,A1,D3.W)
+        bus.write_word(0x0102, 0x00B7);
+        bus.write_word(0x0104, 0x3000);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("profiled ANDI.B indexed form should decode");
+        assert_eq!(
+            (trace.extension, trace.extension2),
+            (Some(0x00B7), Some(0x3000))
+        );
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::AndImmByteMem {
+                immediate: 0xB7,
+                dst: JitEa::Index {
+                    base: 1,
+                    index: JitDirectReg::Data(3),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 0,
+                },
+            }
+        ));
+
+        // Full-format indexed extensions on 68020+ retain their existing
+        // fallback; the narrow trace op only handles the brief form.
+        bus.write_word(0x0104, 0x3100);
+        assert!(decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040).is_none());
+    }
+
+    #[test]
+    fn andi_byte_index_matches_the_interpreter_with_exact_68000_cycles() {
+        let words = [0x0231u16, 0x00B7, 0x3000];
+        let setup = |cpu: &mut CpuCore| {
+            cpu.set_cpu_type(CpuType::M68000);
+            cpu.set_a(1, 0x0300);
+            cpu.set_d(3, 4);
+            cpu.set_ccr(0x10); // X is unaffected by ANDI.
+            cpu.pc = 0x0100;
+        };
+
+        let mut ibus = super::super::memory::LinearMemoryBus::new(0x1000);
+        for (index, word) in words.iter().enumerate() {
+            ibus.write_word(0x0100 + index as u32 * 2, *word);
+        }
+        ibus.write_byte(0x0304, 0xF3);
+        let mut icpu = cpu();
+        setup(&mut icpu);
+        let icycles = match icpu.step(&mut ibus) {
+            super::super::types::StepResult::Ok { cycles } => cycles,
+            other => panic!("interpreter step failed: {other:?}"),
+        };
+
+        let mut pmem = vec![0u8; 0x1000];
+        for (index, word) in words.iter().enumerate() {
+            pmem[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
+        }
+        pmem[0x0304] = 0xF3;
+        let mut pcpu = cpu();
+        setup(&mut pcpu);
+        attach_window(&mut pcpu, &mut pmem);
+        let trace = decode_trace_op(&pcpu, &mut ibus, 0x0100, CpuType::M68000)
+            .expect("ANDI.B indexed form should decode");
+        let pcycles = execute_portable_op(&mut pcpu, trace, CodeSpans::caller(0x0100, 0x0106))
+            .expect("portable trace op should execute");
+
+        assert_eq!(pcycles, icycles);
+        assert_eq!(icycles, 22);
+        assert_eq!(pmem[0x0304], 0xB3);
+        assert_eq!(pmem[0x0304], ibus.read_byte(0x0304));
+        assert_eq!(pcpu.dar, icpu.dar);
+        assert_eq!(pcpu.get_ccr(), icpu.get_ccr());
+        assert_ne!(pcpu.get_ccr() & 0x10, 0, "X preserved");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_andi_byte_index_matches_portable_and_bails_on_code_overlap() {
+        let andi = TraceBuildOp {
+            opcode: 0x0231,
+            extension: Some(0x00B7),
+            extension2: Some(0x3000),
+            pc: 0x0100,
+            op: JitTraceOp::AndImmByteMem {
+                immediate: 0xB7,
+                dst: JitEa::Index {
+                    base: 1,
+                    index: JitDirectReg::Data(3),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 0,
+                },
+            },
+        };
+        let branch = TraceBuildOp {
+            opcode: 0x60F8,
+            extension: None,
+            extension2: None,
+            pc: 0x0106,
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -8,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+        let ops = vec![andi, branch];
+        let prepare = |mem: &mut Vec<u8>| {
+            let mut cpu = cpu();
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_a(1, 0x0300);
+            cpu.set_d(3, 4);
+            cpu.set_ccr(0x10);
+            mem[0x0304] = 0xF3;
+            attach_window(&mut cpu, mem);
+            cpu
+        };
+
+        let mut pmem = vec![0u8; 0x1000];
+        let mut portable = prepare(&mut pmem);
+        let expected =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(0x0100, 0x0108));
+        let mut nmem = vec![0u8; 0x1000];
+        let mut native = prepare(&mut nmem);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&native, 0x0100, CpuType::M68040, ops.clone(), Some(0x0100))
+            .expect("ANDI.B loop should compile");
+        let actual = unsafe { compiled.call_native(&mut native, 1) };
+        assert_eq!(actual, expected, "cycles/retired");
+        assert_eq!(native.dar, portable.dar);
+        assert_eq!(native.get_ccr(), portable.get_ccr());
+        assert_eq!(nmem, pmem);
+        assert_eq!(nmem[0x0304], 0xB3);
+
+        // Aim the store into its own immediate word. Both executors must
+        // bail before touching memory or flags.
+        let overlap = |mem: &mut Vec<u8>| {
+            let mut cpu = prepare(mem);
+            cpu.set_a(1, 0x0102);
+            cpu.set_d(3, 0);
+            cpu
+        };
+        let mut pbail_mem = vec![0u8; 0x1000];
+        let mut pbail = overlap(&mut pbail_mem);
+        let packed = execute_portable_trace(&mut pbail, &ops, CodeSpans::caller(0x0100, 0x0108));
+        assert_eq!(packed, 0);
+        assert_eq!(pbail.get_ccr(), 0x10);
+        let mut nbail_mem = vec![0u8; 0x1000];
+        let mut nbail = overlap(&mut nbail_mem);
+        let packed = unsafe { compiled.call_native(&mut nbail, 1) };
+        assert_eq!(packed, 0);
+        assert_eq!(nbail.get_ccr(), 0x10);
+        assert_eq!(nbail_mem, pbail_mem);
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -493,6 +493,15 @@ pub(crate) enum JitTraceOp {
         return_pc: u32,
         cycles: i32,
     },
+    /// A nested call at the recorder's one-level depth cap. Execute the
+    /// architectural push, land at the observed static callee, and end the
+    /// trace there; normal exit seeding can then compile or chain that callee
+    /// without adding work to interpreted call dispatch.
+    CallExit {
+        return_pc: u32,
+        target_pc: u32,
+        cycles: i32,
+    },
     /// The callee's RTS: pops the return address and bails unless it
     /// equals the recorded call's return -- a different return value is
     /// a different flow. Checked before the stack pointer moves.
@@ -894,6 +903,11 @@ struct CompiledTrace {
     /// iterations.
     #[cfg_attr(all(feature = "jit", not(target_family = "wasm")), allow(dead_code))]
     self_loop: bool,
+    /// A clean completion should seed candidacy at its exit (a dynamic
+    /// return continuation or a forward nested-call callee). Computed once
+    /// when the trace is built instead of decoding the last op on every
+    /// native entry.
+    seeded_exit: bool,
     /// The native body was generated as a counted loop. Short read/write
     /// MoveMem loops deliberately retain the original one-pass body: the
     /// extra loop-carried state costs more than the saved call boundary.
@@ -1329,10 +1343,7 @@ impl TraceJit {
             // head, which a fresh continuation never is, so without this
             // the continuations after a returning subroutine would only
             // ever compile by luck of a backward branch.
-            let ends_in_return_exit = trace
-                .ops
-                .last()
-                .is_some_and(|op| matches!(op.op, JitTraceOp::ReturnExit { .. }));
+            let ends_in_seeded_exit = trace.seeded_exit;
             // A generated loop clearly amortizes the ABI boundary for
             // profiled mixed 3+-op and read-only loops. A
             // two-op read/write MoveMem loop is already dominated by its two
@@ -1544,12 +1555,12 @@ impl TraceJit {
             if clean_link_exit {
                 super::trace_profile::note_link_exit(pc, cpu_type);
             }
-            // A clean ReturnExit completion seeds its dynamic target
-            // (each caller's continuation) even when nothing is compiled
-            // there yet; see `ends_in_return_exit` above.
-            let return_exit_completion =
-                ends_in_return_exit && !guarded_branch_exit && !partial_call_this_entry;
-            if (guarded_branch_exit || clean_link_exit || return_exit_completion)
+            // A clean ReturnExit completion seeds its dynamic continuation;
+            // a CallExit similarly seeds the static nested callee that the
+            // recorder could not include at its one-level depth cap.
+            let seeded_exit_completion =
+                ends_in_seeded_exit && !guarded_branch_exit && !partial_call_this_entry;
+            if (guarded_branch_exit || clean_link_exit || seeded_exit_completion)
                 && !single_iter
                 && chain_budget > 0
                 && cpu.pc != pc
@@ -2494,9 +2505,24 @@ impl TraceJit {
                 JitTraceOp::CallThrough { return_pc, .. } => {
                     let recording = self.recording.as_mut().unwrap();
                     if recording.pending_return.is_some() {
-                        // Depth cap: a nested call ends the region at the
-                        // outer callee's boundary.
-                        self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        // A forward nested call has no backward edge to seed
+                        // its callee independently. Make the call itself the
+                        // trace terminal so the normal compiled-exit path can
+                        // seed and eventually chain the callee. Backward
+                        // callees keep the existing edge-admission behavior.
+                        if next_pc > executed_pc {
+                            recording.ops.push(TraceBuildOp {
+                                op: JitTraceOp::CallExit {
+                                    return_pc,
+                                    target_pc: next_pc,
+                                    cycles: call_op.op.max_cycles(),
+                                },
+                                ..call_op
+                            });
+                            self.finish_recording(cpu, next_pc, RecordingEnd::Region);
+                        } else {
+                            self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        }
                         return;
                     }
                     // The caller's recorded bytes and the callee's each get
@@ -2851,7 +2877,9 @@ impl TraceJit {
         let ends_in_dynamic_exit = ops.last().is_some_and(|op| {
             matches!(
                 op.op,
-                JitTraceOp::IndirectJsr { .. } | JitTraceOp::ReturnExit { .. }
+                JitTraceOp::IndirectJsr { .. }
+                    | JitTraceOp::ReturnExit { .. }
+                    | JitTraceOp::CallExit { .. }
             )
         });
         if ends_in_dynamic_exit && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS {
@@ -2929,6 +2957,7 @@ impl TraceJit {
                     | JitTraceOp::AnDispBit { .. }
                     | JitTraceOp::IndirectJsr { .. }
                     | JitTraceOp::CallThrough { .. }
+                    | JitTraceOp::CallExit { .. }
                     | JitTraceOp::RtsReturn { .. }
                     | JitTraceOp::ReturnExit { .. }
             )
@@ -3370,7 +3399,7 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("Unlk implies a window env");
                         emit_unlk(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
-                    JitTraceOp::CallThrough { .. } => {
+                    JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
                         let env = mem_env.as_ref().expect("CallThrough implies a window env");
                         emit_call_through(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
@@ -3494,6 +3523,12 @@ impl TraceJit {
         };
 
         let guarded_ops = guarded_op_mask(ops);
+        let seeded_exit = ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: start_pc,
             cpu_type,
@@ -3502,6 +3537,7 @@ impl TraceJit {
             code_segments,
             max_cycles,
             self_loop,
+            seeded_exit,
             native_loop,
             callee_start,
             callee_end,
@@ -3520,6 +3556,12 @@ impl TraceJit {
     #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
     fn compile_ops(&mut self, params: CompileParams<'_>) -> Option<CompiledTrace> {
         let guarded_ops = guarded_op_mask(params.ops);
+        let seeded_exit = params.ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: params.start_pc,
             cpu_type: params.cpu_type,
@@ -3530,6 +3572,7 @@ impl TraceJit {
             code_segments: params.code_segments,
             max_cycles: params.max_cycles,
             self_loop: params.self_loop,
+            seeded_exit,
             needs_window: params.needs_window,
             code_start: params.code_start,
             code_end: params.code_end,
@@ -3684,6 +3727,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::MoveImmReg { .. }
             | JitTraceOp::MoveImmMem { .. }
             | JitTraceOp::CallThrough { .. }
+            | JitTraceOp::CallExit { .. }
             | JitTraceOp::RtsReturn { .. }
             | JitTraceOp::ReturnExit { .. } => return false,
         }
@@ -4174,7 +4218,7 @@ impl JitTraceOp {
             Self::Unlk { .. } => 12,
             // MC68000 BSR is 18(2/2) for every displacement width; RTS is
             // 16(4/0).
-            Self::CallThrough { cycles, .. } => cycles,
+            Self::CallThrough { cycles, .. } | Self::CallExit { cycles, .. } => cycles,
             Self::RtsReturn { .. } => 16,
             Self::ReturnExit { cycles, .. } => cycles,
         }
@@ -4186,6 +4230,7 @@ impl JitTraceOp {
             Self::Branch { .. }
                 | Self::Dbcc { .. }
                 | Self::IndirectJsr { .. }
+                | Self::CallExit { .. }
                 | Self::PcIndexJmp {
                     expected_target: Some(_),
                     ..
@@ -5865,7 +5910,10 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     if matches!(op.op, JitTraceOp::Unlk { .. }) {
         return execute_portable_unlk(cpu, op);
     }
-    if matches!(op.op, JitTraceOp::CallThrough { .. }) {
+    if matches!(
+        op.op,
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. }
+    ) {
         return execute_portable_call_through(cpu, op, spans);
     }
     if matches!(op.op, JitTraceOp::RtsReturn { .. }) {
@@ -7427,7 +7475,7 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::Link { .. } | JitTraceOp::Unlk { .. } => {
             unreachable!("LINK/UNLK are handled by execute_portable_link/unlk")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is handled by execute_portable_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -8133,7 +8181,7 @@ fn emit_jit_op(
         JitTraceOp::PeaInd { .. } | JitTraceOp::PeaDisp { .. } | JitTraceOp::PeaAbs { .. } => {
             unreachable!("PEA is emitted by emit_pea_disp")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is emitted by emit_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -9098,8 +9146,14 @@ fn emit_call_through(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        unreachable!("expected a call-through trace op")
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => unreachable!("expected a call-through or call-exit trace op"),
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -9114,6 +9168,10 @@ fn emit_call_through(
     let value = iconst_u32(builder, return_pc);
     window_store(builder, env, off, Size::Long, value);
     store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
+    if let Some(target_pc) = exit_target {
+        store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
+        store_u32(builder, cpu, offset_of!(CpuCore, pc), target_pc);
+    }
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -9195,8 +9253,14 @@ fn execute_portable_call_through(
     trace: TraceBuildOp,
     spans: CodeSpans,
 ) -> Option<i32> {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        return None;
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => return None,
     };
     if cpu.fm_len == 0 {
         return None;
@@ -9222,6 +9286,10 @@ fn execute_portable_call_through(
         *p.add(3) = b[3];
     }
     cpu.dar[15] = new_sp;
+    if let Some(target_pc) = exit_target {
+        cpu.change_of_flow = true;
+        cpu.pc = target_pc;
+    }
     Some(trace.op.max_cycles())
 }
 
@@ -17094,6 +17162,128 @@ mod portable_tests {
             },
         });
         ops
+    }
+
+    #[test]
+    fn forward_nested_call_becomes_an_executing_seeded_exit() {
+        const HEAD: u32 = 0x0100;
+        const CALL_PC: u32 = 0x010C;
+        const TARGET: u32 = 0x0180;
+        const RETURN: u32 = 0x010E;
+
+        let mut prefix = rts_region_ops(TRACE_MIN_INDIRECT_JSR_OPS);
+        prefix.pop();
+        let mut recording_cpu = cpu();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        // BSR.S +0x72: base is RETURN, destination is TARGET.
+        bus.write_word(CALL_PC, 0x6172);
+        recording_cpu.ir = 0x6172;
+        recording_cpu.pc = TARGET;
+        recording_cpu.trace_recording = true;
+
+        let mut jit = TraceJit::new();
+        // This test is about the depth-cap terminal, not first-pass linear
+        // admission, so treat the shape as already deferred once.
+        jit.defer_linear_compilation(HEAD);
+        jit.recording = Some(TraceRecording {
+            start_pc: HEAD,
+            cpu_type: CpuType::M68000,
+            ops: prefix,
+            adaptive_rerecords: 0,
+            allow_call_through: true,
+            pending_return: Some(0x0200),
+            skip_record_until: None,
+            from_exit_seed: false,
+        });
+        jit.record_executed(&mut recording_cpu, &mut bus, CALL_PC, TARGET);
+
+        let TraceSlot::Compiled(trace) = &jit.slots[trace_cache_index(HEAD)] else {
+            panic!("the forward nested-call region should compile");
+        };
+        assert!(matches!(
+            trace.ops.last().unwrap().op,
+            JitTraceOp::CallExit {
+                return_pc: RETURN,
+                target_pc: TARGET,
+                cycles: 18,
+            }
+        ));
+        assert!(trace.seeded_exit);
+        assert_eq!(
+            (trace.code_start, trace.code_end),
+            (HEAD, RETURN),
+            "the terminal call bytes belong to the caller snapshot"
+        );
+        assert_eq!(
+            (trace.callee_start, trace.callee_end),
+            (0, 0),
+            "CallExit does not pretend the separately compiled callee is inline"
+        );
+        let ops = trace.ops.clone();
+
+        let mut portable_memory = vec![0u8; 0x1000];
+        let mut portable = cpu();
+        attach_window(&mut portable, &mut portable_memory);
+        portable.set_a(7, 0x0800);
+        portable.change_of_flow = false;
+        let portable_packed =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!(
+            (portable_packed >> 32) as u32,
+            TRACE_MIN_INDIRECT_JSR_OPS as u32
+        );
+        assert_eq!(portable_packed as u32 as i32, 42); // six MOVEQs + BSR
+        assert_eq!(portable.a(7), 0x07FC);
+        assert_eq!(&portable_memory[0x07FC..0x0800], &RETURN.to_be_bytes());
+        assert_eq!(portable.pc, TARGET);
+        assert!(portable.change_of_flow);
+
+        // The push is a checked operation. If its address is outside the
+        // active window, the prefix remains committed but the call itself
+        // must not change SP, PC, flow state, or memory; full dispatch will
+        // retry it at CALL_PC.
+        let prepare_bail = |memory: &mut Vec<u8>| {
+            let mut bail = cpu();
+            attach_window(&mut bail, memory);
+            bail.set_a(7, 2);
+            bail.pc = HEAD;
+            bail.change_of_flow = false;
+            bail
+        };
+        let mut portable_bail_memory = vec![0u8; 0x1000];
+        let mut portable_bail = prepare_bail(&mut portable_bail_memory);
+        let portable_bail_packed =
+            execute_portable_trace(&mut portable_bail, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!((portable_bail_packed >> 32) as u32, ops.len() as u32 - 1);
+        assert_eq!(portable_bail_packed as u32 as i32, 24); // six MOVEQs only
+        assert_eq!(portable_bail.a(7), 2);
+        assert_eq!(portable_bail.pc, CALL_PC);
+        assert!(!portable_bail.change_of_flow);
+        assert!(portable_bail_memory.iter().all(|&byte| byte == 0));
+
+        #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+        {
+            let mut native_memory = vec![0u8; 0x1000];
+            let mut native = cpu();
+            attach_window(&mut native, &mut native_memory);
+            native.set_a(7, 0x0800);
+            native.change_of_flow = false;
+            let native_packed = unsafe { trace.call_native(&mut native, 1) };
+            assert_eq!(native_packed, portable_packed);
+            assert_eq!(native.dar, portable.dar);
+            assert_eq!(native.pc, portable.pc);
+            assert_eq!(native.change_of_flow, portable.change_of_flow);
+            assert_eq!(native_memory, portable_memory);
+
+            let mut native_bail_memory = vec![0u8; 0x1000];
+            let mut native_bail = prepare_bail(&mut native_bail_memory);
+            let native_bail_packed = unsafe { trace.call_native(&mut native_bail, 1) };
+            assert_eq!(native_bail_packed, portable_bail_packed);
+            assert_eq!(native_bail.dar, portable_bail.dar);
+            assert_eq!(native_bail.pc, portable_bail.pc);
+            assert_eq!(native_bail.change_of_flow, portable_bail.change_of_flow);
+            assert_eq!(native_bail_memory, portable_bail_memory);
+        }
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -480,11 +480,11 @@ pub(crate) enum JitTraceOp {
         reg: u8,
         displacement: i16,
     },
-    /// Terminal `JSR (An)`. The target is dynamic, and the return address
-    /// store is checked against the active fastmem window before any CPU
-    /// state is committed.
+    /// Terminal `JSR (An)` / `JSR d16(An)`. The target is dynamic, and the
+    /// return-address store is checked against the active fastmem window
+    /// before any CPU state is committed.
     IndirectJsr {
-        reg: u8,
+        target: JitEa,
     },
     /// A BSR recorded THROUGH: pushes the constant return address and
     /// falls through to the callee's ops, which follow inline in the
@@ -3377,9 +3377,17 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("AddRegToMem implies a window env");
                         emit_add_reg_to_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
-                    JitTraceOp::IndirectJsr { reg } => {
+                    JitTraceOp::IndirectJsr { target } => {
                         let env = mem_env.as_ref().expect("IndirectJsr implies a window env");
-                        emit_indirect_jsr(&mut builder, cpu_ptr, *op, reg, env, &mut bails, bail_at)
+                        emit_indirect_jsr(
+                            &mut builder,
+                            cpu_ptr,
+                            *op,
+                            target,
+                            env,
+                            &mut bails,
+                            bail_at,
+                        )
                     }
                     JitTraceOp::MemAddqSubq { .. } => {
                         let env = mem_env.as_ref().expect("MemAddqSubq implies a window env");
@@ -4216,7 +4224,15 @@ impl JitTraceOp {
                 (_, JitEa::Disp(_, _)) => 16,
                 _ => 12,
             },
-            Self::IndirectJsr { .. } => 16,
+            Self::IndirectJsr {
+                target: JitEa::Ind(_),
+            } => 16,
+            // JSR d16(An) adds the displacement-extension fetch to the
+            // M68000's 16-cycle JSR (An) bound.
+            Self::IndirectJsr {
+                target: JitEa::Disp(_, _),
+            } => 18,
+            Self::IndirectJsr { .. } => unreachable!("JSR decoder admitted unsupported EA"),
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::MemAddqSubq { .. } | Self::AnDispUnary { .. } | Self::AnDispBit { .. } => 24,
@@ -4347,7 +4363,7 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_branch_word_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
-    if let Some(op) = decode_indirect_jsr_trace_op(pc, opcode) {
+    if let Some(op) = decode_indirect_jsr_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
     if let Some(op) = decode_return_exit_trace_op(cpu, bus, pc, opcode, cpu_type) {
@@ -4768,18 +4784,29 @@ fn decode_movem_word_postinc_trace_op<B: AddressBus>(
     })
 }
 
-fn decode_indirect_jsr_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
-    if (opcode & 0xFFF8) != 0x4E90 {
-        return None;
-    }
+fn decode_indirect_jsr_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+) -> Option<TraceBuildOp> {
+    let (extension, target) = match opcode & 0xFFF8 {
+        0x4E90 => (None, JitEa::Ind((opcode & 7) as u8)),
+        0x4EA8 => {
+            let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (
+                Some(extension),
+                JitEa::Disp((opcode & 7) as u8, extension as i16),
+            )
+        }
+        _ => return None,
+    };
     Some(TraceBuildOp {
         opcode,
-        extension: None,
+        extension,
         extension2: None,
         pc,
-        op: JitTraceOp::IndirectJsr {
-            reg: (opcode & 7) as u8,
-        },
+        op: JitTraceOp::IndirectJsr { target },
     })
 }
 
@@ -5947,8 +5974,8 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     ) {
         return execute_portable_an_disp(cpu, op, spans);
     }
-    if let JitTraceOp::IndirectJsr { reg } = op.op {
-        return execute_portable_indirect_jsr(cpu, op, reg);
+    if let JitTraceOp::IndirectJsr { target } = op.op {
+        return execute_portable_indirect_jsr(cpu, op, target);
     }
     Some(execute_portable_reg_op(cpu, op))
 }
@@ -6074,15 +6101,19 @@ fn execute_portable_movem_long_postinc(cpu: &mut CpuCore, trace: TraceBuildOp) -
 }
 
 #[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
-fn execute_portable_indirect_jsr(cpu: &mut CpuCore, trace: TraceBuildOp, reg: u8) -> Option<i32> {
+fn execute_portable_indirect_jsr(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    target: JitEa,
+) -> Option<i32> {
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
-    if super::mem_ops::execute_mem_op(
-        cpu,
-        DecodedMemOp::Jsr {
-            ea: FastEa::AnInd(reg),
-        },
-    ) {
+    let ea = match target {
+        JitEa::Ind(reg) => FastEa::AnInd(reg),
+        JitEa::Disp(reg, _) => FastEa::AnDisp(reg),
+        _ => unreachable!("JSR decoder admitted unsupported EA"),
+    };
+    if super::mem_ops::execute_mem_op(cpu, DecodedMemOp::Jsr { ea }) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -9112,16 +9143,17 @@ fn emit_add_reg_to_mem(
     cycles_const(builder, trace.op.max_cycles())
 }
 
-/// Emit terminal `JSR (An)`. The stack write is checked before the stack
-/// pointer, flow state, or PC changes, so a miss can re-execute the call via
-/// full dispatch. A successful call ends this non-self-loop trace; writing
-/// into its code is therefore safe because any later entry revalidates it.
+/// Emit terminal `JSR (An)` / `JSR d16(An)`. The stack write is checked before
+/// the stack pointer, flow state, or PC changes, so a miss can re-execute the
+/// call via full dispatch. A successful call ends this non-self-loop trace;
+/// writing into its code is therefore safe because any later entry revalidates
+/// it.
 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
 fn emit_indirect_jsr(
     builder: &mut FunctionBuilder<'_>,
     cpu: Value,
     trace: TraceBuildOp,
-    reg: u8,
+    target: JitEa,
     env: &MemEnv,
     bails: &mut Vec<BailReq>,
     at: BailAt,
@@ -9133,11 +9165,18 @@ fn emit_indirect_jsr(
         at,
     });
 
-    let target = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+    let target = match target {
+        JitEa::Ind(reg) => load_reg(builder, cpu, JitDirectReg::Addr(reg)),
+        JitEa::Disp(reg, displacement) => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+            builder.ins().iadd_imm(base, i64::from(displacement))
+        }
+        _ => unreachable!("JSR decoder admitted unsupported EA"),
+    };
     let old_sp = load_reg(builder, cpu, JitDirectReg::Addr(7));
     let new_sp = builder.ins().iadd_imm(old_sp, -4);
     let (off, _) = checked_window_off(builder, env, bail, new_sp, Size::Long);
-    let return_pc = iconst_u32(builder, trace.pc.wrapping_add(2));
+    let return_pc = iconst_u32(builder, trace.pc.wrapping_add(trace.length() as u32));
     window_store(builder, env, off, Size::Long, return_pc);
 
     store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
@@ -11871,8 +11910,26 @@ mod portable_tests {
         let jsr = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
         assert_eq!(jsr.extension, None);
         assert_eq!(jsr.length(), 2);
-        assert!(matches!(jsr.op, JitTraceOp::IndirectJsr { reg: 0 }));
+        assert!(matches!(
+            jsr.op,
+            JitTraceOp::IndirectJsr {
+                target: JitEa::Ind(0)
+            }
+        ));
         assert!(jsr.op.ends_trace());
+
+        mem.write_word(0x0100, 0x4EAD); // JSR -$0010(A5)
+        mem.write_word(0x0102, 0xFFF0);
+        let jsr = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jsr.extension, Some(0xFFF0));
+        assert_eq!(jsr.length(), 4);
+        assert_eq!(jsr.op.max_cycles(), 18);
+        assert!(matches!(
+            jsr.op,
+            JitTraceOp::IndirectJsr {
+                target: JitEa::Disp(5, -16)
+            }
+        ));
     }
 
     #[test]
@@ -11889,7 +11946,9 @@ mod portable_tests {
             extension: None,
             extension2: None,
             pc: 0x0100,
-            op: JitTraceOp::IndirectJsr { reg: 0 },
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Ind(0),
+            },
         };
         assert_eq!(
             execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0102)),
@@ -11897,6 +11956,35 @@ mod portable_tests {
         );
         assert_eq!(cpu.a(7), 0x07FC);
         assert_eq!(&mem[0x07FC..0x0800], &0x0102u32.to_be_bytes());
+        assert_eq!(cpu.pc, 0x0340);
+        assert!(cpu.change_of_flow);
+    }
+
+    #[test]
+    fn portable_displacement_jsr_uses_extension_extent_and_live_base() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0xFFF0u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0350);
+        cpu.set_a(7, 0x0800);
+        cpu.change_of_flow = false;
+
+        let op = TraceBuildOp {
+            opcode: 0x4EAD,
+            extension: Some(0xFFF0),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Disp(5, -16),
+            },
+        };
+        assert_eq!(
+            execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0104)),
+            Some(18)
+        );
+        assert_eq!(cpu.a(7), 0x07FC);
+        assert_eq!(&mem[0x07FC..0x0800], &0x0104u32.to_be_bytes());
         assert_eq!(cpu.pc, 0x0340);
         assert!(cpu.change_of_flow);
     }
@@ -11916,7 +12004,9 @@ mod portable_tests {
             extension: None,
             extension2: None,
             pc: 0x0100,
-            op: JitTraceOp::IndirectJsr { reg: 0 },
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Ind(0),
+            },
         };
         assert_eq!(
             execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0102)),
@@ -17015,7 +17105,9 @@ mod portable_tests {
                 extension: None,
                 extension2: None,
                 pc: 0x0100 + (count - 1) as u32 * 2,
-                op: JitTraceOp::IndirectJsr { reg: 0 },
+                op: JitTraceOp::IndirectJsr {
+                    target: JitEa::Ind(0),
+                },
             });
             ops
         };
@@ -17102,7 +17194,9 @@ mod portable_tests {
                 extension: None,
                 extension2: None,
                 pc: 0x010E,
-                op: JitTraceOp::IndirectJsr { reg: 0 },
+                op: JitTraceOp::IndirectJsr {
+                    target: JitEa::Ind(0),
+                },
             },
         ];
         let mut compile_cpu = cpu();
@@ -17147,6 +17241,72 @@ mod portable_tests {
         assert_eq!(bail.d(7), 0xA5A5_8000, "prefix remains committed");
         assert_eq!(bail.a(7), 2, "call itself did not commit");
         assert_eq!(bail.pc, 0x010E, "retry the unexecuted call");
+        assert!(!bail.change_of_flow);
+        assert!(bail_mem[0x07FC..0x0800].iter().all(|&byte| byte == 0));
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_displacement_jsr_uses_live_base_and_captured_displacement() {
+        let mut ops = Vec::new();
+        for index in 0..TRACE_MIN_INDIRECT_JSR_OPS - 1 {
+            ops.push(TraceBuildOp {
+                opcode: 0x7001,
+                extension: None,
+                extension2: None,
+                pc: 0x0100 + index as u32 * 2,
+                op: JitTraceOp::Moveq { reg: 0, data: 1 },
+            });
+        }
+        let call_pc = 0x0100 + (TRACE_MIN_INDIRECT_JSR_OPS as u32 - 1) * 2;
+        ops.push(TraceBuildOp {
+            opcode: 0x4EAD,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: call_pc,
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Disp(5, 0x0010),
+            },
+        });
+
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&cpu(), 0x0100, CpuType::M68000, ops, Some(0x0350))
+            .expect("displacement JSR region should compile");
+
+        let prepare = |stack: u32| {
+            let mut cpu = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            attach_window(&mut cpu, &mut mem);
+            cpu.set_a(5, 0x0340);
+            cpu.set_a(7, stack);
+            cpu.change_of_flow = false;
+            (cpu, mem)
+        };
+
+        let (mut success, success_mem) = prepare(0x0800);
+        let packed = unsafe { compiled.call_native(&mut success, 1) };
+        assert_eq!((packed >> 32) as u32, TRACE_MIN_INDIRECT_JSR_OPS as u32);
+        assert_eq!(packed as u32 as i32, 42);
+        assert_eq!(success.a(7), 0x07FC);
+        assert_eq!(
+            &success_mem[0x07FC..0x0800],
+            &call_pc.wrapping_add(4).to_be_bytes()
+        );
+        assert_eq!(success.pc, 0x0350);
+        assert_eq!(success.ppc, call_pc);
+        assert_eq!(success.ir, 0x4EAD);
+        assert!(success.change_of_flow);
+
+        let (mut bail, bail_mem) = prepare(2);
+        let packed = unsafe { compiled.call_native(&mut bail, 1) };
+        assert_eq!(
+            (packed >> 32) as u32,
+            (TRACE_MIN_INDIRECT_JSR_OPS - 1) as u32
+        );
+        assert_eq!(packed as u32 as i32, 24);
+        assert_eq!(bail.a(7), 2);
+        assert_eq!(bail.pc, call_pc);
         assert!(!bail.change_of_flow);
         assert!(bail_mem[0x07FC..0x0800].iter().all(|&byte| byte == 0));
     }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -577,6 +577,13 @@ pub(crate) enum JitTraceOp {
         immediate: u16,
         src: JitEa,
     },
+    /// Read-only `CMPI.B #imm,abs.W`, the hot absolute-byte table sentinel
+    /// used by SC2K. The immediate and sign-extended absolute address are
+    /// captured while recording; execution performs one checked byte load.
+    CmpiByteAbs {
+        immediate: u8,
+        address: u32,
+    },
     /// Read-only TST through a checked fast-memory effective address.
     TstMem {
         size: Size,
@@ -2920,6 +2927,7 @@ impl TraceJit {
                     op.op,
                     JitTraceOp::AluMemToReg { .. }
                         | JitTraceOp::CmpiWordMem { .. }
+                        | JitTraceOp::CmpiByteAbs { .. }
                         | JitTraceOp::AddrCmpMemToReg { .. }
                         | JitTraceOp::AddaMemToReg { .. }
                 )
@@ -2952,6 +2960,7 @@ impl TraceJit {
                     | JitTraceOp::MovemWordPostInc { .. }
                     | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::CmpiWordMem { .. }
+                    | JitTraceOp::CmpiByteAbs { .. }
                     | JitTraceOp::TstMem { .. }
                     | JitTraceOp::ClrMem { .. }
                     | JitTraceOp::MoveImmMem { .. }
@@ -3344,6 +3353,10 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("CmpiWordMem implies a window env");
                         emit_cmpi_word_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
+                    JitTraceOp::CmpiByteAbs { .. } => {
+                        let env = mem_env.as_ref().expect("CmpiByteAbs implies a window env");
+                        emit_cmpi_byte_abs(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
                     JitTraceOp::TstMem { .. } => {
                         let env = mem_env.as_ref().expect("TstMem implies a window env");
                         emit_tst_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
@@ -3686,6 +3699,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             // polled value is the only input that can change.
             JitTraceOp::TstMem { .. }
             | JitTraceOp::CmpiWordMem { .. }
+            | JitTraceOp::CmpiByteAbs { .. }
             | JitTraceOp::AddrCmpMemToReg { .. }
             | JitTraceOp::AluMemToReg {
                 op: JitBinaryOp::Cmp,
@@ -4171,6 +4185,9 @@ impl JitTraceOp {
                 ..
             } => 18,
             Self::CmpiWordMem { .. } => 16,
+            // CMPI.B #imm,abs.W has the same eight-cycle immediate base and
+            // eight-cycle absolute-word effective-address read.
+            Self::CmpiByteAbs { .. } => 16,
             // TST is a four-cycle operation plus the indexed EA read
             // (M68000UM); byte and word reads have the same EA cost.
             Self::TstMem { size, src } => match (size, src) {
@@ -4315,6 +4332,7 @@ fn is_if_convertible_block_op(op: &JitTraceOp) -> bool {
             | JitTraceOp::MoveMem { .. }
             | JitTraceOp::AluMemToReg { .. }
             | JitTraceOp::CmpiWordMem { .. }
+            | JitTraceOp::CmpiByteAbs { .. }
             | JitTraceOp::TstMem { .. }
             | JitTraceOp::ClrMem { .. }
             | JitTraceOp::MoveImmMem { .. }
@@ -4382,6 +4400,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_cmpi_word_mem_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_cmpi_byte_abs_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_addr_cmp_immediate_trace_op(cpu, bus, pc, opcode, cpu_type) {
@@ -4707,6 +4728,40 @@ fn decode_cmpi_word_mem_trace_op<B: AddressBus>(
         extension2: Some(ea_extension),
         pc,
         op: JitTraceOp::CmpiWordMem { immediate, src },
+    })
+}
+
+/// Decode only the profiled absolute-word byte form. Keeping it distinct from
+/// `CmpiWordMem` leaves the representation and generated code of existing hot
+/// indexed word compares unchanged in other workloads.
+fn decode_cmpi_byte_abs_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    if !matches!(
+        DecodedMemOp::decode(cpu_type, opcode)?,
+        DecodedMemOp::AluImm {
+            op: BinaryOp::Cmp,
+            size: Size::Byte,
+            dst: FastEa::AbsW,
+        }
+    ) {
+        return None;
+    }
+    let immediate_word = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+    let address_word = bus.try_read_word(cpu.address(pc.wrapping_add(4))).ok()?;
+    Some(TraceBuildOp {
+        opcode,
+        extension: Some(immediate_word),
+        extension2: Some(address_word),
+        pc,
+        op: JitTraceOp::CmpiByteAbs {
+            immediate: immediate_word as u8,
+            address: address_word as i16 as i32 as u32,
+        },
     })
 }
 
@@ -5917,6 +5972,9 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     if matches!(op.op, JitTraceOp::CmpiWordMem { .. }) {
         return execute_portable_cmpi_word_mem(cpu, op);
     }
+    if matches!(op.op, JitTraceOp::CmpiByteAbs { .. }) {
+        return execute_portable_cmpi_byte_abs(cpu, op);
+    }
     if matches!(op.op, JitTraceOp::TstMem { .. }) {
         return execute_portable_tst_mem(cpu, op);
     }
@@ -6380,6 +6438,28 @@ fn execute_portable_cmpi_word_mem(cpu: &mut CpuCore, trace: TraceBuildOp) -> Opt
             op: BinaryOp::Cmp,
             size: Size::Word,
             dst,
+        },
+    ) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
+#[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
+fn execute_portable_cmpi_byte_abs(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
+    if !matches!(trace.op, JitTraceOp::CmpiByteAbs { .. }) {
+        return None;
+    }
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::AluImm {
+            op: BinaryOp::Cmp,
+            size: Size::Byte,
+            dst: FastEa::AbsW,
         },
     ) {
         Some(trace.op.max_cycles())
@@ -7489,6 +7569,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::CmpiWordMem { .. } => {
             unreachable!("CmpiWordMem is handled by execute_portable_cmpi_word_mem")
         }
+        JitTraceOp::CmpiByteAbs { .. } => {
+            unreachable!("CmpiByteAbs is handled by execute_portable_cmpi_byte_abs")
+        }
         JitTraceOp::TstMem { .. } => {
             unreachable!("TstMem is handled by execute_portable_tst_mem")
         }
@@ -8191,6 +8274,9 @@ fn emit_jit_op(
         }
         JitTraceOp::CmpiWordMem { .. } => {
             unreachable!("CmpiWordMem is emitted by emit_cmpi_word_mem")
+        }
+        JitTraceOp::CmpiByteAbs { .. } => {
+            unreachable!("CmpiByteAbs is emitted by emit_cmpi_byte_abs")
         }
         JitTraceOp::TstMem { .. } => {
             unreachable!("TstMem is emitted by emit_tst_mem")
@@ -8989,6 +9075,37 @@ fn emit_cmpi_word_mem(
     cycles_const(builder, trace.op.max_cycles())
 }
 
+/// Emit the profiled absolute-word CMPI.B as one checked byte load and flag
+/// update. The address and immediate are constants captured in validated trace
+/// code; a window miss reaches the side exit before any flags change.
+#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+fn emit_cmpi_byte_abs(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::CmpiByteAbs { immediate, address } = trace.op else {
+        unreachable!("expected an absolute-byte CMPI trace")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let address = iconst_u32(builder, address);
+    let (off, _) = checked_window_off(builder, env, bail, address, Size::Byte);
+    let dst_value = window_load(builder, env, off, Size::Byte);
+    let immediate = iconst_u32(builder, u32::from(immediate));
+    let result = builder.ins().isub(dst_value, immediate);
+    set_cmp_flags(builder, cpu, immediate, dst_value, result, Size::Byte);
+    cycles_const(builder, 16)
+}
+
 /// Emit CMPA.W/L from checked guest memory. Address calculation and the
 /// fast-memory bounds/alignment checks precede every flag write, so a failed
 /// window access can fall back and re-execute the instruction atomically.
@@ -9707,6 +9824,9 @@ fn emit_block_op(
         }
         JitTraceOp::CmpiWordMem { .. } => {
             emit_cmpi_word_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
+        }
+        JitTraceOp::CmpiByteAbs { .. } => {
+            emit_cmpi_byte_abs(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
         }
         JitTraceOp::TstMem { .. } => {
             emit_tst_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
@@ -12264,6 +12384,57 @@ mod portable_tests {
         assert_eq!(cpu.pc, 0x0106);
     }
 
+    #[test]
+    fn absolute_word_cmpi_byte_matches_the_68000_interpreter() {
+        let words = [0x0C38u16, 0x0042, 0x0320]; // CMPI.B #$42,$0320.W
+        let setup = |cpu: &mut CpuCore| {
+            cpu.set_cpu_type(CpuType::M68000);
+            cpu.set_ccr(0x10); // X must be preserved.
+            cpu.pc = 0x0100;
+        };
+
+        let mut interpreter_bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        for (index, word) in words.iter().enumerate() {
+            interpreter_bus.write_word(0x0100 + index as u32 * 2, *word);
+        }
+        interpreter_bus.write_byte(0x0320, 0x41);
+        let mut interpreter = cpu();
+        setup(&mut interpreter);
+        let interpreter_cycles = match interpreter.step(&mut interpreter_bus) {
+            super::super::types::StepResult::Ok { cycles } => cycles,
+            other => panic!("interpreter CMPI.B failed: {other:?}"),
+        };
+
+        let mut memory = vec![0u8; 0x1000];
+        for (index, word) in words.iter().enumerate() {
+            memory[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
+        }
+        memory[0x0320] = 0x41;
+        let mut portable = cpu();
+        setup(&mut portable);
+        attach_window(&mut portable, &mut memory);
+        let trace = decode_trace_op(&portable, &mut interpreter_bus, 0x0100, CpuType::M68000)
+            .expect("absolute-word CMPI.B should decode");
+        assert_eq!(trace.extension, Some(0x0042));
+        assert_eq!(trace.extension2, Some(0x0320));
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::CmpiByteAbs {
+                immediate: 0x42,
+                address: 0x0320,
+            }
+        ));
+        let portable_cycles =
+            execute_portable_op(&mut portable, trace, CodeSpans::caller(0x0100, 0x0106))
+                .expect("portable CMPI.B should execute");
+
+        assert_eq!(portable_cycles, interpreter_cycles);
+        assert_eq!(portable.pc, interpreter.pc);
+        assert_eq!(portable.get_ccr(), interpreter.get_ccr());
+        assert_eq!(portable.get_ccr(), 0x19, "X/N/C set, Z/V clear");
+        assert_eq!(memory[0x0320], 0x41, "CMPI is read-only");
+    }
+
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
     #[test]
     fn native_indexed_cmpi_word_matches_portable_and_bails_atomically() {
@@ -12363,6 +12534,82 @@ mod portable_tests {
         assert_eq!(bailed.pc, 0x0100);
         assert_eq!(bailed.dar, before);
         assert_eq!(bailed.get_ccr(), 0x10);
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_absolute_word_cmpi_byte_matches_portable_and_bails_atomically() {
+        let compare = TraceBuildOp {
+            opcode: 0x0C38,
+            extension: Some(0x0042),
+            extension2: Some(0x0320),
+            pc: 0x0100,
+            op: JitTraceOp::CmpiByteAbs {
+                immediate: 0x42,
+                address: 0x0320,
+            },
+        };
+        let branch = TraceBuildOp {
+            opcode: 0x60F8,
+            extension: None,
+            extension2: None,
+            pc: 0x0106,
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -8,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+        let ops = [compare, branch];
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&cpu(), 0x0100, CpuType::M68000, ops.to_vec(), Some(0x0100))
+            .expect("absolute-word CMPI.B loop should compile");
+
+        let seed = |memory: &mut [u8]| {
+            for (index, word) in [0x0C38u16, 0x0042, 0x0320, 0x60F8].iter().enumerate() {
+                memory[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
+            }
+            memory[0x0320] = 0x41;
+        };
+
+        let mut portable_memory = vec![0u8; 0x1000];
+        seed(&mut portable_memory);
+        let mut portable = cpu();
+        portable.set_cpu_type(CpuType::M68000);
+        portable.set_ccr(0x10);
+        attach_window(&mut portable, &mut portable_memory);
+        let portable_packed =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(0x0100, 0x0108));
+
+        let mut native_memory = vec![0u8; 0x1000];
+        seed(&mut native_memory);
+        let mut native = cpu();
+        native.set_cpu_type(CpuType::M68000);
+        native.set_ccr(0x10);
+        attach_window(&mut native, &mut native_memory);
+        let native_packed = unsafe { compiled.call_native(&mut native, 1) };
+        assert_eq!(native_packed, portable_packed);
+        assert_eq!((native_packed >> 32) as u32, 2);
+        assert_eq!(native_packed as u32 as i32, 26);
+        assert_eq!(native.pc, 0x0100);
+        assert_eq!(native.get_ccr(), portable.get_ccr());
+        assert_eq!(native_memory[0x0320], 0x41);
+
+        let mut short_memory = vec![0u8; 0x0200];
+        for (index, word) in [0x0C38u16, 0x0042, 0x0320, 0x60F8].iter().enumerate() {
+            short_memory[0x0100 + index * 2..0x0102 + index * 2]
+                .copy_from_slice(&word.to_be_bytes());
+        }
+        let mut bail = cpu();
+        bail.set_cpu_type(CpuType::M68000);
+        bail.set_ccr(0x10);
+        attach_window(&mut bail, &mut short_memory);
+        let bail_packed = unsafe { compiled.call_native(&mut bail, 1) };
+        assert_eq!(bail_packed, 0);
+        assert_eq!(bail.pc, 0x0100);
+        assert_eq!(bail.get_ccr(), 0x10);
     }
 
     /// Word-read counting bus for the profiling bus-access regression.


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #168, which is itself stacked on #167. The new work
> begins after `d7cb97c` and is kept in three independent commits:
> `b3934aa`, `6a80fe0`, and `4706bcc`. Once the dependencies merge, the diff
> collapses to those commits.

## Summary

Extend native and portable trace execution across three legal 68k forms that
were terminating heavily reused SimCity 2000 recordings:

- `JSR d16(An)` (`4EAD` in the measured path);
- `CMPI.B #imm,abs.W` (`0C38`);
- `ANDI.B #imm,d8(An,Xn)` (`0231`).

Together they reduce retired host instructions by **4.40%** in the standard
400M-instruction SC2K replay, with identical simulated ticks and framebuffer
output. Each step was also measured independently, and cross-application
controls are neutral.

The blocker profile is used here to prioritize implementation work, not to
define a permanent game-specific whitelist. These are extensions of existing
control-address and immediate-ALU families. Other legal forms continue to run
through the exact decoded/interpreter path, and the trace representation can
grow toward shared family lowerings as their fault/extension-word cases are
made atomic. Admission—not semantic support—should ultimately decide whether
a particular trace is worth compiling.

## Why unsupported forms cost host CPU

The trace recorder stops at an instruction it cannot lower. The cost is not
just dispatching that one instruction: the supported prefix before it cannot
become a reusable native loop. The pre-change 400M opportunity census
projected:

| Blocker | Projected prefix dispatches |
|---|---:|
| `JSR d16(An)` | 1,474,272 |
| `CMPI.B #imm,abs.W` | 1,286,754 + 708,462 |
| `ANDI.B #imm,d8(An,Xn)` | 1,474,725 |

The ANDI result makes the effect especially visible. After adding it, the
rejected head at `$00221014` becomes a 10-op native trace. It retires
2,943,680 guest operations in only 2,803 native entries—1,050 operations per
entry. Across the whole replay:

| Trace counter | Before ANDI | After ANDI | Delta |
|---|---:|---:|---:|
| JIT-retired guest ops | 341,714,179 | 349,981,182 | +8,267,003 |
| rejected hits | 1,825,305 | 1,520,925 | -304,380 |
| native calls | 15,895,996 | 15,586,123 | -309,873 |

This is why implementing one blocker saves much more than one decoded opcode:
it recovers the surrounding long-running loop.

## Implementation and safety

### Displacement indirect JSR

The existing terminal `IndirectJsr` op now carries a predecoded `JitEa`, so
the same path supports `(An)` and `d16(An)`. The displacement word is captured
and validated, while the base address register remains live at execution.

The native path computes the target, checks the complete four-byte stack write,
and only then commits SP, the big-endian return address, flow state, and PC. A
window miss therefore re-executes the call with no partial state. The return
address is derived from the recorded instruction extent (four bytes for the
new form), and the M68000 bound is the exact 18 cycles rather than the 16-cycle
`(An)` value. The portable path delegates to the decoded memory/control
executor and has the same atomic fallback.

### Absolute-byte CMPI

`CmpiByteAbs` captures the byte immediate and sign-extended absolute-short
address while retaining both raw extension words for code validation. Native
execution performs one checked byte load and subtraction, updates NZVC, and
preserves X. It never writes guest memory; a window miss occurs before flags
change. Portable execution reuses `DecodedMemOp::AluImm`.

This is deliberately a separate internal op from the established
`CmpiWordMem`. A first candidate generalized that hot op to carry runtime size.
Although lowering consumes size at compile time, the representation/code-layout
change correlated with small repeatable regressions in 3 in Three and EV
Override. Keeping the fixed word op byte-for-byte unchanged retained the SC2K
gain and removed those regressions; see "Rejected and retained experiments."

### Indexed-byte ANDI

`AndImmByteMem` captures the immediate and decoded brief-indexed EA. The native
path computes the live base/index address, then performs all window and
self-modifying-code overlap guards before the read-modify-write or condition
flags commit. It writes one byte, sets logical NZVC, preserves X, and uses the
exact 22-cycle M68000 maximum. Portable execution again delegates to the
decoded memory-ALU implementation.

Tests cover decoder extents, signed displacement and live-register behavior,
exact M68000 state/cycle parity, native/portable parity, short-window bailout,
and code-overlap bailout with no partial state.

## Host-CPU measurements

All SC2K arms execute 400M guest instructions and finish at the same 185,810
ticks and framebuffer SHA-256. Values are aggregate retired host instructions
from three interleaved A/B pairs:

| Incremental step | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| add `JSR d16(An)` | 168,092,724,217 | 167,247,845,394 | **-0.503%** |
| add isolated `CMPI.B abs.W` | 167,208,637,560 | 165,382,873,087 | **-1.092%** |
| add indexed `ANDI.B` | 165,827,019,725 | 160,877,832,958 | **-2.985%** |
| all three vs pre-JSR | 168,352,532,780 | 160,946,270,841 | **-4.399%** |

The direct cumulative pairs are independently -4.218%, -4.429%, and -4.550%.
The direct -4.399% agrees with the -4.42% compounded prediction from the
incremental steps.

Cross-workload retired-instruction controls for each incremental step:

| Workload | JSR | isolated CMPI | ANDI |
|---|---:|---:|---:|
| Lemmings | +0.026% | -0.017% | +0.001% |
| 3 in Three | +0.046% | +0.0006% | +0.0003% |
| System's Twilight | +0.013% | -0.005% | -0.045% |
| EV Override (per tick) | -0.016% | +0.0059% | +0.018% |

EV is normalized by aggregate simulated ticks because its scripted route is
not tick-deterministic. All other controls have identical ticks and framebuffer
hashes. The small values above are noise-level neutrality, not claimed wins.

## Why the old ANDI rejection changed

The same ANDI implementation measured +0.016% on a single September 1 pair
and was preserved rather than published. That test used the PR-#162-era stack.
Parking had removed the cheap spin loops that were the trace JIT's former
customers; on the then-current SC2K run, native traces retired only 0.07% of
guest instructions, so admitting this opcode had almost nothing to act on.

The later admission and exit-topology work restored a reusable native trace
graph. The current pre-ANDI census retires about 85% of the fixed guest budget
through native traces. Reapplying the unchanged opcode implementation now
recovers the 1,050-op-per-entry loop described above and saves 2.985% host
instructions. Opcode-performance rejections are therefore conditional on the
admission/topology baseline; they should be revisited after structural changes.

## Rejected and retained experiments

- **Generalized CMPI representation:** SC2K improved 1.084%, but 3 in Three
  regressed 0.167% and EV regressed 0.132%/tick. The isolated `CmpiByteAbs`
  control improved SC2K 1.092% while 3 in Three moved only +0.0006% and EV
  +0.0059%/tick. The generalized source and both binaries remain preserved for
  follow-up assembly/layout analysis.
- **`JMP (An)`:** six SC2K pairs measured -0.046%, noise-level neutral. Source
  and binary are retained locally in case another topology change makes it
  useful.
- **`LEA d16(PC),An`:** three SC2K pairs measured +0.042%, also neutral. It is
  retained as instruction-family coverage work, but is not included as a
  performance claim here.
- **Cranelift verifier removal:** not part of this work. Verification remains
  enabled; this PR does not trade safety for compile speed.

## Validation

- `cargo test --lib --features 'jit trace-profile'` — 318 passed
- `cargo test --lib --no-default-features` — 205 passed
- `cargo clippy --lib --all-features -- -D warnings` — clean
- deterministic headless A/B hardware-counter replays on SC2K, Lemmings,
  3 in Three, System's Twilight, and EV Override

