### PR TITLE
perf(trace): compile indexed-dispatch paths across call spans

### DIFF
--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -2172,6 +2172,59 @@ impl TraceJit {
         }
     }
 
+    /// Close a recording that cannot add another callee without making its
+    /// bounded code intervals overly broad, retaining a completed prefix
+    /// when it belongs to an indexed-dispatch path.
+    #[cold]
+    #[inline(never)]
+    fn finish_recording_at_call_span(&mut self, cpu: &mut CpuCore, call_pc: u32) {
+        // A trace carries one caller and one callee SMC interval. SC2K's
+        // table-driven dispatch can cross an indexed JMP, finish one
+        // call/return, and then reach a second far callee. The second call
+        // cannot join this trace without making its callee interval overly
+        // broad, but the completed control-flow prefix before it is
+        // independently useful.
+        //
+        // Keep this salvage deliberately structural. An indexed jump is a
+        // multi-way dispatch boundary; a plain JMP (An) is commonly a cold
+        // function thunk, while an ordinary conditional branch can belong to
+        // an alternate path of an already-productive longer trace. Once the
+        // indexed dispatch proves this topology, retain through the LAST
+        // completed terminal: SC2K does useful work after the dispatch,
+        // including one bounded call/return, before a direct branch leads to
+        // the impossible second call.
+        let salvage = self.recording.as_ref().and_then(|recording| {
+            if recording.ops.last().is_some_and(|op| op.op.ends_trace()) {
+                return None;
+            }
+            let last_terminal = recording.ops.iter().rposition(|op| op.op.ends_trace())?;
+            let has_indexed_dispatch = recording.ops[..=last_terminal].iter().any(|op| {
+                matches!(
+                    op.op,
+                    JitTraceOp::IndirectJmp {
+                        target: JitEa::Index { .. } | JitEa::PcIndex { .. },
+                        expected_target: Some(_),
+                    }
+                )
+            });
+            if !has_indexed_dispatch || last_terminal + 1 < SALVAGE_MIN_OPS {
+                return None;
+            }
+            let continuation = recording.ops.get(last_terminal + 1)?.pc;
+            Some((last_terminal + 1, continuation))
+        });
+        if let Some((prefix_len, continuation)) = salvage {
+            self.recording
+                .as_mut()
+                .expect("salvage came from an active recording")
+                .ops
+                .truncate(prefix_len);
+            self.finish_recording(cpu, continuation, RecordingEnd::Region);
+        } else {
+            self.finish_recording(cpu, call_pc, RecordingEnd::Region);
+        }
+    }
+
     /// `call_retry_pending` marks the one case where a rescued prefix is
     /// worse than no trace at all: a recording stopped by its first
     /// unpermitted call. Salvaging there installs a compiled prefix that
@@ -2578,7 +2631,7 @@ impl TraceJit {
                     if caller_hi.wrapping_sub(caller_lo) > CALL_THROUGH_MAX_SPAN
                         || callee_hi.wrapping_sub(callee_lo) > CALL_THROUGH_MAX_SPAN
                     {
-                        self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        self.finish_recording_at_call_span(cpu, executed_pc);
                         return;
                     }
                     recording.pending_return = Some(return_pc);
@@ -16593,6 +16646,113 @@ mod portable_tests {
              ({compiled_ops} ops)"
         );
         assert_eq!(compiled_ops, 5, "call + leaf + return + tail + latch");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn second_far_call_salvages_the_completed_control_flow_prefix() {
+        // The SC2K topology: a hot head reaches a dispatch target through
+        // a guarded computed jump, records one call/return and a later direct
+        // branch, then encounters a second call whose callee is too far from
+        // the first for one bounded callee-code interval. Refusing that
+        // second call must not throw away the independently reusable prefix
+        // through the last completed branch.
+        const HEAD: u32 = 0x0100;
+        const TARGET: u32 = 0x0200;
+        const TAIL: u32 = 0x0220;
+        const LEAF1: u32 = 0x3000;
+        const LEAF2: u32 = 0x7000;
+        let head = [
+            0x5282, // seven ADDQ.L #1,D2 ops make the guarded prefix
+            0x5282, // meet the measured salvage break-even length
+            0x5282, 0x5282, 0x5282, 0x5282, 0x5282, 0x4EF0,
+            0x1000, // JMP (0,A0,D1.W) -> TARGET (D1 = 0)
+        ];
+        let target = [
+            0x6100, 0x2DFE, // BSR.W LEAF1 (TARGET + 2 + $2DFE)
+            0x6000, 0x001A, // BRA.W TAIL (TARGET + 6 + $001A)
+        ];
+        let tail = [
+            0x5285, // ADDQ.L #1,D5 -- interpreted after the salvaged prefix
+            0x6100, 0x6DDC, // BSR.W LEAF2 (TAIL + 4 + $6DDC)
+            0x51C8, 0xFED8, // DBRA D0,HEAD
+            0x707F, // MOVEQ #127,D0
+            0x6000, 0xFED2, // BRA.W HEAD
+        ];
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x10000);
+        for (index, word) in head.iter().enumerate() {
+            bus.write_word_at(HEAD + index as u32 * 2, *word);
+        }
+        for (index, word) in target.iter().enumerate() {
+            bus.write_word_at(TARGET + index as u32 * 2, *word);
+        }
+        for (index, word) in tail.iter().enumerate() {
+            bus.write_word_at(TAIL + index as u32 * 2, *word);
+        }
+        bus.write_word_at(LEAF1, 0x5283); // ADDQ.L #1,D3
+        bus.write_word_at(LEAF1 + 2, 0x4E75); // RTS
+        bus.write_word_at(LEAF2, 0x5284); // ADDQ.L #1,D4
+        bus.write_word_at(LEAF2 + 2, 0x4E75); // RTS
+
+        let mut cpu = CpuCore::new();
+        cpu.set_cpu_type(CpuType::M68040);
+        cpu.set_sr(0x2700);
+        cpu.pc = HEAD;
+        cpu.set_a(0, TARGET);
+        cpu.set_a(7, 0x9000);
+        cpu.set_d(0, 0x7F);
+        cpu.set_d(1, 0);
+        let result = cpu.run_batch(&mut bus, 100_000, &[0]);
+        assert_eq!(result.instructions, 100_000, "loop runs to budget");
+        assert!(cpu.d(3) > 1_000, "both callees actually ran");
+        assert!(
+            cpu.d(3).abs_diff(cpu.d(4)) <= 1,
+            "the two leaves stay in lockstep"
+        );
+
+        let salvaged = with_trace_jit(|jit| match &jit.slots[trace_cache_index(HEAD)] {
+            TraceSlot::Compiled(trace) if trace.pc == HEAD => Some((
+                trace.ops.len(),
+                matches!(
+                    trace.ops.last().map(|op| op.op),
+                    Some(JitTraceOp::Branch { .. })
+                ),
+                trace
+                    .ops
+                    .iter()
+                    .any(|op| matches!(op.op, JitTraceOp::CallThrough { .. })),
+                trace.ops.iter().any(|op| {
+                    matches!(
+                        op.op,
+                        JitTraceOp::IndirectJmp {
+                            expected_target: Some(TARGET),
+                            ..
+                        }
+                    )
+                }),
+                trace
+                    .ops
+                    .iter()
+                    .any(|op| matches!(op.op, JitTraceOp::RtsReturn { .. })),
+            )),
+            _ => None,
+        });
+        let (ops, ends_at_branch, contains_call, contains_indexed_dispatch, contains_return) =
+            salvaged.expect("the hot head compiles its reusable prefix");
+        assert_eq!(ops, 12, "the trace trims at the last completed branch");
+        assert!(
+            ends_at_branch,
+            "the post-call direct branch is the terminal"
+        );
+        assert!(contains_indexed_dispatch, "the dispatch anchors salvage");
+        assert!(
+            contains_call,
+            "the bounded first call remains in the prefix"
+        );
+        assert!(
+            contains_return,
+            "the first call's checked return remains too"
+        );
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -762,6 +762,120 @@ struct TraceCodeSegment {
     len: u32,
 }
 
+/// Compare live guest instructions with the bytes captured at compilation.
+///
+/// The helper stays outlined: trace entry already pays one call per segment,
+/// and inlining the SIMD loop expands the iterator closure enough to disturb
+/// instruction-cache locality in workloads dominated by tiny segments. Short
+/// ranges use early-out native-word loads; on x86-64, genuinely wide ranges
+/// fold 16-byte differences into one final decision. Very long ranges retain
+/// the platform `memcmp`, whose startup cost is then well amortized.
+#[inline(never)]
+unsafe fn trace_code_eq(live: *const u8, expected: *const u8, len: usize) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    if (48..=512).contains(&len) {
+        use std::arch::x86_64::{
+            __m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+            _mm_setzero_si128, _mm_xor_si128,
+        };
+
+        let mut offset = 0;
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+        let zero = unsafe { _mm_setzero_si128() };
+        let mut difference = zero;
+        while len - offset >= 16 {
+            // SAFETY: each complete vector lies inside the caller-provided
+            // `len`-byte ranges. Unaligned loads are intentional.
+            let live_word = unsafe { _mm_loadu_si128(live.add(offset).cast::<__m128i>()) };
+            let expected_word = unsafe { _mm_loadu_si128(expected.add(offset).cast::<__m128i>()) };
+            // SAFETY: SSE2 is part of the x86-64 baseline ISA.
+            difference =
+                unsafe { _mm_or_si128(difference, _mm_xor_si128(live_word, expected_word)) };
+            offset += 16;
+        }
+
+        let mut tail_difference = 0u64;
+        if len - offset >= 8 {
+            // SAFETY: a complete eight-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            tail_difference |= live_word ^ expected_word;
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            tail_difference |= u64::from(live_word ^ expected_word);
+            offset += 2;
+        }
+        if len != offset {
+            // SAFETY: one byte remains inside each caller-provided range.
+            tail_difference |= u64::from(unsafe { *live.add(offset) ^ *expected.add(offset) });
+        }
+
+        // SAFETY: SSE2 is part of the x86-64 baseline ISA. A zero byte in
+        // every lane produces all 16 bits in the movemask.
+        let wide_equal = unsafe { _mm_movemask_epi8(_mm_cmpeq_epi8(difference, zero)) == 0xFFFF };
+        return wide_equal & (tail_difference == 0);
+    }
+
+    let scalar_limit = if cfg!(target_arch = "x86_64") {
+        47
+    } else {
+        128
+    };
+    if len <= scalar_limit {
+        let mut offset = 0;
+        while len - offset >= 8 {
+            // SAFETY: each complete word lies inside both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u64>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u64>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 8;
+        }
+        if len - offset >= 4 {
+            // SAFETY: a complete four-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u32>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u32>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 4;
+        }
+        if len - offset >= 2 {
+            // SAFETY: a complete two-byte tail remains in both ranges.
+            let live_word = unsafe { std::ptr::read_unaligned(live.add(offset).cast::<u16>()) };
+            let expected_word =
+                unsafe { std::ptr::read_unaligned(expected.add(offset).cast::<u16>()) };
+            if live_word != expected_word {
+                return false;
+            }
+            offset += 2;
+        }
+        return len == offset || unsafe { *live.add(offset) == *expected.add(offset) };
+    }
+
+    // SAFETY: the caller guarantees both ranges are readable for `len` bytes.
+    let live = unsafe { std::slice::from_raw_parts(live, len) };
+    let expected = unsafe { std::slice::from_raw_parts(expected, len) };
+    live == expected
+}
+
 struct CompiledTrace {
     pc: u32,
     cpu_type: CpuType,
@@ -1135,13 +1249,10 @@ impl TraceJit {
                     }
                     let expected = &trace.code[segment.code_offset as usize
                         ..(segment.code_offset + segment.len) as usize];
-                    let live = unsafe {
-                        std::slice::from_raw_parts(
-                            (cpu.fm_ptr as *const u8).add(off as usize),
-                            segment.len as usize,
-                        )
-                    };
-                    live == expected
+                    let live = unsafe { (cpu.fm_ptr as *const u8).add(off as usize) };
+                    // SAFETY: the bounds check above covers the live range,
+                    // and `expected` has exactly `segment.len` bytes.
+                    unsafe { trace_code_eq(live, expected.as_ptr(), segment.len as usize) }
                 });
             }
 
@@ -13836,6 +13947,37 @@ mod portable_tests {
             "with budget to act the miss surfaces"
         );
         assert_eq!(pc, 0x010C, "the miss consumed the changed opcode");
