### PR TITLE
perf: pin the recorder's inactive check and the register-operand reader inline

### DIFF
--- a/src/core/op_cache.rs
+++ b/src/core/op_cache.rs
@@ -1266,7 +1266,10 @@ fn jit_bit_op(op: BitOp) -> JitBitOp {
     }
 }
 
-#[inline]
+/// Always inlined: a masked register load on the decoded-op fast path. Left
+/// to the inliner it drops out of line whenever the surrounding interpreter
+/// grows, and the call then costs more than the load.
+#[inline(always)]
 fn read_direct_reg(cpu: &CpuCore, reg: DirectReg, size: Size) -> u32 {
     match reg {
         DirectReg::Data(reg) => cpu.dar[reg as usize] & size.mask(),

--- a/src/core/trace_jit.rs
+++ b/src/core/trace_jit.rs
@@ -4471,8 +4471,13 @@ pub(crate) fn record_trace_target(pc: u32, cpu_type: CpuType) {
 }
 
 /// Append one instruction that the interpreter just executed while a hot
-/// multi-block path is being recorded. The normal path checks the CPU flag
-/// first, so no TLS access occurs when recording is inactive.
+/// multi-block path is being recorded. Called for every interpreted
+/// instruction, so the inactive check is pinned inline at the call site and
+/// the recording body stays out of line: left to the inliner, the decision
+/// flips with the size of the recorder, and an out-of-line call per guest
+/// instruction just to test the flag costs interpreted workloads several
+/// percent.
+#[inline(always)]
 pub(crate) fn record_executed<B: AddressBus>(
     cpu: &mut CpuCore,
     bus: &mut B,
@@ -4480,17 +4485,33 @@ pub(crate) fn record_executed<B: AddressBus>(
     next_pc: u32,
 ) {
     if cpu.trace_recording {
-        with_trace_jit(|jit| jit.record_executed(cpu, bus, executed_pc, next_pc));
+        record_executed_active(cpu, bus, executed_pc, next_pc);
     }
+}
+
+#[inline(never)]
+fn record_executed_active<B: AddressBus>(
+    cpu: &mut CpuCore,
+    bus: &mut B,
+    executed_pc: u32,
+    next_pc: u32,
+) {
+    with_trace_jit(|jit| jit.record_executed(cpu, bus, executed_pc, next_pc));
 }
 
 /// End an in-progress recording before control leaves the fast decoded-op
 /// path. A usable prefix ending in a branch is compiled; otherwise the
-/// target is marked rejected.
+/// target is marked rejected. Same inline split as `record_executed`.
+#[inline(always)]
 pub(crate) fn stop_recording(cpu: &mut CpuCore, cause: RecordingStop) {
     if cpu.trace_recording {
-        with_trace_jit(|jit| jit.finish_recording(cpu, cpu.pc, RecordingEnd::Stopped(cause)));
+        stop_recording_active(cpu, cause);
     }
+}
+
+#[inline(never)]
+fn stop_recording_active(cpu: &mut CpuCore, cause: RecordingStop) {
+    with_trace_jit(|jit| jit.finish_recording(cpu, cpu.pc, RecordingEnd::Stopped(cause)));
 }
 
 /// Note that execution just took a backward branch to `cpu.pc` (a potential


### PR DESCRIPTION
## Summary

Two inlining pins on the per-instruction fast path, so its cost no longer depends on where fat LTO's inliner happens to draw the line for a given binary size:

1. `record_executed` and `stop_recording` run for every interpreted instruction with the "is a recording active" test inside them and no inline attribute. Whether that test is inlined is decided by the size of the recording body: one binary in our measurements inlined it, a larger one did not, and every guest instruction then paid an out-of-line call to test a flag (3 in Three +2.8%, Lemmings +7.3%, System's Twilight +1.0% host instructions at an identical trace census). Each is split into an always-inline flag check and a never-inline body.
2. `read_direct_reg`, the masked register load on the decoded-op fast paths, is pinned inline for the same reason; in a binary where it had dropped out of line it showed 1.7% self time on a JIT-heavy workload.

Rebased onto current master after #173 merged. This PR contains only the two inlining changes and does not depend on #174; the outlined recorder helpers use the existing per-operation TLS accessor. The measurements below were taken against the original #174 baseline before this rebase.

## Measurements

Paired hardware counters, headless replays in Systemless, both arms interleaved, identical guest instructions and ticks (and framebuffer hash except Escape Velocity, whose replay is not tick-deterministic). Baseline is the #174 head built the same way; medians of the pair ratios for host instructions retired:

| workload | recorder pin alone | both pins |
|---|---|---|
| Lemmings, 1 B | **−1.01%** (6/6) | −0.95% (6/6) |
| SimCity 2000, 400 M | −0.23% (6/6) | −0.08% (5/6) |
| 3 in Three, 200 M | −0.16% (5/5) | −0.15% (5/5) |
| System's Twilight, 100 M | −0.12% (6/6) | −0.12% (6/6) |
| Escape Velocity, 100 M | 0.00% (3/6) | 0.00% (3/6) |

CPU time, re-measured with the machine idle (both pins vs the same baseline, 5 pairs, user seconds):

| workload | instructions | CPU time |
|---|---|---|
| Lemmings, 1 B | −0.9% (5/5) | +2.1% (1/5; cycles +3.3%, 2/5) |
| SimCity 2000, 400 M | −0.2% (5/5) | +1.2% (1/5; cycles +1.1%, 1/5) |

So in this configuration the pins lower the instruction count slightly and leave CPU time within the ±2–4% layout swing a rebuild of this crate produces at identical instructions; there is no CPU-time gain to claim here. The case for them is the other binary, where the inliner's decision cost 2.8–7.3% instructions on the same code.

On the baseline binary the inliner already had both paths inline, so these are the small direct gains; the point of the pins is the regressions above, which appeared in a binary that differed only by an unrelated, larger recorder. Cycles moved within the layout noise of a rebuild (a no-op perturbation of this crate moves cycles ±2–4% at identical instructions), so instructions are the numbers to trust.

## Tests

`cargo test` and `cargo clippy --all-targets` on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqCuD9vsGeeij5DdYt3vcK