+    }
+
+    #[test]
+    fn trace_code_compare_covers_scalar_simd_and_platform_boundaries() {
+        let lengths = [
+            0usize, 1, 2, 3, 7, 8, 9, 15, 16, 47, 48, 49, 511, 512, 513, 768,
+        ];
+        for len in lengths {
+            let mut live = vec![0xA5u8; len + 8];
+            let mut expected = vec![0x5Au8; len + 8];
+            for index in 0..len {
+                let byte = (index as u8).wrapping_mul(37).wrapping_add(11);
+                live[index + 1] = byte;
+                expected[index + 3] = byte;
+            }
+            let live_ptr = unsafe { live.as_ptr().add(1) };
+            let expected_ptr = unsafe { expected.as_ptr().add(3) };
+            assert!(unsafe { trace_code_eq(live_ptr, expected_ptr, len) });
+
+            if len != 0 {
+                let positions = [0, len / 2, len - 1];
+                for position in positions {
+                    live[position + 1] ^= 0x80;
+                    assert!(
+                        !unsafe { trace_code_eq(live.as_ptr().add(1), expected_ptr, len) },
+                        "length {len} mismatch at byte {position}"
+                    );
+                    live[position + 1] ^= 0x80;
+                }
+            }
+        }
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -462,18 +462,6 @@ pub(crate) enum JitTraceOp {
         /// exit and continues along the recorded path on a match.
         expected_taken: Option<bool>,
     },
-    /// `JMP (d8,PC,Xn)` -- an N-way jump-table dispatch. The base (pc +
-    /// 2 + d8) folds to a constant at record time; the recorded taken
-    /// target guards the trace: a mismatch commits the jump (pc = the
-    /// computed target) and side-exits, where exit seeding compiles the
-    /// other dispatch cases as continuations that link back.
-    PcIndexJmp {
-        base: u32,
-        index: JitDirectReg,
-        index_long: bool,
-        scale: u8,
-        expected_target: Option<u32>,
-    },
     Dbcc {
         condition: u8,
         reg: u8,
@@ -485,11 +473,13 @@ pub(crate) enum JitTraceOp {
     IndirectJsr {
         target: JitEa,
     },
-    /// Terminal `JMP (An)`. Unlike an indirect call, this only transfers
-    /// control: there is no stack access, so a short region can still
-    /// amortize trace entry and validation.
+    /// Guarded indirect `JMP` through `(An)`, `d16(An)`, brief
+    /// `d8(An,Xn)`, or brief `d8(PC,Xn)`. The recorder follows the observed
+    /// target; execution commits the live target and side-exits if it differs.
+    /// This spans stable dispatch edges without assuming that they are static.
     IndirectJmp {
-        reg: u8,
+        target: JitEa,
+        expected_target: Option<u32>,
     },
     /// A BSR recorded THROUGH: pushes the constant return address and
     /// falls through to the callee's ops, which follow inline in the
@@ -1010,7 +1000,7 @@ impl CompiledTrace {
                             || (cpu.pc == fallthrough && expected_taken)
                     }
                 }
-                JitTraceOp::PcIndexJmp {
+                JitTraceOp::IndirectJmp {
                     expected_target: Some(expected),
                     ..
                 } => cpu.pc != expected,
@@ -1030,7 +1020,7 @@ fn guarded_op_mask(ops: &[TraceBuildOp]) -> u128 {
             JitTraceOp::Branch {
                 expected_taken: Some(_),
                 ..
-            } | JitTraceOp::PcIndexJmp {
+            } | JitTraceOp::IndirectJmp {
                 expected_target: Some(_),
                 ..
             }
@@ -2728,7 +2718,7 @@ impl TraceJit {
             // A computed jump records its taken target and the recording
             // follows it (like a taken Branch); execution guards on the
             // recorded target and side-exits on any other dispatch case.
-            JitTraceOp::PcIndexJmp {
+            JitTraceOp::IndirectJmp {
                 expected_target, ..
             } => {
                 *expected_target = Some(next_pc);
@@ -2741,11 +2731,6 @@ impl TraceJit {
                 return;
             }
             JitTraceOp::IndirectJsr { .. } => {
-                self.recording.as_mut().unwrap().ops.push(op);
-                self.finish_recording(cpu, next_pc, RecordingEnd::Region);
-                return;
-            }
-            JitTraceOp::IndirectJmp { .. } => {
                 self.recording.as_mut().unwrap().ops.push(op);
                 self.finish_recording(cpu, next_pc, RecordingEnd::Region);
                 return;
@@ -3318,20 +3303,15 @@ impl TraceJit {
                         bail_at.ops_before,
                         1,
                     ),
-                    JitTraceOp::PcIndexJmp {
-                        base,
-                        index: jmp_index,
-                        index_long,
-                        scale,
+                    JitTraceOp::IndirectJmp {
+                        target,
                         expected_target: Some(expected_target),
-                    } => emit_guarded_pc_index_jmp(
+                    } => emit_guarded_indirect_jmp(
                         &mut builder,
                         cpu_ptr,
                         op.pc,
-                        base,
-                        jmp_index,
-                        index_long,
-                        scale,
+                        op.opcode,
+                        target,
                         expected_target,
                         cycles_value,
                         bail_at.ops_before,
@@ -3721,7 +3701,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             // this head; per-head wait accounting would then erase
             // opportunity data belonging to other shapes. A guarded
             // computed jump is an interior N-way branch: same rule.
-            JitTraceOp::Branch { .. } | JitTraceOp::PcIndexJmp { .. } => return false,
+            JitTraceOp::Branch { .. } | JitTraceOp::IndirectJmp { .. } => return false,
             // Memory-reading compares and tests write NZVC only; the
             // polled value is the only input that can change.
             JitTraceOp::TstMem { .. }
@@ -3770,7 +3750,6 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::Swap { .. }
             | JitTraceOp::Dbcc { .. }
             | JitTraceOp::IndirectJsr { .. }
-            | JitTraceOp::IndirectJmp { .. }
             | JitTraceOp::MoveMem { .. }
             | JitTraceOp::MovemWordPostInc { .. }
             | JitTraceOp::AluMemToReg { .. }
@@ -4036,8 +4015,6 @@ impl JitTraceOp {
                 }
             }
             Self::Nop => 4,
-            // JMP (d8,PC,Xn) (M68000UM table 8-, indexed jump).
-            Self::PcIndexJmp { .. } => 14,
             Self::MoveReg { .. } => 4,
             Self::Moveq { .. } => 4,
             // MC68000: 8(2/0) for the word form, 12(3/0) for the long.
@@ -4282,8 +4259,21 @@ impl JitTraceOp {
                 target: JitEa::Disp(_, _),
             } => 18,
             Self::IndirectJsr { .. } => unreachable!("JSR decoder admitted unsupported EA"),
-            // M68000UM control-address timing: JMP (An) is 8(2/0).
-            Self::IndirectJmp { .. } => 8,
+            // M68000UM control-address timing: JMP is eight cycles plus
+            // the effective-address calculation (0/2/6 for these modes).
+            Self::IndirectJmp {
+                target: JitEa::Ind(_),
+                ..
+            } => 8,
+            Self::IndirectJmp {
+                target: JitEa::Disp(_, _),
+                ..
+            } => 10,
+            Self::IndirectJmp {
+                target: JitEa::Index { .. } | JitEa::PcIndex { .. },
+                ..
+            } => 14,
+            Self::IndirectJmp { .. } => unreachable!("JMP decoder admitted unsupported EA"),
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::MemAddqSubq { .. } | Self::AnDispUnary { .. } | Self::AnDispBit { .. } => 24,
@@ -4310,9 +4300,8 @@ impl JitTraceOp {
             Self::Branch { .. }
                 | Self::Dbcc { .. }
                 | Self::IndirectJsr { .. }
-                | Self::IndirectJmp { .. }
                 | Self::CallExit { .. }
-                | Self::PcIndexJmp {
+                | Self::IndirectJmp {
                     expected_target: Some(_),
                     ..
                 }
@@ -4420,7 +4409,7 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_indirect_jsr_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
-    if let Some(op) = decode_indirect_jmp_trace_op(pc, opcode) {
+    if let Some(op) = decode_indirect_jmp_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_return_exit_trace_op(cpu, bus, pc, opcode, cpu_type) {
@@ -4483,10 +4472,6 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_move_mem_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
-    if let Some(op) = decode_pc_index_jmp_trace_op(cpu, bus, pc, opcode) {
-        return Some(op);
-    }
-
     let decoded = DecodedSimpleOp::decode(cpu_type, opcode)?;
     let op = decoded.to_jit_trace_op()?;
     Some(TraceBuildOp {
@@ -4907,17 +4892,66 @@ fn decode_indirect_jsr_trace_op<B: AddressBus>(
     })
 }
 
-fn decode_indirect_jmp_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
-    if (opcode & 0xFFF8) != 0x4ED0 {
-        return None;
-    }
+fn decode_indirect_jmp_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let (extension, target) = match opcode & 0xFFF8 {
+        0x4ED0 => (None, JitEa::Ind((opcode & 7) as u8)),
+        0x4EE8 => {
+            let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (
+                Some(extension),
+                JitEa::Disp((opcode & 7) as u8, extension as i16),
+            )
+        }
+        0x4EF0 => {
+            let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (
+                Some(extension),
+                decode_jit_ea(6, opcode & 7, extension, cpu_type)?,
+            )
+        }
+        _ if opcode == 0x4EFB => {
+            let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            if !is_pre_68020(cpu_type) && (extension & 0x0100) != 0 {
+                return None;
+            }
+            let index_num = ((extension >> 12) & 7) as u8;
+            let index = if (extension & 0x8000) != 0 {
+                JitDirectReg::Addr(index_num)
+            } else {
+                JitDirectReg::Data(index_num)
+            };
+            (
+                Some(extension),
+                JitEa::PcIndex {
+                    base: pc
+                        .wrapping_add(2)
+                        .wrapping_add((extension as u8 as i8) as i32 as u32),
+                    index,
+                    index_long: (extension & 0x0800) != 0,
+                    scale: if is_pre_68020(cpu_type) {
+                        0
+                    } else {
+                        ((extension >> 9) & 3) as u8
+                    },
+                },
+            )
+        }
+        _ => return None,
+    };
     Some(TraceBuildOp {
         opcode,
-        extension: None,
+        extension,
         extension2: None,
         pc,
         op: JitTraceOp::IndirectJmp {
-            reg: (opcode & 7) as u8,
+            target,
+            expected_target: None,
         },
     })
 }
@@ -5605,49 +5639,6 @@ fn decode_move_mem_trace_op<B: AddressBus>(
     })
 }
 
-/// Decode `JMP (d8,PC,Xn)` -- the jump-table dispatch of a bytecode
-/// interpreter. The recorded taken target is filled in by the recorder
-/// (like a Branch's expected direction); execution guards on it.
-fn decode_pc_index_jmp_trace_op<B: AddressBus>(
-    cpu: &CpuCore,
-    bus: &mut B,
-    pc: u32,
-    opcode: u16,
-) -> Option<TraceBuildOp> {
-    if opcode != 0x4EFB {
-        return None;
-    }
-    let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
-    if !is_pre_68020(cpu.cpu_type) && (extension & 0x0100) != 0 {
-        return None;
-    }
-    let index_num = ((extension >> 12) & 7) as u8;
-    let index = if (extension & 0x8000) != 0 {
-        JitDirectReg::Addr(index_num)
-    } else {
-        JitDirectReg::Data(index_num)
-    };
-    Some(TraceBuildOp {
-        opcode,
-        extension: Some(extension),
-        extension2: None,
-        pc,
-        op: JitTraceOp::PcIndexJmp {
-            base: pc
-                .wrapping_add(2)
-                .wrapping_add((extension as u8 as i8) as i32 as u32),
-            index,
-            index_long: (extension & 0x0800) != 0,
-            scale: if is_pre_68020(cpu.cpu_type) {
-                0
-            } else {
-                ((extension >> 9) & 3) as u8
-            },
-            expected_target: None,
-        },
-    })
-}
-
 fn decode_add_reg_to_mem_trace_op<B: AddressBus>(
     cpu: &CpuCore,
     bus: &mut B,
@@ -6017,7 +6008,7 @@ fn execute_portable_trace_raw(cpu: &mut CpuCore, ops: &[TraceBuildOp], spans: Co
                         return ((retired as u64) << 32) | cycles as u32 as u64;
                     }
                 }
-                if let JitTraceOp::PcIndexJmp {
+                if let JitTraceOp::IndirectJmp {
                     expected_target: Some(expected),
                     ..
                 } = op.op
@@ -7159,33 +7150,49 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
             unreachable!("CondSkip is handled in execute_portable_trace, not the register path")
         }
         JitTraceOp::Nop => 4,
-        JitTraceOp::PcIndexJmp {
-            base,
-            index,
-            index_long,
-            scale,
-            ..
-        } => {
-            // The jump commits architecturally regardless of the guard:
-            // pc = base + scaled index. The guard comparison itself is
-            // handled by the trace executor (mirroring Branch).
-            let raw_index = match index {
-                JitDirectReg::Data(r) => cpu.dar[r as usize],
-                JitDirectReg::Addr(r) => cpu.dar[8 + r as usize],
+        JitTraceOp::IndirectJmp { target, .. } => {
+            // The jump commits architecturally regardless of the guard. The
+            // executor compares this live target with the recorded one.
+            cpu.pc = match target {
+                JitEa::Ind(reg) => cpu.a(reg as usize),
+                JitEa::Disp(reg, displacement) => {
+                    cpu.a(reg as usize).wrapping_add(displacement as i32 as u32)
+                }
+                JitEa::Index {
+                    base,
+                    index,
+                    index_long,
+                    scale,
+                    displacement,
+                } => {
+                    let raw_index = portable_read_reg(cpu, index, Size::Long);
+                    let index = if index_long {
+                        raw_index
+                    } else {
+                        raw_index as u16 as i16 as i32 as u32
+                    };
+                    cpu.a(base as usize)
+                        .wrapping_add(index.wrapping_shl(scale as u32))
+                        .wrapping_add(displacement as i32 as u32)
+                }
+                JitEa::PcIndex {
+                    base,
+                    index,
+                    index_long,
+                    scale,
+                } => {
+                    let raw_index = portable_read_reg(cpu, index, Size::Long);
+                    let index = if index_long {
+                        raw_index
+                    } else {
+                        raw_index as u16 as i16 as i32 as u32
+                    };
+                    base.wrapping_add(index.wrapping_shl(scale as u32))
+                }
+                _ => unreachable!("JMP decoder admitted unsupported EA"),
             };
-            let idx = if index_long {
-                raw_index
-            } else {
-                raw_index as u16 as i16 as i32 as u32
-            };
-            cpu.pc = base.wrapping_add(idx.wrapping_shl(scale as u32));
             cpu.change_of_flow = true;
-            14
-        }
-        JitTraceOp::IndirectJmp { reg } => {
-            cpu.pc = cpu.a(reg as usize);
-            cpu.change_of_flow = true;
-            8
+            op.op.max_cycles()
         }
         JitTraceOp::Moveq { reg, data } => {
             cpu.dar[reg as usize] = data;
@@ -7817,8 +7824,8 @@ fn emit_jit_op(
         }
         // Guarded computed jumps are emitted by the main loop (they need
         // the exit plumbing); an unguarded one never compiles.
-        JitTraceOp::PcIndexJmp { .. } => {
-            unreachable!("PcIndexJmp reaches emit_jit_op")
+        JitTraceOp::IndirectJmp { .. } => {
+            unreachable!("guarded IndirectJmp reaches emit_jit_op")
         }
         JitTraceOp::ReturnExit { .. } => {
             unreachable!("ReturnExit is routed to emit_return_exit by the main emit loop")
@@ -8490,12 +8497,6 @@ fn emit_jit_op(
         }
         JitTraceOp::IndirectJsr { .. } => {
             unreachable!("IndirectJsr is emitted by emit_indirect_jsr")
-        }
-        JitTraceOp::IndirectJmp { reg } => {
-            let target = load_reg(builder, cpu, JitDirectReg::Addr(reg));
-            store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
-            store_value_u32(builder, cpu, offset_of!(CpuCore, pc), target);
-            cycles_const(builder, 8)
         }
         JitTraceOp::Branch {
             condition,
@@ -10822,35 +10823,72 @@ fn emit_guarded_branch(
 
 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
 #[allow(clippy::too_many_arguments)]
-fn emit_guarded_pc_index_jmp(
+fn emit_guarded_indirect_jmp(
     builder: &mut FunctionBuilder<'_>,
     cpu: Value,
     trace_pc: u32,
-    base: u32,
-    index: JitDirectReg,
-    index_long: bool,
-    scale: u8,
+    opcode: u16,
+    target_ea: JitEa,
     expected_target: u32,
     cycles_before: Value,
     retired_before_iter: RetiredBefore,
     ops_done: u32,
 ) -> Value {
-    // The jump commits architecturally on every dispatch case:
-    // pc = base + scaled index.
-    let base_v = iconst_u32(builder, base);
-    let raw_index = load_reg(builder, cpu, index);
-    let idx = if index_long {
-        raw_index
-    } else {
-        let word = builder.ins().ireduce(types::I16, raw_index);
-        builder.ins().sextend(types::I32, word)
+    // The jump commits architecturally on every dispatch case. Only the
+    // comparison with the recorded target controls whether the trace can
+    // continue along its recorded path.
+    let target = match target_ea {
+        JitEa::Ind(reg) => load_reg(builder, cpu, JitDirectReg::Addr(reg)),
+        JitEa::Disp(reg, displacement) => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+            builder.ins().iadd_imm(base, displacement as i64)
+        }
+        JitEa::Index {
+            base,
+            index,
+            index_long,
+            scale,
+            displacement,
+        } => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
+            let raw_index = load_reg(builder, cpu, index);
+            let index = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index = if scale == 0 {
+                index
+            } else {
+                builder.ins().ishl_imm(index, i64::from(scale))
+            };
+            let target = builder.ins().iadd(base, index);
+            builder.ins().iadd_imm(target, displacement as i64)
+        }
+        JitEa::PcIndex {
+            base,
+            index,
+            index_long,
+            scale,
+        } => {
+            let base = iconst_u32(builder, base);
+            let raw_index = load_reg(builder, cpu, index);
+            let index = if index_long {
+                raw_index
+            } else {
+                let word = builder.ins().ireduce(types::I16, raw_index);
+                builder.ins().sextend(types::I32, word)
+            };
+            let index = if scale == 0 {
+                index
+            } else {
+                builder.ins().ishl_imm(index, i64::from(scale))
+            };
+            builder.ins().iadd(base, index)
+        }
+        _ => unreachable!("JMP decoder admitted unsupported EA"),
     };
-    let idx = if scale == 0 {
-        idx
-    } else {
-        builder.ins().ishl_imm(idx, i64::from(scale))
-    };
-    let target = builder.ins().iadd(base_v, idx);
     store_pc_value(builder, cpu, target);
     let true_change = builder.ins().iconst(types::I8, 1);
     store_value(
@@ -10860,7 +10898,14 @@ fn emit_guarded_pc_index_jmp(
         true_change,
     );
 
-    let op_cycles = cycles_const(builder, 14);
+    let op_cycles = cycles_const(
+        builder,
+        JitTraceOp::IndirectJmp {
+            target: target_ea,
+            expected_target: None,
+        }
+        .max_cycles(),
+    );
     let expected = iconst_u32(builder, expected_target);
     let matches = builder.ins().icmp(IntCC::Equal, target, expected);
     let continue_block = builder.create_block();
@@ -10871,7 +10916,7 @@ fn emit_guarded_pc_index_jmp(
 
     builder.switch_to_block(side_exit);
     store_u32(builder, cpu, offset_of!(CpuCore, ppc), trace_pc);
-    store_u32(builder, cpu, offset_of!(CpuCore, ir), 0x4EFB);
+    store_u32(builder, cpu, offset_of!(CpuCore, ir), u32::from(opcode));
     let total_cycles = builder.ins().iadd(cycles_before, op_cycles);
     let cycles64 = builder.ins().uextend(types::I64, total_cycles);
     let retired = match retired_before_iter {
@@ -12293,8 +12338,75 @@ mod portable_tests {
         assert_eq!(jmp.extension, None);
         assert_eq!(jmp.length(), 2);
         assert_eq!(jmp.op.max_cycles(), 8);
-        assert!(matches!(jmp.op, JitTraceOp::IndirectJmp { reg: 1 }));
-        assert!(jmp.op.ends_trace());
+        assert!(matches!(
+            jmp.op,
+            JitTraceOp::IndirectJmp {
+                target: JitEa::Ind(1),
+                expected_target: None,
+            }
+        ));
+        assert!(
+            !jmp.op.ends_trace(),
+            "the recorder follows the observed target before installing its guard"
+        );
+
+        mem.write_word(0x0100, 0x4EEA); // JMP -$0010(A2)
+        mem.write_word(0x0102, 0xFFF0);
+        let jmp = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jmp.extension, Some(0xFFF0));
+        assert_eq!(jmp.length(), 4);
+        assert_eq!(jmp.op.max_cycles(), 10);
+        assert!(matches!(
+            jmp.op,
+            JitTraceOp::IndirectJmp {
+                target: JitEa::Disp(2, -16),
+                expected_target: None,
+            }
+        ));
+
+        mem.write_word(0x0100, 0x4EF3); // JMP $06(A3,D4.L)
+        mem.write_word(0x0102, 0x4806);
+        let jmp = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jmp.extension, Some(0x4806));
+        assert_eq!(jmp.length(), 4);
+        assert_eq!(jmp.op.max_cycles(), 14);
+        assert!(matches!(
+            jmp.op,
+            JitTraceOp::IndirectJmp {
+                target: JitEa::Index {
+                    base: 3,
+                    index: JitDirectReg::Data(4),
+                    index_long: true,
+                    scale: 0,
+                    displacement: 6,
+                },
+                expected_target: None,
+            }
+        ));
+
+        mem.write_word(0x0100, 0x4EFB); // JMP $06(PC,A1.W)
+        mem.write_word(0x0102, 0x9006);
+        let jmp = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jmp.extension, Some(0x9006));
+        assert_eq!(jmp.op.max_cycles(), 14);
+        assert!(matches!(
+            jmp.op,
+            JitTraceOp::IndirectJmp {
+                target: JitEa::PcIndex {
+                    base: 0x0108,
+                    index: JitDirectReg::Addr(1),
+                    index_long: false,
+                    scale: 0,
+                },
+                expected_target: None,
+            }
+        ));
+
+        mem.write_word(0x0102, 0x0100); // 68020 full-format extension
+        assert!(
+            decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68020).is_none(),
+            "full-format indexed control EAs remain in the interpreter"
+        );
     }
 
     #[test]
@@ -12307,8 +12419,12 @@ mod portable_tests {
             extension: None,
             extension2: None,
             pc: 0x0100,
-            op: JitTraceOp::IndirectJmp { reg: 1 },
+            op: JitTraceOp::IndirectJmp {
+                target: JitEa::Ind(1),
+                expected_target: Some(0x0340),
+            },
         };
+        assert!(op.op.ends_trace(), "a recorded target makes JMP guarded");
 
         assert_eq!(
             execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0102)),
@@ -12316,6 +12432,130 @@ mod portable_tests {
         );
         assert_eq!(cpu.pc, 0x0340);
         assert!(cpu.change_of_flow);
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn guarded_indirect_jmp_address_modes_match_interpreter_and_portable() {
+        const JMP_PC: u32 = 0x0106;
+        const EXPECTED: u32 = 0x0350;
+        let cases = [
+            (0x4ED0, None, JitEa::Ind(0), 0x0350, 0, 8, true),
+            (
+                0x4EE8,
+                Some(0x0010),
+                JitEa::Disp(0, 0x0010),
+                0x0340,
+                0,
+                10,
+                true,
+            ),
+            (
+                0x4EF0,
+                Some(0x1006),
+                JitEa::Index {
+                    base: 0,
+                    index: JitDirectReg::Data(1),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 6,
+                },
+                0x0300,
+                0x004A,
+                14,
+                false,
+            ),
+            (
+                0x4EFB,
+                Some(0x1006),
+                JitEa::PcIndex {
+                    base: JMP_PC + 8,
+                    index: JitDirectReg::Data(1),
+                    index_long: false,
+                    scale: 0,
+                },
+                0,
+                0x0242,
+                14,
+                false,
+            ),
+        ];
+
+        for (opcode, extension, target, a0, d1, jump_cycles, target_uses_a0) in cases {
+            let mut interpreter_bus = super::super::memory::LinearMemoryBus::new(0x1000);
+            interpreter_bus.write_word(JMP_PC, opcode);
+            if let Some(extension) = extension {
+                interpreter_bus.write_word(JMP_PC + 2, extension);
+            }
+            let mut interpreter = cpu();
+            interpreter.pc = JMP_PC;
+            interpreter.set_a(0, a0);
+            interpreter.set_d(1, d1);
+            let cycles = match interpreter.step(&mut interpreter_bus) {
+                super::super::types::StepResult::Ok { cycles } => cycles,
+                other => panic!("opcode {opcode:04X}: interpreter JMP failed: {other:?}"),
+            };
+            assert_eq!(cycles, jump_cycles, "opcode {opcode:04X}: timing");
+            assert_eq!(interpreter.pc, EXPECTED, "opcode {opcode:04X}: target");
+
+            let mut ops = Vec::new();
+            for index in 0..3 {
+                ops.push(TraceBuildOp {
+                    opcode: 0x4E71,
+                    extension: None,
+                    extension2: None,
+                    pc: 0x0100 + index * 2,
+                    op: JitTraceOp::Nop,
+                });
+            }
+            ops.push(TraceBuildOp {
+                opcode,
+                extension,
+                extension2: None,
+                pc: JMP_PC,
+                op: JitTraceOp::IndirectJmp {
+                    target,
+                    expected_target: Some(EXPECTED),
+                },
+            });
+
+            let mut jit = TraceJit::new();
+            let compiled = jit
+                .compile_decoded_ops(&cpu(), 0x0100, CpuType::M68000, ops.clone(), Some(EXPECTED))
+                .unwrap_or_else(|| panic!("opcode {opcode:04X}: trace should compile"));
+            for delta in [0u32, 2] {
+                let mut native = cpu();
+                native.pc = 0x0100;
+                native.set_a(0, a0 + if target_uses_a0 { delta } else { 0 });
+                native.set_d(1, d1 + if target_uses_a0 { 0 } else { delta });
+                let native_packed = unsafe { compiled.call_native(&mut native, 1) };
+
+                let mut portable = cpu();
+                portable.pc = 0x0100;
+                portable.set_a(0, a0 + if target_uses_a0 { delta } else { 0 });
+                portable.set_d(1, d1 + if target_uses_a0 { 0 } else { delta });
+                let portable_packed = execute_portable_trace(
+                    &mut portable,
+                    &ops,
+                    CodeSpans::caller(0x0100, JMP_PC + 4),
+                );
+
+                assert_eq!(
+                    native_packed, portable_packed,
+                    "opcode {opcode:04X}, delta={delta}: packed result"
+                );
+                assert_eq!((native_packed >> 32) as u32, 4);
+                assert_eq!(native_packed as u32 as i32, 12 + jump_cycles);
+                assert_eq!(native.pc, EXPECTED + delta);
+                assert_eq!(native.ppc, JMP_PC);
+                assert_eq!(native.ir, u32::from(opcode));
+                assert_eq!(
+                    compiled.is_guarded_branch_exit(&native),
+                    delta != 0,
+                    "opcode {opcode:04X}, delta={delta}: guard classification"
+                );
+            }
+        }
     }
 
     #[test]
@@ -18037,7 +18277,10 @@ mod portable_tests {
                 extension: None,
                 extension2: None,
                 pc: 0x0106,
-                op: JitTraceOp::IndirectJmp { reg: 5 },
+                op: JitTraceOp::IndirectJmp {
+                    target: JitEa::Ind(5),
+                    expected_target: Some(0x0350),
+                },
             },
         ];
         let mut jit = TraceJit::new();
@@ -21663,11 +21906,13 @@ mod portable_tests {
                 extension: Some(0x0006),
                 extension2: None,
                 pc: JMP_PC,
-                op: JitTraceOp::PcIndexJmp {
-                    base: 0x0108,
-                    index: JitDirectReg::Data(0),
-                    index_long: false,
-                    scale: 0,
+                op: JitTraceOp::IndirectJmp {
+                    target: JitEa::PcIndex {
+                        base: 0x0108,
+                        index: JitDirectReg::Data(0),
+                        index_long: false,
+                        scale: 0,
+                    },
                     expected_target: Some(EXPECTED),
                 },
             },
@@ -22976,7 +23221,8 @@ mod durable_rejection_tests {
 
     /// Two loop heads one cache period apart share a trace-cache slot.
     /// HEAD_A's loop crosses a
-    /// trap-free stretch and then JUMPS AWAY through a computed JMP before
+    /// trap-free stretch and then JUMPS AWAY through an unsupported
+    /// absolute-long JMP before
     /// any backward branch closes it, so every recording ends
     /// `no-trace-terminal`; HEAD_B is an ordinary tight loop whose
     /// candidacy overwrites A's `Rejected` slot each time it counts.
@@ -22986,15 +23232,34 @@ mod durable_rejection_tests {
     fn build_bus() -> LinearMemoryBus {
         let mut bus = LinearMemoryBus::new(0x10000);
         // HEAD_A: ADDQ.L #1,D0; ADDQ.L #1,D1; ADDQ.L #1,D2; ADDQ.L #1,D3;
-        //         JMP (A0)                 -- A0 = HEAD_B (structural dead end)
-        for (i, w) in [0x5280u16, 0x5281, 0x5282, 0x5283, 0x4ED0]
-            .iter()
-            .enumerate()
+        //         JMP (HEAD_B).L           -- structural dead end
+        // Absolute-long JMP deliberately remains outside this experiment's
+        // guarded dynamic-EA family, so it preserves the no-terminal fixture.
+        for (i, w) in [
+            0x5280u16,
+            0x5281,
+            0x5282,
+            0x5283,
+            0x4EF9,
+            (HEAD_B >> 16) as u16,
+            HEAD_B as u16,
+        ]
+        .iter()
+        .enumerate()
         {
             bus.load(HEAD_A + 2 * i as u32, &w.to_be_bytes());
         }
-        // HEAD_B: SUBQ.W #1,D7; BNE.S HEAD_B ; then JMP (A1) -- A1 = HEAD_A
-        for (i, w) in [0x5347u16, 0x66FC, 0x4ED1].iter().enumerate() {
+        // HEAD_B: SUBQ.W #1,D7; BNE.S HEAD_B ; then JMP (HEAD_A).L
+        for (i, w) in [
+            0x5347u16,
+            0x66FC,
+            0x4EF9,
+            (HEAD_A >> 16) as u16,
+            HEAD_A as u16,
+        ]
+        .iter()
+        .enumerate()
+        {
             bus.load(HEAD_B + 2 * i as u32, &w.to_be_bytes());
         }
         bus
@@ -23004,8 +23269,6 @@ mod durable_rejection_tests {
     fn structural_rejection_survives_slot_eviction() {
         let mut bus = build_bus();
         let mut cpu = cpu_at(HEAD_A);
-        cpu.set_a(0, HEAD_B);
-        cpu.set_a(1, HEAD_A);
         // HEAD_A is only ever entered by the JMP from HEAD_B's exit; give it
         // backward-branch hits by making HEAD_B's fallthrough jump back.
         // Each outer round: A's 4 ops, then B spins D7 iterations, then back.
@@ -23101,8 +23364,6 @@ mod durable_rejection_tests {
         // `compiled_before` gate this assertion fails (HEAD_A is frozen).
         let mut bus = build_bus();
         let mut cpu = cpu_at(HEAD_A);
-        cpu.set_a(0, HEAD_B);
-        cpu.set_a(1, HEAD_A);
         with_trace_jit(|jit| jit.remember_compiled(HEAD_A));
 
         for _ in 0..40 {
@@ -23402,7 +23663,7 @@ mod durable_rejection_tests {
                     trace.ops.iter().any(|op| {
                         matches!(
                             op.op,
-                            JitTraceOp::PcIndexJmp {
+                            JitTraceOp::IndirectJmp {
                                 expected_target: Some(_),
                                 ..
                             }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -1575,7 +1575,20 @@ impl TraceJit {
                 let entry_watched = watch_pcs
                     .iter()
                     .any(|&watched| cpu.address(watched) == cpu.address(cpu.pc));
-                match self.note_trace_exit(cpu.pc, cpu_type, entry_watched) {
+                // A clean link already performed this exact slot lookup;
+                // guarded and seeded exits need it once. Keep the compiled
+                // steady state in this caller so it does not pay an outlined
+                // admission-helper call merely to return `Chain`.
+                let exit_seed = if clean_link_exit || self.compiled_head_at(cpu.pc, cpu_type) {
+                    if entry_watched {
+                        ExitSeed::None
+                    } else {
+                        ExitSeed::Chain
+                    }
+                } else {
+                    self.note_trace_exit(cpu.pc, cpu_type, entry_watched)
+                };
+                match exit_seed {
                     ExitSeed::Chain => {
                         match self.try_execute(
                             cpu,

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -604,6 +604,15 @@ pub(crate) enum JitTraceOp {
         value: u32,
         dst: JitEa,
     },
+    /// `ANDI.B #imm,d8(An,Xn)` through checked fast memory. This is the
+    /// dominant unsupported trace terminal in the profiled SimCity 2000
+    /// workload. Both extension words are captured while recording; every
+    /// address and self-modification guard passes before the read-modify-
+    /// write or condition-code update commits.
+    AndImmByteMem {
+        immediate: u8,
+        dst: JitEa,
+    },
     /// CMPA.W/L through `(An)` or `d16(An)`. Unlike ordinary CMP, the
     /// destination is always the full address register and a word source is
     /// sign-extended before the 32-bit comparison.
@@ -2928,6 +2937,7 @@ impl TraceJit {
                     JitTraceOp::AluMemToReg { .. }
                         | JitTraceOp::CmpiWordMem { .. }
                         | JitTraceOp::CmpiByteAbs { .. }
+                        | JitTraceOp::AndImmByteMem { .. }
                         | JitTraceOp::AddrCmpMemToReg { .. }
                         | JitTraceOp::AddaMemToReg { .. }
                 )
@@ -2964,6 +2974,7 @@ impl TraceJit {
                     | JitTraceOp::TstMem { .. }
                     | JitTraceOp::ClrMem { .. }
                     | JitTraceOp::MoveImmMem { .. }
+                    | JitTraceOp::AndImmByteMem { .. }
                     | JitTraceOp::AddrCmpMemToReg { .. }
                     | JitTraceOp::AddaMemToReg { .. }
                     | JitTraceOp::AddRegToMem { .. }
@@ -3369,6 +3380,12 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("MoveImmMem implies a window env");
                         emit_move_imm_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
+                    JitTraceOp::AndImmByteMem { .. } => {
+                        let env = mem_env
+                            .as_ref()
+                            .expect("AndImmByteMem implies a window env");
+                        emit_and_imm_byte_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
                     JitTraceOp::AddrCmpMemToReg { .. } => {
                         let env = mem_env
                             .as_ref()
@@ -3761,6 +3778,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::ClrMem { .. }
             | JitTraceOp::MoveImmReg { .. }
             | JitTraceOp::MoveImmMem { .. }
+            | JitTraceOp::AndImmByteMem { .. }
             | JitTraceOp::CallThrough { .. }
             | JitTraceOp::CallExit { .. }
             | JitTraceOp::RtsReturn { .. }
@@ -4221,6 +4239,9 @@ impl JitTraceOp {
                 (_, JitEa::Disp(_, _)) => 16,
                 _ => 12,
             },
+            // M68000 immediate ALU to memory: twelve-cycle byte/word base
+            // plus the ten-cycle brief-indexed destination read/EA cost.
+            Self::AndImmByteMem { .. } => 22,
             Self::AddrCmpMemToReg { .. } => 24,
             // MC68000 ADDA: word base 8, long-memory base 6, plus the
             // source EA fetch (4/8 for (An), 8/12 for d16(An)). Memory
@@ -4336,6 +4357,7 @@ fn is_if_convertible_block_op(op: &JitTraceOp) -> bool {
             | JitTraceOp::TstMem { .. }
             | JitTraceOp::ClrMem { .. }
             | JitTraceOp::MoveImmMem { .. }
+            | JitTraceOp::AndImmByteMem { .. }
             | JitTraceOp::AddrCmpMemToReg { .. }
             | JitTraceOp::AddRegToMem { .. }
             | JitTraceOp::MemAddqSubq { .. }
@@ -4391,6 +4413,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_binary_immediate_data_reg_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_andi_byte_index_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_bit_imm_reg_trace_op(cpu, bus, pc, opcode) {
@@ -5397,6 +5422,39 @@ fn decode_move_imm_mem_trace_op<B: AddressBus>(
     })
 }
 
+/// Decode the measured `ANDI.B #imm,d8(An,Xn)` trace blocker. Keeping the
+/// admission deliberately byte/index-only matches the profiled form and
+/// avoids growing the native emitter for unmeasured sizes or destinations.
+fn decode_andi_byte_index_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    let DecodedMemOp::AluImm {
+        op: BinaryOp::And,
+        size: Size::Byte,
+        dst: FastEa::AnIndex(base),
+    } = DecodedMemOp::decode(cpu_type, opcode)?
+    else {
+        return None;
+    };
+    let immediate_word = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+    let brief = bus.try_read_word(cpu.address(pc.wrapping_add(4))).ok()?;
+    let dst = decode_jit_ea(6, u16::from(base), brief, cpu_type)?;
+    Some(TraceBuildOp {
+        opcode,
+        extension: Some(immediate_word),
+        extension2: Some(brief),
+        pc,
+        op: JitTraceOp::AndImmByteMem {
+            immediate: immediate_word as u8,
+            dst,
+        },
+    })
+}
+
 fn decode_move_mem_trace_op<B: AddressBus>(
     cpu: &CpuCore,
     bus: &mut B,
@@ -5983,6 +6041,9 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     }
     if matches!(op.op, JitTraceOp::MoveImmMem { .. }) {
         return execute_portable_move_imm_mem(cpu, op, spans);
+    }
+    if matches!(op.op, JitTraceOp::AndImmByteMem { .. }) {
+        return execute_portable_and_imm_byte_mem(cpu, op, spans);
     }
     if matches!(op.op, JitTraceOp::AddrCmpMemToReg { .. }) {
         return execute_portable_addr_cmp_mem_to_reg(cpu, op);
@@ -6647,6 +6708,53 @@ fn execute_portable_move_imm_mem(
     }
     write(cpu, off, value);
     cpu.set_logic_flags(value, size);
+    Some(trace.op.max_cycles())
+}
+
+#[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
+fn execute_portable_and_imm_byte_mem(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    spans: CodeSpans,
+) -> Option<i32> {
+    let JitTraceOp::AndImmByteMem { immediate, dst } = trace.op else {
+        return None;
+    };
+    let JitEa::Index {
+        base,
+        index,
+        index_long,
+        scale,
+        displacement,
+    } = dst
+    else {
+        return None;
+    };
+    let base_value = cpu.dar[8 + base as usize];
+    let raw_index = match index {
+        JitDirectReg::Addr(reg) => cpu.dar[8 + reg as usize],
+        JitDirectReg::Data(reg) => cpu.dar[reg as usize],
+    };
+    let index_value = if index_long {
+        raw_index
+    } else {
+        raw_index as u16 as i16 as i32 as u32
+    };
+    let raw = base_value
+        .wrapping_add(index_value << scale)
+        .wrapping_add(displacement as i32 as u32);
+    if cpu.fm_len == 0 {
+        return None;
+    }
+    let masked = raw & cpu.address_mask;
+    let off = masked.wrapping_sub(cpu.fm_base);
+    if off >= cpu.fm_len || spans.store_hits_code(masked, 1) {
+        return None;
+    }
+    let ptr = unsafe { (cpu.fm_ptr as *mut u8).add(off as usize) };
+    let result = unsafe { *ptr } & immediate;
+    unsafe { *ptr = result };
+    cpu.set_logic_flags(u32::from(result), Size::Byte);
     Some(trace.op.max_cycles())
 }
 
@@ -7581,6 +7689,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::MoveImmMem { .. } => {
             unreachable!("MoveImmMem is handled by execute_portable_move_imm_mem")
         }
+        JitTraceOp::AndImmByteMem { .. } => {
+            unreachable!("AndImmByteMem is handled by execute_portable_and_imm_byte_mem")
+        }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is handled by execute_portable_addr_cmp_mem_to_reg")
         }
@@ -8287,6 +8398,9 @@ fn emit_jit_op(
         JitTraceOp::MoveImmMem { .. } => {
             unreachable!("MoveImmMem is emitted by emit_move_imm_mem")
         }
+        JitTraceOp::AndImmByteMem { .. } => {
+            unreachable!("AndImmByteMem is emitted by emit_and_imm_byte_mem")
+        }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             unreachable!("AddrCmpMemToReg is emitted by emit_addr_cmp_mem_to_reg")
         }
@@ -8925,6 +9039,63 @@ fn emit_move_imm_mem(
     let value = iconst_u32(builder, value);
     window_store(builder, env, off, size, value);
     set_logic_flags(builder, cpu, value, size);
+    cycles_const(builder, trace.op.max_cycles())
+}
+
+/// Emit `ANDI.B #imm,d8(An,Xn)`. The address passes the window and
+/// code-overlap guards before the read-modify-write and flag updates, so a
+/// bail leaves both memory and architectural state untouched.
+#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+fn emit_and_imm_byte_mem(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::AndImmByteMem { immediate, dst } = trace.op else {
+        unreachable!("expected an indexed immediate AND trace")
+    };
+    let JitEa::Index {
+        base,
+        index,
+        index_long,
+        scale,
+        displacement,
+    } = dst
+    else {
+        unreachable!("ANDI.B decoder admitted an unsupported EA")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let base = load_reg(builder, cpu, JitDirectReg::Addr(base));
+    let raw_index = load_reg(builder, cpu, index);
+    let index = if index_long {
+        raw_index
+    } else {
+        let word = builder.ins().ireduce(types::I16, raw_index);
+        builder.ins().sextend(types::I32, word)
+    };
+    let index = if scale == 0 {
+        index
+    } else {
+        builder.ins().ishl_imm(index, i64::from(scale))
+    };
+    let address = builder.ins().iadd(base, index);
+    let address = builder.ins().iadd_imm(address, displacement as i64);
+    let (off, masked) = checked_window_off(builder, env, bail, address, Size::Byte);
+    guard_store_not_code(builder, env, bail, masked, Size::Byte);
+    let old = window_load(builder, env, off, Size::Byte);
+    let immediate = iconst_u32(builder, u32::from(immediate));
+    let result = builder.ins().band(old, immediate);
+    window_store(builder, env, off, Size::Byte, result);
+    set_logic_flags(builder, cpu, result, Size::Byte);
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -9836,6 +10007,9 @@ fn emit_block_op(
         }
         JitTraceOp::MoveImmMem { .. } => {
             emit_move_imm_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
+        }
+        JitTraceOp::AndImmByteMem { .. } => {
+            emit_and_imm_byte_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
         }
         JitTraceOp::AddrCmpMemToReg { .. } => {
             emit_addr_cmp_mem_to_reg(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
@@ -15609,6 +15783,166 @@ mod portable_tests {
             !matches!(t.map(|t| t.op), Some(JitTraceOp::MoveImmMem { .. })),
             "long immediate to an indexed destination must stay decoded"
         );
+    }
+
+    #[test]
+    fn andi_byte_index_decodes_the_profiled_trace_blocker() {
+        let mut dcpu = cpu();
+        dcpu.set_cpu_type(CpuType::M68040);
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        bus.write_word(0x0100, 0x0231); // ANDI.B #imm,(d8,A1,D3.W)
+        bus.write_word(0x0102, 0x00B7);
+        bus.write_word(0x0104, 0x3000);
+        let trace = decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040)
+            .expect("profiled ANDI.B indexed form should decode");
+        assert_eq!(
+            (trace.extension, trace.extension2),
+            (Some(0x00B7), Some(0x3000))
+        );
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::AndImmByteMem {
+                immediate: 0xB7,
+                dst: JitEa::Index {
+                    base: 1,
+                    index: JitDirectReg::Data(3),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 0,
+                },
+            }
+        ));
+
+        // Full-format indexed extensions on 68020+ retain their existing
+        // fallback; the narrow trace op only handles the brief form.
+        bus.write_word(0x0104, 0x3100);
+        assert!(decode_trace_op(&dcpu, &mut bus, 0x0100, CpuType::M68040).is_none());
+    }
+
+    #[test]
+    fn andi_byte_index_matches_the_interpreter_with_exact_68000_cycles() {
+        let words = [0x0231u16, 0x00B7, 0x3000];
+        let setup = |cpu: &mut CpuCore| {
+            cpu.set_cpu_type(CpuType::M68000);
+            cpu.set_a(1, 0x0300);
+            cpu.set_d(3, 4);
+            cpu.set_ccr(0x10); // X is unaffected by ANDI.
+            cpu.pc = 0x0100;
+        };
+
+        let mut ibus = super::super::memory::LinearMemoryBus::new(0x1000);
+        for (index, word) in words.iter().enumerate() {
+            ibus.write_word(0x0100 + index as u32 * 2, *word);
+        }
+        ibus.write_byte(0x0304, 0xF3);
+        let mut icpu = cpu();
+        setup(&mut icpu);
+        let icycles = match icpu.step(&mut ibus) {
+            super::super::types::StepResult::Ok { cycles } => cycles,
+            other => panic!("interpreter step failed: {other:?}"),
+        };
+
+        let mut pmem = vec![0u8; 0x1000];
+        for (index, word) in words.iter().enumerate() {
+            pmem[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
+        }
+        pmem[0x0304] = 0xF3;
+        let mut pcpu = cpu();
+        setup(&mut pcpu);
+        attach_window(&mut pcpu, &mut pmem);
+        let trace = decode_trace_op(&pcpu, &mut ibus, 0x0100, CpuType::M68000)
+            .expect("ANDI.B indexed form should decode");
+        let pcycles = execute_portable_op(&mut pcpu, trace, CodeSpans::caller(0x0100, 0x0106))
+            .expect("portable trace op should execute");
+
+        assert_eq!(pcycles, icycles);
+        assert_eq!(icycles, 22);
+        assert_eq!(pmem[0x0304], 0xB3);
+        assert_eq!(pmem[0x0304], ibus.read_byte(0x0304));
+        assert_eq!(pcpu.dar, icpu.dar);
+        assert_eq!(pcpu.get_ccr(), icpu.get_ccr());
+        assert_ne!(pcpu.get_ccr() & 0x10, 0, "X preserved");
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_andi_byte_index_matches_portable_and_bails_on_code_overlap() {
+        let andi = TraceBuildOp {
+            opcode: 0x0231,
+            extension: Some(0x00B7),
+            extension2: Some(0x3000),
+            pc: 0x0100,
+            op: JitTraceOp::AndImmByteMem {
+                immediate: 0xB7,
+                dst: JitEa::Index {
+                    base: 1,
+                    index: JitDirectReg::Data(3),
+                    index_long: false,
+                    scale: 0,
+                    displacement: 0,
+                },
+            },
+        };
+        let branch = TraceBuildOp {
+            opcode: 0x60F8,
+            extension: None,
+            extension2: None,
+            pc: 0x0106,
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -8,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+        let ops = vec![andi, branch];
+        let prepare = |mem: &mut Vec<u8>| {
+            let mut cpu = cpu();
+            cpu.set_cpu_type(CpuType::M68040);
+            cpu.set_a(1, 0x0300);
+            cpu.set_d(3, 4);
+            cpu.set_ccr(0x10);
+            mem[0x0304] = 0xF3;
+            attach_window(&mut cpu, mem);
+            cpu
+        };
+
+        let mut pmem = vec![0u8; 0x1000];
+        let mut portable = prepare(&mut pmem);
+        let expected =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(0x0100, 0x0108));
+        let mut nmem = vec![0u8; 0x1000];
+        let mut native = prepare(&mut nmem);
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&native, 0x0100, CpuType::M68040, ops.clone(), Some(0x0100))
+            .expect("ANDI.B loop should compile");
+        let actual = unsafe { compiled.call_native(&mut native, 1) };
+        assert_eq!(actual, expected, "cycles/retired");
+        assert_eq!(native.dar, portable.dar);
+        assert_eq!(native.get_ccr(), portable.get_ccr());
+        assert_eq!(nmem, pmem);
+        assert_eq!(nmem[0x0304], 0xB3);
+
+        // Aim the store into its own immediate word. Both executors must
+        // bail before touching memory or flags.
+        let overlap = |mem: &mut Vec<u8>| {
+            let mut cpu = prepare(mem);
+            cpu.set_a(1, 0x0102);
+            cpu.set_d(3, 0);
+            cpu
+        };
+        let mut pbail_mem = vec![0u8; 0x1000];
+        let mut pbail = overlap(&mut pbail_mem);
+        let packed = execute_portable_trace(&mut pbail, &ops, CodeSpans::caller(0x0100, 0x0108));
+        assert_eq!(packed, 0);
+        assert_eq!(pbail.get_ccr(), 0x10);
+        let mut nbail_mem = vec![0u8; 0x1000];
+        let mut nbail = overlap(&mut nbail_mem);
+        let packed = unsafe { compiled.call_native(&mut nbail, 1) };
+        assert_eq!(packed, 0);
+        assert_eq!(nbail.get_ccr(), 0x10);
+        assert_eq!(nbail_mem, pbail_mem);
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -493,6 +493,15 @@ pub(crate) enum JitTraceOp {
         return_pc: u32,
         cycles: i32,
     },
+    /// A nested call at the recorder's one-level depth cap. Execute the
+    /// architectural push, land at the observed static callee, and end the
+    /// trace there; normal exit seeding can then compile or chain that callee
+    /// without adding work to interpreted call dispatch.
+    CallExit {
+        return_pc: u32,
+        target_pc: u32,
+        cycles: i32,
+    },
     /// The callee's RTS: pops the return address and bails unless it
     /// equals the recorded call's return -- a different return value is
     /// a different flow. Checked before the stack pointer moves.
@@ -894,6 +903,11 @@ struct CompiledTrace {
     /// iterations.
     #[cfg_attr(all(feature = "jit", not(target_family = "wasm")), allow(dead_code))]
     self_loop: bool,
+    /// A clean completion should seed candidacy at its exit (a dynamic
+    /// return continuation or a forward nested-call callee). Computed once
+    /// when the trace is built instead of decoding the last op on every
+    /// native entry.
+    seeded_exit: bool,
     /// The native body was generated as a counted loop. Short read/write
     /// MoveMem loops deliberately retain the original one-pass body: the
     /// extra loop-carried state costs more than the saved call boundary.
@@ -1329,10 +1343,7 @@ impl TraceJit {
             // head, which a fresh continuation never is, so without this
             // the continuations after a returning subroutine would only
             // ever compile by luck of a backward branch.
-            let ends_in_return_exit = trace
-                .ops
-                .last()
-                .is_some_and(|op| matches!(op.op, JitTraceOp::ReturnExit { .. }));
+            let ends_in_seeded_exit = trace.seeded_exit;
             // A generated loop clearly amortizes the ABI boundary for
             // profiled mixed 3+-op and read-only loops. A
             // two-op read/write MoveMem loop is already dominated by its two
@@ -1544,12 +1555,12 @@ impl TraceJit {
             if clean_link_exit {
                 super::trace_profile::note_link_exit(pc, cpu_type);
             }
-            // A clean ReturnExit completion seeds its dynamic target
-            // (each caller's continuation) even when nothing is compiled
-            // there yet; see `ends_in_return_exit` above.
-            let return_exit_completion =
-                ends_in_return_exit && !guarded_branch_exit && !partial_call_this_entry;
-            if (guarded_branch_exit || clean_link_exit || return_exit_completion)
+            // A clean ReturnExit completion seeds its dynamic continuation;
+            // a CallExit similarly seeds the static nested callee that the
+            // recorder could not include at its one-level depth cap.
+            let seeded_exit_completion =
+                ends_in_seeded_exit && !guarded_branch_exit && !partial_call_this_entry;
+            if (guarded_branch_exit || clean_link_exit || seeded_exit_completion)
                 && !single_iter
                 && chain_budget > 0
                 && cpu.pc != pc
@@ -2494,9 +2505,24 @@ impl TraceJit {
                 JitTraceOp::CallThrough { return_pc, .. } => {
                     let recording = self.recording.as_mut().unwrap();
                     if recording.pending_return.is_some() {
-                        // Depth cap: a nested call ends the region at the
-                        // outer callee's boundary.
-                        self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        // A forward nested call has no backward edge to seed
+                        // its callee independently. Make the call itself the
+                        // trace terminal so the normal compiled-exit path can
+                        // seed and eventually chain the callee. Backward
+                        // callees keep the existing edge-admission behavior.
+                        if next_pc > executed_pc {
+                            recording.ops.push(TraceBuildOp {
+                                op: JitTraceOp::CallExit {
+                                    return_pc,
+                                    target_pc: next_pc,
+                                    cycles: call_op.op.max_cycles(),
+                                },
+                                ..call_op
+                            });
+                            self.finish_recording(cpu, next_pc, RecordingEnd::Region);
+                        } else {
+                            self.finish_recording(cpu, executed_pc, RecordingEnd::Region);
+                        }
                         return;
                     }
                     // The caller's recorded bytes and the callee's each get
@@ -2851,7 +2877,9 @@ impl TraceJit {
         let ends_in_dynamic_exit = ops.last().is_some_and(|op| {
             matches!(
                 op.op,
-                JitTraceOp::IndirectJsr { .. } | JitTraceOp::ReturnExit { .. }
+                JitTraceOp::IndirectJsr { .. }
+                    | JitTraceOp::ReturnExit { .. }
+                    | JitTraceOp::CallExit { .. }
             )
         });
         if ends_in_dynamic_exit && ops.len() < TRACE_MIN_INDIRECT_JSR_OPS {
@@ -2929,6 +2957,7 @@ impl TraceJit {
                     | JitTraceOp::AnDispBit { .. }
                     | JitTraceOp::IndirectJsr { .. }
                     | JitTraceOp::CallThrough { .. }
+                    | JitTraceOp::CallExit { .. }
                     | JitTraceOp::RtsReturn { .. }
                     | JitTraceOp::ReturnExit { .. }
             )
@@ -3370,7 +3399,7 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("Unlk implies a window env");
                         emit_unlk(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
-                    JitTraceOp::CallThrough { .. } => {
+                    JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
                         let env = mem_env.as_ref().expect("CallThrough implies a window env");
                         emit_call_through(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
@@ -3494,6 +3523,12 @@ impl TraceJit {
         };
 
         let guarded_ops = guarded_op_mask(ops);
+        let seeded_exit = ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: start_pc,
             cpu_type,
@@ -3502,6 +3537,7 @@ impl TraceJit {
             code_segments,
             max_cycles,
             self_loop,
+            seeded_exit,
             native_loop,
             callee_start,
             callee_end,
@@ -3520,6 +3556,12 @@ impl TraceJit {
     #[cfg(any(not(feature = "jit"), target_family = "wasm"))]
     fn compile_ops(&mut self, params: CompileParams<'_>) -> Option<CompiledTrace> {
         let guarded_ops = guarded_op_mask(params.ops);
+        let seeded_exit = params.ops.last().is_some_and(|op| {
+            matches!(
+                op.op,
+                JitTraceOp::ReturnExit { .. } | JitTraceOp::CallExit { .. }
+            )
+        });
         Some(CompiledTrace {
             pc: params.start_pc,
             cpu_type: params.cpu_type,
@@ -3530,6 +3572,7 @@ impl TraceJit {
             code_segments: params.code_segments,
             max_cycles: params.max_cycles,
             self_loop: params.self_loop,
+            seeded_exit,
             needs_window: params.needs_window,
             code_start: params.code_start,
             code_end: params.code_end,
@@ -3684,6 +3727,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::MoveImmReg { .. }
             | JitTraceOp::MoveImmMem { .. }
             | JitTraceOp::CallThrough { .. }
+            | JitTraceOp::CallExit { .. }
             | JitTraceOp::RtsReturn { .. }
             | JitTraceOp::ReturnExit { .. } => return false,
         }
@@ -4174,7 +4218,7 @@ impl JitTraceOp {
             Self::Unlk { .. } => 12,
             // MC68000 BSR is 18(2/2) for every displacement width; RTS is
             // 16(4/0).
-            Self::CallThrough { cycles, .. } => cycles,
+            Self::CallThrough { cycles, .. } | Self::CallExit { cycles, .. } => cycles,
             Self::RtsReturn { .. } => 16,
             Self::ReturnExit { cycles, .. } => cycles,
         }
@@ -4186,6 +4230,7 @@ impl JitTraceOp {
             Self::Branch { .. }
                 | Self::Dbcc { .. }
                 | Self::IndirectJsr { .. }
+                | Self::CallExit { .. }
                 | Self::PcIndexJmp {
                     expected_target: Some(_),
                     ..
@@ -5865,7 +5910,10 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     if matches!(op.op, JitTraceOp::Unlk { .. }) {
         return execute_portable_unlk(cpu, op);
     }
-    if matches!(op.op, JitTraceOp::CallThrough { .. }) {
+    if matches!(
+        op.op,
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. }
+    ) {
         return execute_portable_call_through(cpu, op, spans);
     }
     if matches!(op.op, JitTraceOp::RtsReturn { .. }) {
@@ -7427,7 +7475,7 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::Link { .. } | JitTraceOp::Unlk { .. } => {
             unreachable!("LINK/UNLK are handled by execute_portable_link/unlk")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is handled by execute_portable_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -8133,7 +8181,7 @@ fn emit_jit_op(
         JitTraceOp::PeaInd { .. } | JitTraceOp::PeaDisp { .. } | JitTraceOp::PeaAbs { .. } => {
             unreachable!("PEA is emitted by emit_pea_disp")
         }
-        JitTraceOp::CallThrough { .. } => {
+        JitTraceOp::CallThrough { .. } | JitTraceOp::CallExit { .. } => {
             unreachable!("CallThrough is emitted by emit_call_through")
         }
         JitTraceOp::RtsReturn { .. } => {
@@ -9098,8 +9146,14 @@ fn emit_call_through(
     bails: &mut Vec<BailReq>,
     at: BailAt,
 ) -> Value {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        unreachable!("expected a call-through trace op")
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => unreachable!("expected a call-through or call-exit trace op"),
     };
     let bail = builder.create_block();
     bails.push(BailReq {
@@ -9114,6 +9168,10 @@ fn emit_call_through(
     let value = iconst_u32(builder, return_pc);
     window_store(builder, env, off, Size::Long, value);
     store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
+    if let Some(target_pc) = exit_target {
+        store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
+        store_u32(builder, cpu, offset_of!(CpuCore, pc), target_pc);
+    }
     cycles_const(builder, trace.op.max_cycles())
 }
 
@@ -9195,8 +9253,14 @@ fn execute_portable_call_through(
     trace: TraceBuildOp,
     spans: CodeSpans,
 ) -> Option<i32> {
-    let JitTraceOp::CallThrough { return_pc, .. } = trace.op else {
-        return None;
+    let (return_pc, exit_target) = match trace.op {
+        JitTraceOp::CallThrough { return_pc, .. } => (return_pc, None),
+        JitTraceOp::CallExit {
+            return_pc,
+            target_pc,
+            ..
+        } => (return_pc, Some(target_pc)),
+        _ => return None,
     };
     if cpu.fm_len == 0 {
         return None;
@@ -9222,6 +9286,10 @@ fn execute_portable_call_through(
         *p.add(3) = b[3];
     }
     cpu.dar[15] = new_sp;
+    if let Some(target_pc) = exit_target {
+        cpu.change_of_flow = true;
+        cpu.pc = target_pc;
+    }
     Some(trace.op.max_cycles())
 }
 
@@ -17094,6 +17162,128 @@ mod portable_tests {
             },
         });
         ops
+    }
+
+    #[test]
+    fn forward_nested_call_becomes_an_executing_seeded_exit() {
+        const HEAD: u32 = 0x0100;
+        const CALL_PC: u32 = 0x010C;
+        const TARGET: u32 = 0x0180;
+        const RETURN: u32 = 0x010E;
+
+        let mut prefix = rts_region_ops(TRACE_MIN_INDIRECT_JSR_OPS);
+        prefix.pop();
+        let mut recording_cpu = cpu();
+        let mut bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        // BSR.S +0x72: base is RETURN, destination is TARGET.
+        bus.write_word(CALL_PC, 0x6172);
+        recording_cpu.ir = 0x6172;
+        recording_cpu.pc = TARGET;
+        recording_cpu.trace_recording = true;
+
+        let mut jit = TraceJit::new();
+        // This test is about the depth-cap terminal, not first-pass linear
+        // admission, so treat the shape as already deferred once.
+        jit.defer_linear_compilation(HEAD);
+        jit.recording = Some(TraceRecording {
+            start_pc: HEAD,
+            cpu_type: CpuType::M68000,
+            ops: prefix,
+            adaptive_rerecords: 0,
+            allow_call_through: true,
+            pending_return: Some(0x0200),
+            skip_record_until: None,
+            from_exit_seed: false,
+        });
+        jit.record_executed(&mut recording_cpu, &mut bus, CALL_PC, TARGET);
+
+        let TraceSlot::Compiled(trace) = &jit.slots[trace_cache_index(HEAD)] else {
+            panic!("the forward nested-call region should compile");
+        };
+        assert!(matches!(
+            trace.ops.last().unwrap().op,
+            JitTraceOp::CallExit {
+                return_pc: RETURN,
+                target_pc: TARGET,
+                cycles: 18,
+            }
+        ));
+        assert!(trace.seeded_exit);
+        assert_eq!(
+            (trace.code_start, trace.code_end),
+            (HEAD, RETURN),
+            "the terminal call bytes belong to the caller snapshot"
+        );
+        assert_eq!(
+            (trace.callee_start, trace.callee_end),
+            (0, 0),
+            "CallExit does not pretend the separately compiled callee is inline"
+        );
+        let ops = trace.ops.clone();
+
+        let mut portable_memory = vec![0u8; 0x1000];
+        let mut portable = cpu();
+        attach_window(&mut portable, &mut portable_memory);
+        portable.set_a(7, 0x0800);
+        portable.change_of_flow = false;
+        let portable_packed =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!(
+            (portable_packed >> 32) as u32,
+            TRACE_MIN_INDIRECT_JSR_OPS as u32
+        );
+        assert_eq!(portable_packed as u32 as i32, 42); // six MOVEQs + BSR
+        assert_eq!(portable.a(7), 0x07FC);
+        assert_eq!(&portable_memory[0x07FC..0x0800], &RETURN.to_be_bytes());
+        assert_eq!(portable.pc, TARGET);
+        assert!(portable.change_of_flow);
+
+        // The push is a checked operation. If its address is outside the
+        // active window, the prefix remains committed but the call itself
+        // must not change SP, PC, flow state, or memory; full dispatch will
+        // retry it at CALL_PC.
+        let prepare_bail = |memory: &mut Vec<u8>| {
+            let mut bail = cpu();
+            attach_window(&mut bail, memory);
+            bail.set_a(7, 2);
+            bail.pc = HEAD;
+            bail.change_of_flow = false;
+            bail
+        };
+        let mut portable_bail_memory = vec![0u8; 0x1000];
+        let mut portable_bail = prepare_bail(&mut portable_bail_memory);
+        let portable_bail_packed =
+            execute_portable_trace(&mut portable_bail, &ops, CodeSpans::caller(HEAD, RETURN));
+        assert_eq!((portable_bail_packed >> 32) as u32, ops.len() as u32 - 1);
+        assert_eq!(portable_bail_packed as u32 as i32, 24); // six MOVEQs only
+        assert_eq!(portable_bail.a(7), 2);
+        assert_eq!(portable_bail.pc, CALL_PC);
+        assert!(!portable_bail.change_of_flow);
+        assert!(portable_bail_memory.iter().all(|&byte| byte == 0));
+
+        #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+        {
+            let mut native_memory = vec![0u8; 0x1000];
+            let mut native = cpu();
+            attach_window(&mut native, &mut native_memory);
+            native.set_a(7, 0x0800);
+            native.change_of_flow = false;
+            let native_packed = unsafe { trace.call_native(&mut native, 1) };
+            assert_eq!(native_packed, portable_packed);
+            assert_eq!(native.dar, portable.dar);
+            assert_eq!(native.pc, portable.pc);
+            assert_eq!(native.change_of_flow, portable.change_of_flow);
+            assert_eq!(native_memory, portable_memory);
+
+            let mut native_bail_memory = vec![0u8; 0x1000];
+            let mut native_bail = prepare_bail(&mut native_bail_memory);
+            let native_bail_packed = unsafe { trace.call_native(&mut native_bail, 1) };
+            assert_eq!(native_bail_packed, portable_bail_packed);
+            assert_eq!(native_bail.dar, portable_bail.dar);
+            assert_eq!(native_bail.pc, portable_bail.pc);
+            assert_eq!(native_bail.change_of_flow, portable_bail.change_of_flow);
+            assert_eq!(native_bail_memory, portable_bail_memory);
+        }
     }
 
     #[test]

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -480,11 +480,11 @@ pub(crate) enum JitTraceOp {
         reg: u8,
         displacement: i16,
     },
-    /// Terminal `JSR (An)`. The target is dynamic, and the return address
-    /// store is checked against the active fastmem window before any CPU
-    /// state is committed.
+    /// Terminal `JSR (An)` / `JSR d16(An)`. The target is dynamic, and the
+    /// return-address store is checked against the active fastmem window
+    /// before any CPU state is committed.
     IndirectJsr {
-        reg: u8,
+        target: JitEa,
     },
     /// A BSR recorded THROUGH: pushes the constant return address and
     /// falls through to the callee's ops, which follow inline in the
@@ -3377,9 +3377,17 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("AddRegToMem implies a window env");
                         emit_add_reg_to_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
-                    JitTraceOp::IndirectJsr { reg } => {
+                    JitTraceOp::IndirectJsr { target } => {
                         let env = mem_env.as_ref().expect("IndirectJsr implies a window env");
-                        emit_indirect_jsr(&mut builder, cpu_ptr, *op, reg, env, &mut bails, bail_at)
+                        emit_indirect_jsr(
+                            &mut builder,
+                            cpu_ptr,
+                            *op,
+                            target,
+                            env,
+                            &mut bails,
+                            bail_at,
+                        )
                     }
                     JitTraceOp::MemAddqSubq { .. } => {
                         let env = mem_env.as_ref().expect("MemAddqSubq implies a window env");
@@ -4216,7 +4224,15 @@ impl JitTraceOp {
                 (_, JitEa::Disp(_, _)) => 16,
                 _ => 12,
             },
-            Self::IndirectJsr { .. } => 16,
+            Self::IndirectJsr {
+                target: JitEa::Ind(_),
+            } => 16,
+            // JSR d16(An) adds the displacement-extension fetch to the
+            // M68000's 16-cycle JSR (An) bound.
+            Self::IndirectJsr {
+                target: JitEa::Disp(_, _),
+            } => 18,
+            Self::IndirectJsr { .. } => unreachable!("JSR decoder admitted unsupported EA"),
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::MemAddqSubq { .. } | Self::AnDispUnary { .. } | Self::AnDispBit { .. } => 24,
@@ -4347,7 +4363,7 @@ fn decode_trace_op<B: AddressBus>(
     if let Some(op) = decode_branch_word_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
-    if let Some(op) = decode_indirect_jsr_trace_op(pc, opcode) {
+    if let Some(op) = decode_indirect_jsr_trace_op(cpu, bus, pc, opcode) {
         return Some(op);
     }
     if let Some(op) = decode_return_exit_trace_op(cpu, bus, pc, opcode, cpu_type) {
@@ -4768,18 +4784,29 @@ fn decode_movem_word_postinc_trace_op<B: AddressBus>(
     })
 }
 
-fn decode_indirect_jsr_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
-    if (opcode & 0xFFF8) != 0x4E90 {
-        return None;
-    }
+fn decode_indirect_jsr_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+) -> Option<TraceBuildOp> {
+    let (extension, target) = match opcode & 0xFFF8 {
+        0x4E90 => (None, JitEa::Ind((opcode & 7) as u8)),
+        0x4EA8 => {
+            let extension = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+            (
+                Some(extension),
+                JitEa::Disp((opcode & 7) as u8, extension as i16),
+            )
+        }
+        _ => return None,
+    };
     Some(TraceBuildOp {
         opcode,
-        extension: None,
+        extension,
         extension2: None,
         pc,
-        op: JitTraceOp::IndirectJsr {
-            reg: (opcode & 7) as u8,
-        },
+        op: JitTraceOp::IndirectJsr { target },
     })
 }
 
@@ -5947,8 +5974,8 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     ) {
         return execute_portable_an_disp(cpu, op, spans);
     }
-    if let JitTraceOp::IndirectJsr { reg } = op.op {
-        return execute_portable_indirect_jsr(cpu, op, reg);
+    if let JitTraceOp::IndirectJsr { target } = op.op {
+        return execute_portable_indirect_jsr(cpu, op, target);
     }
     Some(execute_portable_reg_op(cpu, op))
 }
@@ -6074,15 +6101,19 @@ fn execute_portable_movem_long_postinc(cpu: &mut CpuCore, trace: TraceBuildOp) -
 }
 
 #[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
-fn execute_portable_indirect_jsr(cpu: &mut CpuCore, trace: TraceBuildOp, reg: u8) -> Option<i32> {
+fn execute_portable_indirect_jsr(
+    cpu: &mut CpuCore,
+    trace: TraceBuildOp,
+    target: JitEa,
+) -> Option<i32> {
     let old_pc = cpu.pc;
     cpu.pc = trace.pc.wrapping_add(2);
-    if super::mem_ops::execute_mem_op(
-        cpu,
-        DecodedMemOp::Jsr {
-            ea: FastEa::AnInd(reg),
-        },
-    ) {
+    let ea = match target {
+        JitEa::Ind(reg) => FastEa::AnInd(reg),
+        JitEa::Disp(reg, _) => FastEa::AnDisp(reg),
+        _ => unreachable!("JSR decoder admitted unsupported EA"),
+    };
+    if super::mem_ops::execute_mem_op(cpu, DecodedMemOp::Jsr { ea }) {
         Some(trace.op.max_cycles())
     } else {
         cpu.pc = old_pc;
@@ -9112,16 +9143,17 @@ fn emit_add_reg_to_mem(
     cycles_const(builder, trace.op.max_cycles())
 }
 
-/// Emit terminal `JSR (An)`. The stack write is checked before the stack
-/// pointer, flow state, or PC changes, so a miss can re-execute the call via
-/// full dispatch. A successful call ends this non-self-loop trace; writing
-/// into its code is therefore safe because any later entry revalidates it.
+/// Emit terminal `JSR (An)` / `JSR d16(An)`. The stack write is checked before
+/// the stack pointer, flow state, or PC changes, so a miss can re-execute the
+/// call via full dispatch. A successful call ends this non-self-loop trace;
+/// writing into its code is therefore safe because any later entry revalidates
+/// it.
 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
 fn emit_indirect_jsr(
     builder: &mut FunctionBuilder<'_>,
     cpu: Value,
     trace: TraceBuildOp,
-    reg: u8,
+    target: JitEa,
     env: &MemEnv,
     bails: &mut Vec<BailReq>,
     at: BailAt,
@@ -9133,11 +9165,18 @@ fn emit_indirect_jsr(
         at,
     });
 
-    let target = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+    let target = match target {
+        JitEa::Ind(reg) => load_reg(builder, cpu, JitDirectReg::Addr(reg)),
+        JitEa::Disp(reg, displacement) => {
+            let base = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+            builder.ins().iadd_imm(base, i64::from(displacement))
+        }
+        _ => unreachable!("JSR decoder admitted unsupported EA"),
+    };
     let old_sp = load_reg(builder, cpu, JitDirectReg::Addr(7));
     let new_sp = builder.ins().iadd_imm(old_sp, -4);
     let (off, _) = checked_window_off(builder, env, bail, new_sp, Size::Long);
-    let return_pc = iconst_u32(builder, trace.pc.wrapping_add(2));
+    let return_pc = iconst_u32(builder, trace.pc.wrapping_add(trace.length() as u32));
     window_store(builder, env, off, Size::Long, return_pc);
 
     store_reg(builder, cpu, JitDirectReg::Addr(7), new_sp);
@@ -11871,8 +11910,26 @@ mod portable_tests {
         let jsr = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
         assert_eq!(jsr.extension, None);
         assert_eq!(jsr.length(), 2);
-        assert!(matches!(jsr.op, JitTraceOp::IndirectJsr { reg: 0 }));
+        assert!(matches!(
+            jsr.op,
+            JitTraceOp::IndirectJsr {
+                target: JitEa::Ind(0)
+            }
+        ));
         assert!(jsr.op.ends_trace());
+
+        mem.write_word(0x0100, 0x4EAD); // JSR -$0010(A5)
+        mem.write_word(0x0102, 0xFFF0);
+        let jsr = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jsr.extension, Some(0xFFF0));
+        assert_eq!(jsr.length(), 4);
+        assert_eq!(jsr.op.max_cycles(), 18);
+        assert!(matches!(
+            jsr.op,
+            JitTraceOp::IndirectJsr {
+                target: JitEa::Disp(5, -16)
+            }
+        ));
     }
 
     #[test]
@@ -11889,7 +11946,9 @@ mod portable_tests {
             extension: None,
             extension2: None,
             pc: 0x0100,
-            op: JitTraceOp::IndirectJsr { reg: 0 },
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Ind(0),
+            },
         };
         assert_eq!(
             execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0102)),
@@ -11897,6 +11956,35 @@ mod portable_tests {
         );
         assert_eq!(cpu.a(7), 0x07FC);
         assert_eq!(&mem[0x07FC..0x0800], &0x0102u32.to_be_bytes());
+        assert_eq!(cpu.pc, 0x0340);
+        assert!(cpu.change_of_flow);
+    }
+
+    #[test]
+    fn portable_displacement_jsr_uses_extension_extent_and_live_base() {
+        let mut cpu = cpu();
+        let mut mem = vec![0u8; 0x1000];
+        mem[0x0102..0x0104].copy_from_slice(&0xFFF0u16.to_be_bytes());
+        attach_window(&mut cpu, &mut mem);
+        cpu.set_a(5, 0x0350);
+        cpu.set_a(7, 0x0800);
+        cpu.change_of_flow = false;
+
+        let op = TraceBuildOp {
+            opcode: 0x4EAD,
+            extension: Some(0xFFF0),
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Disp(5, -16),
+            },
+        };
+        assert_eq!(
+            execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0104)),
+            Some(18)
+        );
+        assert_eq!(cpu.a(7), 0x07FC);
+        assert_eq!(&mem[0x07FC..0x0800], &0x0104u32.to_be_bytes());
         assert_eq!(cpu.pc, 0x0340);
         assert!(cpu.change_of_flow);
     }
@@ -11916,7 +12004,9 @@ mod portable_tests {
             extension: None,
             extension2: None,
             pc: 0x0100,
-            op: JitTraceOp::IndirectJsr { reg: 0 },
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Ind(0),
+            },
         };
         assert_eq!(
             execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0102)),
@@ -17015,7 +17105,9 @@ mod portable_tests {
                 extension: None,
                 extension2: None,
                 pc: 0x0100 + (count - 1) as u32 * 2,
-                op: JitTraceOp::IndirectJsr { reg: 0 },
+                op: JitTraceOp::IndirectJsr {
+                    target: JitEa::Ind(0),
+                },
             });
             ops
         };
@@ -17102,7 +17194,9 @@ mod portable_tests {
                 extension: None,
                 extension2: None,
                 pc: 0x010E,
-                op: JitTraceOp::IndirectJsr { reg: 0 },
+                op: JitTraceOp::IndirectJsr {
+                    target: JitEa::Ind(0),
+                },
             },
         ];
         let mut compile_cpu = cpu();
@@ -17147,6 +17241,72 @@ mod portable_tests {
         assert_eq!(bail.d(7), 0xA5A5_8000, "prefix remains committed");
         assert_eq!(bail.a(7), 2, "call itself did not commit");
         assert_eq!(bail.pc, 0x010E, "retry the unexecuted call");
+        assert!(!bail.change_of_flow);
+        assert!(bail_mem[0x07FC..0x0800].iter().all(|&byte| byte == 0));
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_displacement_jsr_uses_live_base_and_captured_displacement() {
+        let mut ops = Vec::new();
+        for index in 0..TRACE_MIN_INDIRECT_JSR_OPS - 1 {
+            ops.push(TraceBuildOp {
+                opcode: 0x7001,
+                extension: None,
+                extension2: None,
+                pc: 0x0100 + index as u32 * 2,
+                op: JitTraceOp::Moveq { reg: 0, data: 1 },
+            });
+        }
+        let call_pc = 0x0100 + (TRACE_MIN_INDIRECT_JSR_OPS as u32 - 1) * 2;
+        ops.push(TraceBuildOp {
+            opcode: 0x4EAD,
+            extension: Some(0x0010),
+            extension2: None,
+            pc: call_pc,
+            op: JitTraceOp::IndirectJsr {
+                target: JitEa::Disp(5, 0x0010),
+            },
+        });
+
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&cpu(), 0x0100, CpuType::M68000, ops, Some(0x0350))
+            .expect("displacement JSR region should compile");
+
+        let prepare = |stack: u32| {
+            let mut cpu = cpu();
+            let mut mem = vec![0u8; 0x1000];
+            attach_window(&mut cpu, &mut mem);
+            cpu.set_a(5, 0x0340);
+            cpu.set_a(7, stack);
+            cpu.change_of_flow = false;
+            (cpu, mem)
+        };
+
+        let (mut success, success_mem) = prepare(0x0800);
+        let packed = unsafe { compiled.call_native(&mut success, 1) };
+        assert_eq!((packed >> 32) as u32, TRACE_MIN_INDIRECT_JSR_OPS as u32);
+        assert_eq!(packed as u32 as i32, 42);
+        assert_eq!(success.a(7), 0x07FC);
+        assert_eq!(
+            &success_mem[0x07FC..0x0800],
+            &call_pc.wrapping_add(4).to_be_bytes()
+        );
+        assert_eq!(success.pc, 0x0350);
+        assert_eq!(success.ppc, call_pc);
+        assert_eq!(success.ir, 0x4EAD);
+        assert!(success.change_of_flow);
+
+        let (mut bail, bail_mem) = prepare(2);
+        let packed = unsafe { compiled.call_native(&mut bail, 1) };
+        assert_eq!(
+            (packed >> 32) as u32,
+            (TRACE_MIN_INDIRECT_JSR_OPS - 1) as u32
+        );
+        assert_eq!(packed as u32 as i32, 24);
+        assert_eq!(bail.a(7), 2);
+        assert_eq!(bail.pc, call_pc);
         assert!(!bail.change_of_flow);
         assert!(bail_mem[0x07FC..0x0800].iter().all(|&byte| byte == 0));
     }

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -577,6 +577,13 @@ pub(crate) enum JitTraceOp {
         immediate: u16,
         src: JitEa,
     },
+    /// Read-only `CMPI.B #imm,abs.W`, the hot absolute-byte table sentinel
+    /// used by SC2K. The immediate and sign-extended absolute address are
+    /// captured while recording; execution performs one checked byte load.
+    CmpiByteAbs {
+        immediate: u8,
+        address: u32,
+    },
     /// Read-only TST through a checked fast-memory effective address.
     TstMem {
         size: Size,
@@ -2920,6 +2927,7 @@ impl TraceJit {
                     op.op,
                     JitTraceOp::AluMemToReg { .. }
                         | JitTraceOp::CmpiWordMem { .. }
+                        | JitTraceOp::CmpiByteAbs { .. }
                         | JitTraceOp::AddrCmpMemToReg { .. }
                         | JitTraceOp::AddaMemToReg { .. }
                 )
@@ -2952,6 +2960,7 @@ impl TraceJit {
                     | JitTraceOp::MovemWordPostInc { .. }
                     | JitTraceOp::AluMemToReg { .. }
                     | JitTraceOp::CmpiWordMem { .. }
+                    | JitTraceOp::CmpiByteAbs { .. }
                     | JitTraceOp::TstMem { .. }
                     | JitTraceOp::ClrMem { .. }
                     | JitTraceOp::MoveImmMem { .. }
@@ -3344,6 +3353,10 @@ impl TraceJit {
                         let env = mem_env.as_ref().expect("CmpiWordMem implies a window env");
                         emit_cmpi_word_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
                     }
+                    JitTraceOp::CmpiByteAbs { .. } => {
+                        let env = mem_env.as_ref().expect("CmpiByteAbs implies a window env");
+                        emit_cmpi_byte_abs(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
+                    }
                     JitTraceOp::TstMem { .. } => {
                         let env = mem_env.as_ref().expect("TstMem implies a window env");
                         emit_tst_mem(&mut builder, cpu_ptr, *op, env, &mut bails, bail_at)
@@ -3686,6 +3699,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             // polled value is the only input that can change.
             JitTraceOp::TstMem { .. }
             | JitTraceOp::CmpiWordMem { .. }
+            | JitTraceOp::CmpiByteAbs { .. }
             | JitTraceOp::AddrCmpMemToReg { .. }
             | JitTraceOp::AluMemToReg {
                 op: JitBinaryOp::Cmp,
@@ -4171,6 +4185,9 @@ impl JitTraceOp {
                 ..
             } => 18,
             Self::CmpiWordMem { .. } => 16,
+            // CMPI.B #imm,abs.W has the same eight-cycle immediate base and
+            // eight-cycle absolute-word effective-address read.
+            Self::CmpiByteAbs { .. } => 16,
             // TST is a four-cycle operation plus the indexed EA read
             // (M68000UM); byte and word reads have the same EA cost.
             Self::TstMem { size, src } => match (size, src) {
@@ -4315,6 +4332,7 @@ fn is_if_convertible_block_op(op: &JitTraceOp) -> bool {
             | JitTraceOp::MoveMem { .. }
             | JitTraceOp::AluMemToReg { .. }
             | JitTraceOp::CmpiWordMem { .. }
+            | JitTraceOp::CmpiByteAbs { .. }
             | JitTraceOp::TstMem { .. }
             | JitTraceOp::ClrMem { .. }
             | JitTraceOp::MoveImmMem { .. }
@@ -4382,6 +4400,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_cmpi_word_mem_trace_op(cpu, bus, pc, opcode, cpu_type) {
+        return Some(op);
+    }
+    if let Some(op) = decode_cmpi_byte_abs_trace_op(cpu, bus, pc, opcode, cpu_type) {
         return Some(op);
     }
     if let Some(op) = decode_addr_cmp_immediate_trace_op(cpu, bus, pc, opcode, cpu_type) {
@@ -4707,6 +4728,40 @@ fn decode_cmpi_word_mem_trace_op<B: AddressBus>(
         extension2: Some(ea_extension),
         pc,
         op: JitTraceOp::CmpiWordMem { immediate, src },
+    })
+}
+
+/// Decode only the profiled absolute-word byte form. Keeping it distinct from
+/// `CmpiWordMem` leaves the representation and generated code of existing hot
+/// indexed word compares unchanged in other workloads.
+fn decode_cmpi_byte_abs_trace_op<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    pc: u32,
+    opcode: u16,
+    cpu_type: CpuType,
+) -> Option<TraceBuildOp> {
+    if !matches!(
+        DecodedMemOp::decode(cpu_type, opcode)?,
+        DecodedMemOp::AluImm {
+            op: BinaryOp::Cmp,
+            size: Size::Byte,
+            dst: FastEa::AbsW,
+        }
+    ) {
+        return None;
+    }
+    let immediate_word = bus.try_read_word(cpu.address(pc.wrapping_add(2))).ok()?;
+    let address_word = bus.try_read_word(cpu.address(pc.wrapping_add(4))).ok()?;
+    Some(TraceBuildOp {
+        opcode,
+        extension: Some(immediate_word),
+        extension2: Some(address_word),
+        pc,
+        op: JitTraceOp::CmpiByteAbs {
+            immediate: immediate_word as u8,
+            address: address_word as i16 as i32 as u32,
+        },
     })
 }
 
@@ -5917,6 +5972,9 @@ fn execute_portable_op(cpu: &mut CpuCore, op: TraceBuildOp, spans: CodeSpans) ->
     if matches!(op.op, JitTraceOp::CmpiWordMem { .. }) {
         return execute_portable_cmpi_word_mem(cpu, op);
     }
+    if matches!(op.op, JitTraceOp::CmpiByteAbs { .. }) {
+        return execute_portable_cmpi_byte_abs(cpu, op);
+    }
     if matches!(op.op, JitTraceOp::TstMem { .. }) {
         return execute_portable_tst_mem(cpu, op);
     }
@@ -6380,6 +6438,28 @@ fn execute_portable_cmpi_word_mem(cpu: &mut CpuCore, trace: TraceBuildOp) -> Opt
             op: BinaryOp::Cmp,
             size: Size::Word,
             dst,
+        },
+    ) {
+        Some(trace.op.max_cycles())
+    } else {
+        cpu.pc = old_pc;
+        None
+    }
+}
+
+#[cfg(any(not(feature = "jit"), target_family = "wasm", test))]
+fn execute_portable_cmpi_byte_abs(cpu: &mut CpuCore, trace: TraceBuildOp) -> Option<i32> {
+    if !matches!(trace.op, JitTraceOp::CmpiByteAbs { .. }) {
+        return None;
+    }
+    let old_pc = cpu.pc;
+    cpu.pc = trace.pc.wrapping_add(2);
+    if super::mem_ops::execute_mem_op(
+        cpu,
+        DecodedMemOp::AluImm {
+            op: BinaryOp::Cmp,
+            size: Size::Byte,
+            dst: FastEa::AbsW,
         },
     ) {
         Some(trace.op.max_cycles())
@@ -7489,6 +7569,9 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
         JitTraceOp::CmpiWordMem { .. } => {
             unreachable!("CmpiWordMem is handled by execute_portable_cmpi_word_mem")
         }
+        JitTraceOp::CmpiByteAbs { .. } => {
+            unreachable!("CmpiByteAbs is handled by execute_portable_cmpi_byte_abs")
+        }
         JitTraceOp::TstMem { .. } => {
             unreachable!("TstMem is handled by execute_portable_tst_mem")
         }
@@ -8191,6 +8274,9 @@ fn emit_jit_op(
         }
         JitTraceOp::CmpiWordMem { .. } => {
             unreachable!("CmpiWordMem is emitted by emit_cmpi_word_mem")
+        }
+        JitTraceOp::CmpiByteAbs { .. } => {
+            unreachable!("CmpiByteAbs is emitted by emit_cmpi_byte_abs")
         }
         JitTraceOp::TstMem { .. } => {
             unreachable!("TstMem is emitted by emit_tst_mem")
@@ -8989,6 +9075,37 @@ fn emit_cmpi_word_mem(
     cycles_const(builder, trace.op.max_cycles())
 }
 
+/// Emit the profiled absolute-word CMPI.B as one checked byte load and flag
+/// update. The address and immediate are constants captured in validated trace
+/// code; a window miss reaches the side exit before any flags change.
+#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+fn emit_cmpi_byte_abs(
+    builder: &mut FunctionBuilder<'_>,
+    cpu: Value,
+    trace: TraceBuildOp,
+    env: &MemEnv,
+    bails: &mut Vec<BailReq>,
+    at: BailAt,
+) -> Value {
+    let JitTraceOp::CmpiByteAbs { immediate, address } = trace.op else {
+        unreachable!("expected an absolute-byte CMPI trace")
+    };
+    let bail = builder.create_block();
+    bails.push(BailReq {
+        block: bail,
+        pc: trace.pc,
+        at,
+    });
+
+    let address = iconst_u32(builder, address);
+    let (off, _) = checked_window_off(builder, env, bail, address, Size::Byte);
+    let dst_value = window_load(builder, env, off, Size::Byte);
+    let immediate = iconst_u32(builder, u32::from(immediate));
+    let result = builder.ins().isub(dst_value, immediate);
+    set_cmp_flags(builder, cpu, immediate, dst_value, result, Size::Byte);
+    cycles_const(builder, 16)
+}
+
 /// Emit CMPA.W/L from checked guest memory. Address calculation and the
 /// fast-memory bounds/alignment checks precede every flag write, so a failed
 /// window access can fall back and re-execute the instruction atomically.
@@ -9707,6 +9824,9 @@ fn emit_block_op(
         }
         JitTraceOp::CmpiWordMem { .. } => {
             emit_cmpi_word_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
+        }
+        JitTraceOp::CmpiByteAbs { .. } => {
+            emit_cmpi_byte_abs(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
         }
         JitTraceOp::TstMem { .. } => {
             emit_tst_mem(builder, cpu_ptr, *op, mem_env.expect("env"), bails, bail_at)
@@ -12264,6 +12384,57 @@ mod portable_tests {
         assert_eq!(cpu.pc, 0x0106);
     }
 
+    #[test]
+    fn absolute_word_cmpi_byte_matches_the_68000_interpreter() {
+        let words = [0x0C38u16, 0x0042, 0x0320]; // CMPI.B #$42,$0320.W
+        let setup = |cpu: &mut CpuCore| {
+            cpu.set_cpu_type(CpuType::M68000);
+            cpu.set_ccr(0x10); // X must be preserved.
+            cpu.pc = 0x0100;
+        };
+
+        let mut interpreter_bus = super::super::memory::LinearMemoryBus::new(0x1000);
+        for (index, word) in words.iter().enumerate() {
+            interpreter_bus.write_word(0x0100 + index as u32 * 2, *word);
+        }
+        interpreter_bus.write_byte(0x0320, 0x41);
+        let mut interpreter = cpu();
+        setup(&mut interpreter);
+        let interpreter_cycles = match interpreter.step(&mut interpreter_bus) {
+            super::super::types::StepResult::Ok { cycles } => cycles,
+            other => panic!("interpreter CMPI.B failed: {other:?}"),
+        };
+
+        let mut memory = vec![0u8; 0x1000];
+        for (index, word) in words.iter().enumerate() {
+            memory[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
+        }
+        memory[0x0320] = 0x41;
+        let mut portable = cpu();
+        setup(&mut portable);
+        attach_window(&mut portable, &mut memory);
+        let trace = decode_trace_op(&portable, &mut interpreter_bus, 0x0100, CpuType::M68000)
+            .expect("absolute-word CMPI.B should decode");
+        assert_eq!(trace.extension, Some(0x0042));
+        assert_eq!(trace.extension2, Some(0x0320));
+        assert!(matches!(
+            trace.op,
+            JitTraceOp::CmpiByteAbs {
+                immediate: 0x42,
+                address: 0x0320,
+            }
+        ));
+        let portable_cycles =
+            execute_portable_op(&mut portable, trace, CodeSpans::caller(0x0100, 0x0106))
+                .expect("portable CMPI.B should execute");
+
+        assert_eq!(portable_cycles, interpreter_cycles);
+        assert_eq!(portable.pc, interpreter.pc);
+        assert_eq!(portable.get_ccr(), interpreter.get_ccr());
+        assert_eq!(portable.get_ccr(), 0x19, "X/N/C set, Z/V clear");
+        assert_eq!(memory[0x0320], 0x41, "CMPI is read-only");
+    }
+
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]
     #[test]
     fn native_indexed_cmpi_word_matches_portable_and_bails_atomically() {
@@ -12363,6 +12534,82 @@ mod portable_tests {
         assert_eq!(bailed.pc, 0x0100);
         assert_eq!(bailed.dar, before);
         assert_eq!(bailed.get_ccr(), 0x10);
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_absolute_word_cmpi_byte_matches_portable_and_bails_atomically() {
+        let compare = TraceBuildOp {
+            opcode: 0x0C38,
+            extension: Some(0x0042),
+            extension2: Some(0x0320),
+            pc: 0x0100,
+            op: JitTraceOp::CmpiByteAbs {
+                immediate: 0x42,
+                address: 0x0320,
+            },
+        };
+        let branch = TraceBuildOp {
+            opcode: 0x60F8,
+            extension: None,
+            extension2: None,
+            pc: 0x0106,
+            op: JitTraceOp::Branch {
+                condition: 0,
+                displacement: -8,
+                length: 2,
+                expected_taken: None,
+            },
+        };
+        let ops = [compare, branch];
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&cpu(), 0x0100, CpuType::M68000, ops.to_vec(), Some(0x0100))
+            .expect("absolute-word CMPI.B loop should compile");
+
+        let seed = |memory: &mut [u8]| {
+            for (index, word) in [0x0C38u16, 0x0042, 0x0320, 0x60F8].iter().enumerate() {
+                memory[0x0100 + index * 2..0x0102 + index * 2].copy_from_slice(&word.to_be_bytes());
+            }
+            memory[0x0320] = 0x41;
+        };
+
+        let mut portable_memory = vec![0u8; 0x1000];
+        seed(&mut portable_memory);
+        let mut portable = cpu();
+        portable.set_cpu_type(CpuType::M68000);
+        portable.set_ccr(0x10);
+        attach_window(&mut portable, &mut portable_memory);
+        let portable_packed =
+            execute_portable_trace(&mut portable, &ops, CodeSpans::caller(0x0100, 0x0108));
+
+        let mut native_memory = vec![0u8; 0x1000];
+        seed(&mut native_memory);
+        let mut native = cpu();
+        native.set_cpu_type(CpuType::M68000);
+        native.set_ccr(0x10);
+        attach_window(&mut native, &mut native_memory);
+        let native_packed = unsafe { compiled.call_native(&mut native, 1) };
+        assert_eq!(native_packed, portable_packed);
+        assert_eq!((native_packed >> 32) as u32, 2);
+        assert_eq!(native_packed as u32 as i32, 26);
+        assert_eq!(native.pc, 0x0100);
+        assert_eq!(native.get_ccr(), portable.get_ccr());
+        assert_eq!(native_memory[0x0320], 0x41);
+
+        let mut short_memory = vec![0u8; 0x0200];
+        for (index, word) in [0x0C38u16, 0x0042, 0x0320, 0x60F8].iter().enumerate() {
+            short_memory[0x0100 + index * 2..0x0102 + index * 2]
+                .copy_from_slice(&word.to_be_bytes());
+        }
+        let mut bail = cpu();
+        bail.set_cpu_type(CpuType::M68000);
+        bail.set_ccr(0x10);
+        attach_window(&mut bail, &mut short_memory);
+        let bail_packed = unsafe { compiled.call_native(&mut bail, 1) };
+        assert_eq!(bail_packed, 0);
+        assert_eq!(bail.pc, 0x0100);
+        assert_eq!(bail.get_ccr(), 0x10);
     }
 
     /// Word-read counting bus for the profiling bus-access regression.

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -485,6 +485,12 @@ pub(crate) enum JitTraceOp {
     IndirectJsr {
         target: JitEa,
     },
+    /// Terminal `JMP (An)`. Unlike an indirect call, this only transfers
+    /// control: there is no stack access, so a short region can still
+    /// amortize trace entry and validation.
+    IndirectJmp {
+        reg: u8,
+    },
     /// A BSR recorded THROUGH: pushes the constant return address and
     /// falls through to the callee's ops, which follow inline in the
     /// trace. Admitted only on a call-through retry recording.
@@ -2739,6 +2745,11 @@ impl TraceJit {
                 self.finish_recording(cpu, next_pc, RecordingEnd::Region);
                 return;
             }
+            JitTraceOp::IndirectJmp { .. } => {
+                self.recording.as_mut().unwrap().ops.push(op);
+                self.finish_recording(cpu, next_pc, RecordingEnd::Region);
+                return;
+            }
             // A bare return is the region's dynamic exit: the trace ends
             // here and execution continues at whatever address the guest
             // stack held (next_pc), which exit seeding turns into a
@@ -3759,6 +3770,7 @@ fn is_pure_poll_loop(ops: &[TraceBuildOp]) -> bool {
             | JitTraceOp::Swap { .. }
             | JitTraceOp::Dbcc { .. }
             | JitTraceOp::IndirectJsr { .. }
+            | JitTraceOp::IndirectJmp { .. }
             | JitTraceOp::MoveMem { .. }
             | JitTraceOp::MovemWordPostInc { .. }
             | JitTraceOp::AluMemToReg { .. }
@@ -4270,6 +4282,8 @@ impl JitTraceOp {
                 target: JitEa::Disp(_, _),
             } => 18,
             Self::IndirectJsr { .. } => unreachable!("JSR decoder admitted unsupported EA"),
+            // M68000UM control-address timing: JMP (An) is 8(2/0).
+            Self::IndirectJmp { .. } => 8,
             // These ops only execute in instruction-budgeted fastmem mode;
             // conservative cycle maxima preserve the trace headroom guard.
             Self::MemAddqSubq { .. } | Self::AnDispUnary { .. } | Self::AnDispBit { .. } => 24,
@@ -4296,6 +4310,7 @@ impl JitTraceOp {
             Self::Branch { .. }
                 | Self::Dbcc { .. }
                 | Self::IndirectJsr { .. }
+                | Self::IndirectJmp { .. }
                 | Self::CallExit { .. }
                 | Self::PcIndexJmp {
                     expected_target: Some(_),
@@ -4403,6 +4418,9 @@ fn decode_trace_op<B: AddressBus>(
         return Some(op);
     }
     if let Some(op) = decode_indirect_jsr_trace_op(cpu, bus, pc, opcode) {
+        return Some(op);
+    }
+    if let Some(op) = decode_indirect_jmp_trace_op(pc, opcode) {
         return Some(op);
     }
     if let Some(op) = decode_return_exit_trace_op(cpu, bus, pc, opcode, cpu_type) {
@@ -4886,6 +4904,21 @@ fn decode_indirect_jsr_trace_op<B: AddressBus>(
         extension2: None,
         pc,
         op: JitTraceOp::IndirectJsr { target },
+    })
+}
+
+fn decode_indirect_jmp_trace_op(pc: u32, opcode: u16) -> Option<TraceBuildOp> {
+    if (opcode & 0xFFF8) != 0x4ED0 {
+        return None;
+    }
+    Some(TraceBuildOp {
+        opcode,
+        extension: None,
+        extension2: None,
+        pc,
+        op: JitTraceOp::IndirectJmp {
+            reg: (opcode & 7) as u8,
+        },
     })
 }
 
@@ -7149,6 +7182,11 @@ fn execute_portable_reg_op(cpu: &mut CpuCore, op: TraceBuildOp) -> i32 {
             cpu.change_of_flow = true;
             14
         }
+        JitTraceOp::IndirectJmp { reg } => {
+            cpu.pc = cpu.a(reg as usize);
+            cpu.change_of_flow = true;
+            8
+        }
         JitTraceOp::Moveq { reg, data } => {
             cpu.dar[reg as usize] = data;
             cpu.n_flag = if (data as i32) < 0 { NFLAG_SET } else { 0 };
@@ -8452,6 +8490,12 @@ fn emit_jit_op(
         }
         JitTraceOp::IndirectJsr { .. } => {
             unreachable!("IndirectJsr is emitted by emit_indirect_jsr")
+        }
+        JitTraceOp::IndirectJmp { reg } => {
+            let target = load_reg(builder, cpu, JitDirectReg::Addr(reg));
+            store_bool(builder, cpu, offset_of!(CpuCore, change_of_flow), true);
+            store_value_u32(builder, cpu, offset_of!(CpuCore, pc), target);
+            cycles_const(builder, 8)
         }
         JitTraceOp::Branch {
             condition,
@@ -12216,7 +12260,7 @@ mod portable_tests {
     }
 
     #[test]
-    fn decodes_indirect_jsr_trace_boundary() {
+    fn decodes_indirect_control_trace_boundaries() {
         let cpu = cpu();
         let mut mem = super::super::memory::LinearMemoryBus::new(0x1000);
         mem.write_word(0x0100, 0x4E90); // JSR (A0)
@@ -12243,6 +12287,35 @@ mod portable_tests {
                 target: JitEa::Disp(5, -16)
             }
         ));
+
+        mem.write_word(0x0100, 0x4ED1); // JMP (A1)
+        let jmp = decode_trace_op(&cpu, &mut mem, 0x0100, CpuType::M68000).unwrap();
+        assert_eq!(jmp.extension, None);
+        assert_eq!(jmp.length(), 2);
+        assert_eq!(jmp.op.max_cycles(), 8);
+        assert!(matches!(jmp.op, JitTraceOp::IndirectJmp { reg: 1 }));
+        assert!(jmp.op.ends_trace());
+    }
+
+    #[test]
+    fn portable_indirect_jmp_uses_live_target_and_changes_flow() {
+        let mut cpu = cpu();
+        cpu.set_a(1, 0x0340);
+        cpu.change_of_flow = false;
+        let op = TraceBuildOp {
+            opcode: 0x4ED1,
+            extension: None,
+            extension2: None,
+            pc: 0x0100,
+            op: JitTraceOp::IndirectJmp { reg: 1 },
+        };
+
+        assert_eq!(
+            execute_portable_op(&mut cpu, op, CodeSpans::caller(0x0100, 0x0102)),
+            Some(8)
+        );
+        assert_eq!(cpu.pc, 0x0340);
+        assert!(cpu.change_of_flow);
     }
 
     #[test]
@@ -17932,6 +18005,57 @@ mod portable_tests {
         assert_eq!(bail.pc, call_pc);
         assert!(!bail.change_of_flow);
         assert!(bail_mem[0x07FC..0x0800].iter().all(|&byte| byte == 0));
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[test]
+    fn native_short_indirect_jmp_region_is_profitable_and_exact() {
+        let ops = vec![
+            TraceBuildOp {
+                opcode: 0x7001,
+                extension: None,
+                extension2: None,
+                pc: 0x0100,
+                op: JitTraceOp::Moveq { reg: 0, data: 1 },
+            },
+            TraceBuildOp {
+                opcode: 0x7202,
+                extension: None,
+                extension2: None,
+                pc: 0x0102,
+                op: JitTraceOp::Moveq { reg: 1, data: 2 },
+            },
+            TraceBuildOp {
+                opcode: 0x7403,
+                extension: None,
+                extension2: None,
+                pc: 0x0104,
+                op: JitTraceOp::Moveq { reg: 2, data: 3 },
+            },
+            TraceBuildOp {
+                opcode: 0x4ED5,
+                extension: None,
+                extension2: None,
+                pc: 0x0106,
+                op: JitTraceOp::IndirectJmp { reg: 5 },
+            },
+        ];
+        let mut jit = TraceJit::new();
+        let compiled = jit
+            .compile_decoded_ops(&cpu(), 0x0100, CpuType::M68000, ops, Some(0x0350))
+            .expect("four-op indirect-jump region should compile");
+        let mut actual = cpu();
+        actual.set_a(5, 0x0350);
+        actual.change_of_flow = false;
+
+        let packed = unsafe { compiled.call_native(&mut actual, 1) };
+
+        assert_eq!((packed >> 32) as u32, 4);
+        assert_eq!(packed as u32 as i32, 20);
+        assert_eq!(actual.pc, 0x0350);
+        assert_eq!(actual.ppc, 0x0106);
+        assert_eq!(actual.ir, 0x4ED5);
+        assert!(actual.change_of_flow);
     }
 
     /// A `count`-op region: `count - 1` MOVEQs then a bare RTS terminal.

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -396,10 +396,9 @@ pub(crate) enum JitTraceOp {
         dst: u8,
         cycles: i32,
     },
-    /// LEA `(xxx).W`/`(xxx).L,An`. The absolute address is sign-extended
-    /// (word form) or taken whole (long form) while recording, so
-    /// execution loads a constant into the address register -- no memory
-    /// access, no condition codes.
+    /// LEA `d16(PC)`/`(xxx).W`/`(xxx).L,An`. The final address is resolved
+    /// while recording, so execution loads a constant into the address
+    /// register -- no memory access, no condition codes.
     LeaAbs {
         address: u32,
         dst: u8,
@@ -5288,6 +5287,26 @@ fn decode_an_disp_trace_op<B: AddressBus>(
                     dst,
                     // MC68000 LEA (d8,An,Xn) is twelve cycles.
                     cycles: if is_pre_68020(cpu_type) { 12 } else { 4 },
+                },
+            )
+        }
+        DecodedMemOp::Lea {
+            reg: dst,
+            ea: FastEa::PcDisp,
+        } => {
+            let extension = read_ext(2, bus)?;
+            (
+                Some(extension),
+                None,
+                JitTraceOp::LeaAbs {
+                    // The 68k PC-relative base is the address of the
+                    // displacement extension word, not the next opcode.
+                    address: pc
+                        .wrapping_add(2)
+                        .wrapping_add(extension as i16 as i32 as u32),
+                    dst,
+                    // MC68000 LEA d16(PC) is eight cycles.
+                    cycles: if is_pre_68020(cpu_type) { 8 } else { 4 },
                 },
             )
         }
@@ -13216,7 +13235,7 @@ mod portable_tests {
     }
 
     #[test]
-    fn lea_abs_decode_and_native_execution_load_the_constant() {
+    fn lea_constant_forms_decode_and_portable_execution_load_the_constant() {
         let mut cpu = cpu();
         cpu.set_cpu_type(CpuType::M68040);
         cpu.set_a(1, 0xDEAD_BEEF);
@@ -13259,6 +13278,29 @@ mod portable_tests {
             }
         ));
         assert_eq!(word.length(), 4);
+
+        // LEA d16(PC),A1 = 43FA. The PC base is the address of the
+        // extension word ($0302), so -$0100 resolves to $0202.
+        cpu.set_cpu_type(CpuType::M68000);
+        bus.write_word_at(0x0300, 0x43FA);
+        bus.write_word_at(0x0302, 0xFF00);
+        let pc_relative = decode_trace_op(&cpu, &mut bus, 0x0300, CpuType::M68000)
+            .expect("LEA d16(PC) should decode");
+        assert!(matches!(
+            pc_relative.op,
+            JitTraceOp::LeaAbs {
+                address: 0x0202,
+                dst: 1,
+                cycles: 8,
+            }
+        ));
+        assert_eq!(pc_relative.length(), 4);
+        assert_eq!(
+            execute_portable_op(&mut cpu, pc_relative, CodeSpans::caller(0x0300, 0x0304)),
+            Some(8)
+        );
+        assert_eq!(cpu.dar[9], 0x0202);
+        assert_eq!(cpu.get_ccr(), 0x1F);
     }
 
     #[cfg(all(feature = "jit", not(target_family = "wasm")))]


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #169. The new work begins after `4706bcc` and is
> kept in four commits: `4eb51b9`, `5bffbbe`, `5cc2718`, and `212748f`.
> Once the dependency merges, the diff collapses to those commits.

## Summary

Compile a hot table-dispatch path that SimCity 2000's recorder could observe
but previously threw away:

- admit `LEA d16(PC),An`;
- represent and execute indirect `JMP` through `(An)`, `d16(An)`, brief
  `d8(An,Xn)`, and brief `d8(PC,Xn)`;
- record through an indirect jump by guarding the observed target rather than
  pretending that a dynamic target is static;
- when a later second call would make the bounded callee-code interval too
  broad, retain the completed prefix through its last safe terminal—but only
  when that prefix belongs to an indexed-dispatch path.

The complete stack reduces retired host instructions by **1.19%** in the
standard 400M-instruction SC2K replay, with identical simulated ticks and
framebuffer output. 3 in Three, System's Twilight, Lemmings, and EV Override
are neutral.

This does not skip guest work, loosen code validation, or widen the allowed
self-modifying-code intervals. It moves an already-observed, repeatedly
executed guest prefix from decoded execution into the existing guarded native
trace machinery.

## The failed SC2K topology

The hot head at guest PC `$002891A8` executes this shape:

```text
$002891A8  setup and compare operations
     ...
$002891BE  LEA d16(PC),An
$002891C2  JMP d8(An,Xn)          ; table dispatch, target observed at runtime
     ...   selected dispatch case
             BSR                  ; first bounded callee
             ... callee ...
             RTS                  ; checked return to the recorded caller
             BRA                  ; another completed control-flow boundary
     ...
$00289288  BSR                    ; second, far-away callee
```

Before this stack, the PC-relative LEA and indexed jump stopped recording. The
new control-flow representation lets the recorder follow the observed table
case, but exposes a second structural limit: one trace carries one caller code
interval and one callee code interval for self-modifying-code validation. The
first call fits. Adding the second far callee would make the single callee
interval exceed `CALL_THROUGH_MAX_SPAN`.

That span cap exists for a good reason. Treating two small, distant callees as
one enormous interval would make each trace entry validate unrelated memory
between them and would increase both false invalidation and steady-state host
work. The recorder therefore must refuse the second call.

The old refusal, however, discarded too much. It closed the recording as an
ordinary region while the last recorded operation was not a terminal.
Compilation returned `NoTraceTerminal`; repeated identical observations then
made the head structurally rejected. In a 400M parent profile this one head
had 183,834 hits, 183,623 rejected hits, five recording attempts, and zero
compiled calls. The second call poisoned the independently valid prefix before
it.

## The rule

At a call-span refusal, an out-of-line helper now:

1. verifies that the incomplete recording is not already terminal;
2. finds its last completed trace terminal;
3. requires a guarded brief-indexed or PC-indexed `JMP` at or before that
   terminal;
4. retains the existing `SALVAGE_MIN_OPS` profitability floor;
5. truncates to that last terminal and hands the prefix back to the ordinary
   linear admission/deferral path.

The indexed jump is a **topology anchor**, not necessarily the truncation
point. That distinction accounts for most of the win: SC2K performs useful
work after the dispatch, including the first call/return, before reaching the
later direct branch. The final trace keeps that work and leaves the impossible
second call plus its tail to full dispatch.

The structural restriction matters. A generic “call span means salvage” rule
also matched cold function thunks and data-dependent alternate paths in other
programs. An indexed dispatch says something stronger: this is a multi-way
control-flow join whose observed case is worth guarding. A plain `JMP (An)` or
ordinary conditional branch does not establish that topology.

The helper is `#[cold]` and `#[inline(never)]`. The vector scan and policy code
therefore do not change the common trace-entry, native-execution, or recording
layout; they run only when a recording has already reached this uncommon
second-callee span refusal.

## Guarded indirect JMP semantics

`IndirectJmp` carries a decoded `JitEa` plus an optional observed target.
During recording, the jump first decodes without a prediction. Once the guest
executes it, the recorder stores the actual successor and continues along that
case.

Native and portable execution both:

- recompute the target from the live address/index registers;
- apply 68000/68020 index-width and scale semantics;
- commit the architectural jump (`pc` and `change_of_flow`);
- compare the committed target with the recorded successor;
- continue natively on a match or side-exit with exact `ppc`/`ir` state on a
  mismatch.

Thus the trace specializes an observed dispatch edge without assuming the
jump is immutable. Existing guarded-exit accounting can re-record if another
table case becomes dominant. Raw opcode extension words remain in the trace's
code snapshot, and every discontiguous caller/callee segment is validated
before native execution.

`LEA d16(PC),An` records its PC-derived base as a constant plus the signed
displacement and preserves condition codes, matching the interpreter. The
indirect-JMP family uses the existing checked EA representation rather than a
game-specific address or opcode whitelist.

## Actual host-CPU measurements

All fixed-endpoint runs alternate A/B order. The primary metric is retired
**host** instructions: actual CPU work performed by Systemless, not emulated
68k cycles and not merely the number of guest instructions. Each SC2K arm runs
the same 400M guest instructions, ends at exactly 185,810 simulated ticks, and
has the same final framebuffer SHA-256.

Complete PR stack versus the exact #169 artifact, three interleaved pairs:

| Workload | Budget | #169 host instructions | Candidate | Change |
|---|---:|---:|---:|---:|
| SimCity 2000 | 400M | 160,600,336,338 | 158,688,715,569 | **-1.1903%** |
| 3 in Three | 200M | 284,822,684,554 | 284,763,977,068 | -0.0206% |
| System's Twilight | 100M | 304,968,183,095 | 305,000,953,454 | +0.0107% |
| Lemmings | 400M | 121,473,897,905 | 121,423,993,241 | -0.0411% |
| EV Override | 200M | normalized per tick | normalized per tick | +0.0759% |

SC2K's individual pairs were approximately -1.27%, -1.08%, and -1.23%; all
three were favorable. Ticks and screenshots are identical for every workload
except EV Override, whose scripted endpoint is intentionally tick-variable;
EV is therefore normalized by aggregate ticks. The control-workload changes
are noise-scale neutrality, not claimed wins.

To isolate only the final salvage policy from its indirect-JMP parent, a
second three-pair SC2K comparison measured **-1.2410%** host instructions
(160,879,368,743 -> 158,882,823,422). This shows the gain comes from retaining
the safe native prefix, not from holding guest work or simulated time fixed in
a misleading way.

## Rejected and refined approaches

### 1. Salvage every call-span recording

The first prototype treated every call-span stop like an unsupported-opcode
blocker and salvaged through the last terminal. It improved SC2K by **1.0816%**
but regressed 3 in Three by **+0.1506%** and System's Twilight by **+0.1529%**.
Lemmings was -0.0822%; EV Override was -0.0240% instructions/tick.

Profiles explained the conflicting results:

- SC2K has the hot indexed table-dispatch path described above.
- 3 in Three's superficially similar failures end in plain `JMP (A0)` function
  thunks. The observed heads had only 5-9 hits, far below the 208-hit
  independent-linear threshold, and produced no useful compiled shape.
- System's Twilight's `$003A2B06` head already had a productive 43-op trace
  (94 native calls, 3,948 retired guest ops). A data-dependent alternate path
  reached the span refusal after an ordinary conditional branch, so broad
  salvage could replace the useful long shape with a shorter alternate one.

Even where the broad rule compiled nothing, adding a hot-path enum case and
policy branch correlated with a repeatable ~0.15% representation/layout cost.
Moving the narrow rule out of line removed that effect.

### 2. Keep only the indexed-JMP prefix

A conservative version required the right topology but truncated exactly at
the indexed jump—an eight-op SC2K trace. It removed the other-game regressions
but saved only **0.4252%** on SC2K. It threw away the useful first call/return
and later direct branch. The final rule uses the indexed jump as proof of the
topology and the last later terminal as the safe endpoint.

### 3. Refuse salvage after any previous compile

The first indexed-only version also refused heads that had compiled at any
point in the past, to protect an existing shape. Removing that history guard
produced only **0.2768%** SC2K improvement in a fresh three-pair run, so blocked
adaptive re-recording was not the missing opportunity. The indexed topology
test already excludes Twilight's conditional alternate path; a durable
compiled-history exception is unnecessary and would interfere with the
existing dominant-target adaptation policy.

### 4. Follow the second call too

Another prototype appended a `CallExit` for the second far call, compiled the
parent through it, and seeded that callee separately. Against prefix salvage,
it was **0.6948% worse on SC2K** over three 400M pairs. It duplicated an
already-productive downstream trace graph and added validation/chaining work.
The second call remains outside this trace.

### 5. Judge the new control forms in isolation

Earlier isolated tests found `LEA d16(PC),An` at +0.042% and terminal
`JMP (An)` at -0.046% on SC2K—both neutral. They were retained locally rather
than claimed as wins. The present result shows why opcode admission and trace
topology cannot always be evaluated independently: those forms make the hot
dispatch path recordable, while call-span salvage lets the newly visible path
compile. The complete stack directly measured -1.1903% against #169.

## Validation

The new end-to-end test constructs:

```text
indexed dispatch -> first far BSR -> callee -> checked RTS
                 -> direct branch -> second far BSR
```

It runs the guest loop to a fixed budget, verifies that both callees execute in
lockstep, and inspects the compiled head. The resulting 12-op trace must contain
the guarded indexed dispatch, bounded first call, checked return, and final
direct branch, and must exclude the second call.

Also completed:

- `cargo test --features jit`
- `cargo test --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- deterministic headless hardware-counter replays on SC2K, 3 in Three,
  System's Twilight, Lemmings, and EV Override
